### PR TITLE
keep subtitle/audio popup focus and block keys during playback

### DIFF
--- a/components/manager/ViewCreator.bs
+++ b/components/manager/ViewCreator.bs
@@ -214,7 +214,6 @@ end sub
 sub onAudioSelectorVisibleChanged()
     if not m.audioSelector.visible
         m.audioSelector.unobserveField("audioStreamIndex")
-        m.audioSelector.unobserveField("visible")
         m.view.setFocus(true)
     end if
 end sub
@@ -271,7 +270,6 @@ end sub
 sub onSubtitleSelectorVisibleChanged()
     if not m.subtitleSelector.visible
         m.subtitleSelector.unobserveField("subtitleStream")
-        m.subtitleSelector.unobserveField("visible")
         m.view.setFocus(true)
     end if
 end sub

--- a/components/manager/ViewCreator.bs
+++ b/components/manager/ViewCreator.bs
@@ -93,6 +93,8 @@ end sub
 
 
 sub onSelectAudioPressed()
+    if not isValidAndNotEmpty(m.view.fullAudioData) then return
+
     preferredAudioTrackName = m.global.queueManager.callFunc("getPreferredAudioTrackName")
 
     audioTracks = []
@@ -127,6 +129,8 @@ sub onSelectAudioPressed()
 end sub
 
 sub onSelectSubtitlePressed()
+    if not isValidAndNotEmpty(m.view.fullSubtitleData) then return
+
     subtitleTracks = []
 
     subtitleTracks.push({

--- a/components/movies/AudioSelector.bs
+++ b/components/movies/AudioSelector.bs
@@ -63,5 +63,16 @@ function onKeyEvent(key as string, press as boolean) as boolean
         return true
     end if
 
+    if key = KeyCode.LEFT or key = KeyCode.RIGHT or key = KeyCode.PLAY or key = KeyCode.FASTFORWRD or key = KeyCode.REWIND or key = KeyCode.REPLAY
+        return true
+    end if
+
+    if key = KeyCode.UP or key = KeyCode.DOWN or key = KeyCode.OK
+        if not m.audioMenu.isInFocusChain()
+            m.audioMenu.setFocus(true)
+        end if
+        return true
+    end if
+
     return false
 end function

--- a/components/movies/SubtitleSelector.bs
+++ b/components/movies/SubtitleSelector.bs
@@ -64,5 +64,16 @@ function onKeyEvent(key as string, press as boolean) as boolean
         return true
     end if
 
+    if key = KeyCode.LEFT or key = KeyCode.RIGHT or key = KeyCode.PLAY or key = KeyCode.FASTFORWRD or key = KeyCode.REWIND or key = KeyCode.REPLAY
+        return true
+    end if
+
+    if key = KeyCode.UP or key = KeyCode.DOWN or key = KeyCode.OK
+        if not m.subtitleMenu.isInFocusChain()
+            m.subtitleMenu.setFocus(true)
+        end if
+        return true
+    end if
+
     return false
 end function

--- a/components/video/VideoPlayerView.bs
+++ b/components/video/VideoPlayerView.bs
@@ -378,11 +378,15 @@ sub handleVideoPlayPauseAction()
 end sub
 
 sub handleShowSubtitleMenuAction()
+    if not isValidAndNotEmpty(m.top.fullSubtitleData) then return
+
     handleHideAction(false)
     m.top.selectSubtitlePressed = true
 end sub
 
 sub handleShowAudioMenuAction()
+    if not isValidAndNotEmpty(m.top.fullAudioData) then return
+
     handleHideAction(false)
     m.top.selectAudioPressed = true
 end sub
@@ -590,6 +594,20 @@ sub onSubtitleChange()
     m.LoadMetaDataTask.control = TaskControl.RUN
 end sub
 
+' Toggle subtitle button visbility
+sub updateSubtitleButtonVisibility()
+    ' Show subtitle control only when subtitle tracks are present
+    hasSubtitleTracks = isValidAndNotEmpty(m.top.fullSubtitleData)
+
+    videoControls = m.osd.findNode("videoControls")
+    subtitleButton = m.osd.findNode("showSubtitleMenu")
+
+    if isValid(videoControls) and isValid(subtitleButton)
+        subtitleButton.visible = hasSubtitleTracks
+        subtitleButton.focus = false
+    end if
+end sub
+
 ' Event handler for when audioIndex changes
 sub onAudioIndexChange()
     ' Skip initial audio index setting
@@ -665,6 +683,7 @@ sub onVideoContentLoaded()
     m.top.container = videoContent[0].container
     m.top.mediaSourceId = videoContent[0].mediaSourceId
     m.top.fullSubtitleData = videoContent[0].fullSubtitleData
+    updateSubtitleButtonVisibility()
     m.top.fullAudioData = videoContent[0].fullAudioData
     m.top.audioIndex = videoContent[0].audioIndex
     m.top.transcodeParams = videoContent[0].transcodeparams


### PR DESCRIPTION
## Summary
Fixes subtitle/audio selector popup during video playback so controls remain usable across repeated opens, and key presses do not cause popups to unfocus.

## Related Issues
Fixes #51 

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [X] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
- Removed visible unobserve handlers so focus logic continues to run on subsequent opens
- Updated popup key press handling for Subtitle and Audio to prevent unfocusing the popups
  - Blocked LEFT/RIGHT keys so video longer skips in background while popup is open
  - Bounded UP/DOWN keys so popup cant be unfocused when already at topmost/bottommost option

## Testing
- [X] Tested on physical Roku device
- [X] Tested via sideload
- [X] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. Start video playback and open Subtitle or Audio popup
2. Verify currently selected option, press UP and DOWN to confirm focus stays in the popup
3. Press LEFT and RIGHT while popup is open to confirm video does not skip in background
4. Closing popup with BACK, or selecting an option still closes the popup
5. Verify either Subtitle or Audio popup can be re-opened and are still focused

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
