### PR TITLE
updated the playlist shuffle to use the right endpoint for shuffling …

### DIFF
--- a/source/MainEventHandlers.bs
+++ b/source/MainEventHandlers.bs
@@ -1359,16 +1359,59 @@ sub onPlaylistPlayAllEvent(msg)
     startLoadingSpinner()
     screenContent = msg.getRoSGNode()
 
-    MainAction.playItem(screenContent.listData.getChildren(-1, 0), { method: "set", resetShuffle: true, position: 0 })
+    playlistId = chainLookupReturn(screenContent, "pageContent.id", "")
+    if playlistId = ""
+        stopLoadingSpinner()
+        return
+    end if
+
+    data = api.items.Get({
+        "UserId": m.global.session.user.id,
+        "ParentId": playlistId,
+        "Limit": 2000,
+        "ExcludeLocationTypes": "Virtual",
+        "EnableTotalRecordCount": false
+    })
+
+    if not isChainValid(data, "Items") or data.Items.Count() = 0
+        stopLoadingSpinner()
+        return
+    end if
+
+    m.global.queueManager.callFunc("clear")
+    m.global.queueManager.callFunc("set", data.Items)
+    m.global.queueManager.callFunc("playQueue")
 end sub
 
 ' User clicked "Shuffle" on playlist details
 sub onPlaylistShuffleEvent(msg)
+    if not msg.getData() then return
+
     startLoadingSpinner()
     screenContent = msg.getRoSGNode()
 
-    m.global.queueManager.callFunc("set", screenContent.listData.getChildren(-1, 0))
-    m.global.queueManager.callFunc("setShuffle", true)
+    playlistId = chainLookupReturn(screenContent, "pageContent.id", "")
+    if playlistId = ""
+        stopLoadingSpinner()
+        return
+    end if
+
+    data = api.items.Get({
+        "UserId": m.global.session.user.id,
+        "ParentId": playlistId,
+        "SortBy": "Random",
+        "Limit": 2000,
+        "ExcludeLocationTypes": "Virtual",
+        "EnableTotalRecordCount": false
+    })
+
+    if not isChainValid(data, "Items") or data.Items.Count() = 0
+        stopLoadingSpinner()
+        return
+    end if
+
+    m.global.queueManager.callFunc("clear")
+    m.global.queueManager.callFunc("set", data.Items)
     m.global.queueManager.callFunc("playQueue")
 end sub
 


### PR DESCRIPTION
# Pull Request

## Summary
I updated the playlist shuffle to use the right endpoint for shuffling  non-music files too - also updated the "playall" even handler cause it had an eternal buffer too. Uses the Items API endpoint with `ParentId` and `SortBy=Random` to fetch playable items server-side, matching the web client behavior (this is the endpoint that was called in my web ui on shuffle so and I adding `SortBy=Random` to the playlist/items endpoint didn't do anything).

## Related Issues
https://github.com/Moonfin-Client/Roku/issues/64

- Closes #
- Fixes #64 
- Related to #

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

- `onPlaylistShuffleEvent`: Replaced client-side shuffle with server-side `SortBy=Random` via Items API
- `onPlaylistPlayAllEvent`: Same fix — use Items API with `ParentId` instead of pre-fetched `listData`
- Added `msg.getData()` guard on shuffle to prevent re-trigger when `shufflePlay` resets on screen return

## Testing

- [x] Tested on physical Roku device
- [x] Tested via sideload
- [x] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. Made playlist with two movies and a couple shows (with one having >300 episodes)
2. Opened Playlist on MoonFin client on Roku
3. Clicked Shuffle 5 times (it was a different show/movie nearly each time)
4. Clicked PlayAll (it played first item)

## Screenshots (if applicable)
N/A

## Checklist
- [x] Code builds successfully
- [x] Code follows project style and conventions
- [x] No unnecessary commented-out code
- [x] No new warnings introduced
