### PR TITLE
guard seerr response parsing to handle array payloads

### DIFF
--- a/components/jellyseerr/JellyseerrAPITask.bs
+++ b/components/jellyseerr/JellyseerrAPITask.bs
@@ -502,7 +502,7 @@ function UnwrapPluginProxyResponse(rawResponse as string) as object
         return invalid
     end if
 
-    if parsed.FileContents <> invalid
+    if parsed <> invalid and type(parsed) = "roAssociativeArray" and parsed.FileContents <> invalid
         decoded = DecodeBase64String(parsed.FileContents)
         if decoded = invalid or decoded = ""
             return invalid


### PR DESCRIPTION
# Pull Request

## Summary
Fixes an exception when the Seerr proxy returns a JSON array instead of the expected envelope. This prevents the Seerr tab from failing to load when the proxy returns normal Seerr payloads.

## Related Issues
- Fixes #72

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

- Guard `FileContents` access so proxy responses that are JSON arrays do not throw.
- Allow `UnwrapPluginProxyResponse` to return arrays as-is when no envelope is present.

## Testing
- [X] Tested on physical Roku device
- [X] Tested via sideload
- [X] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. Ensure Moonfin plugin is installed on server, enable the plugin in the app settings as well as Seerr (Jellyseerr in app settings).
2. Navigate to Seerr tab in the navigation bar
3. Everything should load as normal, and no more infinite loading (where an exception is thrown but not shown to the user).

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
