### PR TITLE
adjust style of settings menu items and fix navigation bug

### DIFF
--- a/components/settings/SettingsMenuItem.bs
+++ b/components/settings/SettingsMenuItem.bs
@@ -13,9 +13,6 @@ sub init()
     m.settingCurrentValue.scrollSpeed = m.marqueeScrollSpeed
     m.settingDescription.scrollSpeed = m.marqueeScrollSpeed
 
-    focusColor = chainLookupReturn(m.global.session, "user.settings.colorCursor", ColorPalette.HIGHLIGHT)
-    m.focusColor = focusColor
-
     focusChanged()
 end sub
 
@@ -39,11 +36,13 @@ sub itemContentChanged()
 end sub
 
 sub focusChanged()
+    focusColor = chainLookupReturn(m.global.session, "user.settings.colorCursor", ColorPalette.HIGHLIGHT)
+    
     if m.top.itemHasFocus
         startMarquee(m.settingTitle)
         startMarquee(m.settingCurrentValue)
         startMarquee(m.settingDescription)
-        m.buttonBackground.blendColor = m.focusColor
+        m.buttonBackground.blendColor = focusColor
         m.focusOutline.visible = m.top.drawFocusFeedback
         m.settingTitle.color = "#000000FF"
         m.settingCurrentValue.color = "#000000FF"
@@ -55,7 +54,7 @@ sub focusChanged()
         m.buttonBackground.blendColor = ColorPalette.ELEMENTBACKGROUND
         m.focusOutline.visible = false
         m.settingTitle.color = ColorPalette.WHITE
-        m.settingCurrentValue.color = m.focusColor
+        m.settingCurrentValue.color = focusColor
         m.settingDescription.color = "#C8CCD4FF"
     end if
 end sub

--- a/components/settings/SettingsMenuItem.xml
+++ b/components/settings/SettingsMenuItem.xml
@@ -6,30 +6,28 @@
 
         <ScrollingText
             id="settingTitle"
-            translation="[20, 8]"
-            height="28"
-            font="font:SmallBoldSystemFont"
-            horizAlign="left"
-            maxWidth="700"
-            repeatCount="0" />
+            translation="[20, 20]"
+            width="700"
+            height="24"
+            font="font:SmallestBoldSystemFont"
+            maxLines="1" />
 
         <ScrollingText
             id="settingCurrentValue"
-            translation="[20, 40]"
+            translation="[20, 50]"
+            width="700"
             height="24"
-            font="font:SmallestSystemFont"
-            horizAlign="left"
-            maxWidth="700"
-            repeatCount="0" />
+            font="font:TinySystemFont"
+            maxLines="1" />
 
         <ScrollingText
             id="settingDescription"
-            translation="[20, 68]"
-            height="42"
-            font="font:SmallestSystemFont"
-            horizAlign="left"
-            maxWidth="700"
-            repeatCount="0" />
+            translation="[20, 80]"
+            width="700"
+            height="24"
+            font="font:TinySystemFont"
+            wrap="true"
+            maxLines="2" />
     </children>
     <interface>
         <field id="itemContent" type="node" onChange="itemContentChanged" />

--- a/components/settings/SettingsMenuItem.xml
+++ b/components/settings/SettingsMenuItem.xml
@@ -24,7 +24,7 @@
             id="settingDescription"
             translation="[20, 80]"
             width="700"
-            height="24"
+            height="32"
             font="font:TinySystemFont"
             wrap="true"
             maxLines="2" />

--- a/components/settings/SettingsMenuItem.xml
+++ b/components/settings/SettingsMenuItem.xml
@@ -7,27 +7,29 @@
         <ScrollingText
             id="settingTitle"
             translation="[20, 20]"
-            width="700"
             height="24"
             font="font:SmallestBoldSystemFont"
-            maxLines="1" />
+            horizAlign="left"
+            maxWidth="700"
+            repeatCount="0" />
 
         <ScrollingText
             id="settingCurrentValue"
             translation="[20, 50]"
-            width="700"
             height="24"
             font="font:TinySystemFont"
-            maxLines="1" />
+            horizAlign="left"
+            maxWidth="700"
+            repeatCount="0" />
 
         <ScrollingText
             id="settingDescription"
             translation="[20, 80]"
-            width="700"
             height="32"
             font="font:TinySystemFont"
-            wrap="true"
-            maxLines="2" />
+            horizAlign="left"
+            maxWidth="700"
+            repeatCount="0" />
     </children>
     <interface>
         <field id="itemContent" type="node" onChange="itemContentChanged" />

--- a/components/settings/settings.bs
+++ b/components/settings/settings.bs
@@ -204,7 +204,7 @@ sub refreshCurrentItemValue(settingItem = invalid as dynamic)
     contentItem = m.settingsMenu.content.getChild(focusIndex)
     if not isValid(contentItem) then return
 
-    contentItem.currentValue = getSettingCurrentValueLabel(settingItem)
+    contentItem.addFields({ currentValue: getSettingCurrentValueLabel(settingItem) })
 end sub
 
 ' Sync a setting to the server via PostTask (render-thread safe).
@@ -1165,7 +1165,7 @@ sub LoadMenu(configSection, appendPath = true as boolean)
         listItem = result.CreateChild("ContentNode")
         listItem.title = tr(item.title)
         listItem.Description = tr(item.description)
-        listItem.currentValue = getSettingCurrentValueLabel(item)
+        listItem.addFields({ currentValue: getSettingCurrentValueLabel(item) })
         listItem.id = item.id
     end for
 

--- a/components/settings/settings.bs
+++ b/components/settings/settings.bs
@@ -20,7 +20,7 @@ sub init()
     m.userLocation = []
 
     m.settingsMenu = m.top.findNode("settingsMenu")
-    m.settingsMenu.focusBitmapBlendColor = chainLookupReturn(m.global.session, "user.settings.colorCursor", ColorPalette.HIGHLIGHT)
+    'm.settingsMenu.focusBitmapBlendColor = chainLookupReturn(m.global.session, "user.settings.colorCursor", ColorPalette.HIGHLIGHT)
     m.settingsMenu.focusFootprintBlendColor = ColorPalette.TRANSPARENT
     m.settingsMenu.focusedColor = ColorPalette.WHITE
 
@@ -266,7 +266,7 @@ sub onColorSelected()
             end if
         end if
 
-        m.settingsMenu.focusBitmapBlendColor = selectedColor ?? ColorPalette.HIGHLIGHT
+        'm.settingsMenu.focusBitmapBlendColor = selectedColor ?? ColorPalette.HIGHLIGHT
     end if
 
     if isStringEqual(selectedSetting.settingName, "colorHomeUsername") and isValid(scene)

--- a/components/settings/settings.bs
+++ b/components/settings/settings.bs
@@ -1539,14 +1539,6 @@ function onKeyEvent(key as string, press as boolean) as boolean
 
     checkMagicKeyPressSequence(key)
 
-    ' Navigate to overhang with UP key from settings menu
-    if key = KeyCode.UP and isValid(m.settingsMenu) and m.settingsMenu.hasFocus()
-        if m.settingsMenu.itemFocused = 0
-            m.top.lastFocus = m.settingsMenu
-            return FocusOverhang(m.top)
-        end if
-    end if
-
     if key = "back" or key = "left"
         if m.settingsMenu.focusedChild <> invalid and m.userLocation.Count() > 1
             LoadMenu({})

--- a/components/settings/settings.xml
+++ b/components/settings/settings.xml
@@ -13,7 +13,7 @@
     <MultiStyleLabel id="version" translation="[1140, 1020]" />
 
     <MarkupList
-      translation="[1140, 220]"
+      translation="[1146, 220]"
       id="settingsMenu"
       itemComponentName="SettingsMenuItem"
       itemSize="[747, 120]"


### PR DESCRIPTION
# Pull Request

## Summary
Small style changes to the settings menu for visual consistency. Fixes a navigation bug as well as a bug that caused the menu item's current value to not display.

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [X] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
- Removed the `focusBitmapBlendColor` so only the actual menu item changes when focused
- Adjusted text translation so spacing between title, value, and description remain consistent
- Adjusted markupList translation in settings so buttons appear centered
- Used `addFields()` to set the label text for `settingCurrentValue` to show the current value of a setting in its menu item
- Removed leftover navigation code that caused the settings menu to lose focus when pressing UP on the topmost item

## Testing

- [X] Tested on physical Roku device
- [X] Tested via sideload
- [X] Manual testing completed
- [ ] Not tested (explain why):

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
