### PR TITLE
fix SetServerScreen layout bugs

### DIFF
--- a/components/config/FormElement.bs
+++ b/components/config/FormElement.bs
@@ -3,26 +3,16 @@ import "pkg:/source/enums/String.bs"
 import "pkg:/source/utils/misc.bs"
 
 sub init()
-    m.name = m.top.findNode("label")
-
     m.value = m.top.findNode("value")
     m.value.backgroundUri = "pkg:/images/transparent.png"
-    m.value.width = 440
+    m.value.width = 1000
 
-    m.name.color = ColorPalette.WHITE
     m.value.textColor = ColorPalette.DARKGREY
-    m.value.hintTextColor = ColorPalette.MIDGREY
+    m.value.hintTextColor = ColorPalette.LIGHTGREY
 
-    m.name.width = 240
-    m.name.height = 75
-
-    m.name.vertAlign = "center"
-    m.name.horizAlign = "center"
-
-    m.value.hintText = tr("Enter a username")
+    m.value.hintText = tr("Username")
     m.value.maxTextLength = 120
 
-    ' Observe text changes to update color
     m.value.observeField("text", "onTextChanged")
 end sub
 
@@ -38,9 +28,8 @@ end sub
 sub itemContentChanged()
     data = m.top.itemContent
 
-    m.name.text = data.label
     if isStringEqual(data.type, "password")
-        m.value.hintText = tr("Enter a password")
+        m.value.hintText = tr("Password")
         m.value.secureMode = true
     end if
 

--- a/components/config/FormElement.xml
+++ b/components/config/FormElement.xml
@@ -1,9 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <component name="FormElement" extends="Group">
   <children>
-    <Text id="label" horizAlign="right" translation="[0, 5]" />
-    <Poster id="buttonBackground" uri="pkg:/images/white.9.png" translation="[250, 8]" height="60" width="500" />
-    <TextEditBox id="value" translation="[270, 40]" />
+    <TextEditBox id="value" translation="[5, 40]" />
   </children>
 
   <interface>

--- a/components/config/FormList.bs
+++ b/components/config/FormList.bs
@@ -1,5 +1,3 @@
-import "pkg:/source/utils/config.bs"
-
 sub init()
     m.top.itemComponentName = "FormElement"
 
@@ -8,7 +6,7 @@ sub init()
 
     m.top.observeField("itemSelected", "onItemSelected")
 
-    m.top.itemSize = [750, 75]
+    m.top.itemSize = [1048, 75]
     m.top.itemSpacing = [0, 25]
 
     m.top.setfocus(true)

--- a/components/config/SetServerScreen.bs
+++ b/components/config/SetServerScreen.bs
@@ -91,6 +91,13 @@ sub updateDiscoveredLayout()
     if rowsForNode < 1 then rowsForNode = 1
     m.serverPicker.numRows = rowsForNode
 
+    if m.isManualEntryMode
+        applyManualLayout()
+        m.serverPickerContainer.height = 0
+        m.serverPickerContainer.visible = false
+        return
+    end if
+
     m.serverPickerContainer.height = listHeight
 
     addY = m.serverPickerY

--- a/components/config/SetServerScreen.bs
+++ b/components/config/SetServerScreen.bs
@@ -58,7 +58,7 @@ sub init()
     m.versionGap = 20
     m.versionLabelBaseX = 844
     m.manualMainY = 215
-    m.manualMainHeight = 420
+    m.manualMainHeight = 290
 
     m.addServerButton.observeField("buttonSelected", "onAddServerButtonSelected")
     m.connectButton.observeField("buttonSelected", "onConnectButtonSelected")
@@ -115,7 +115,7 @@ sub applyManualLayout()
     m.mainGroup.height = m.manualMainHeight
 
     if isValid(m.versionLabel)
-        m.versionLabel.translation = [m.versionLabelBaseX, 655]
+        m.versionLabel.translation = [m.versionLabelBaseX, 525]
     end if
 end sub
 
@@ -155,6 +155,7 @@ sub setManualMode()
     m.connectButton.visible = true
     m.cancelButton.visible = true
 
+    applyManualLayout()
     focusServerUrlInput()
 end sub
 

--- a/components/config/SetServerScreen.bs
+++ b/components/config/SetServerScreen.bs
@@ -140,6 +140,7 @@ sub setDiscoveredMode()
 
     m.connectButton.focus = false
     m.cancelButton.focus = false
+    m.addServerButton.focus = false
 
     if hasServers()
         m.serverPicker.setFocus(true)

--- a/components/config/SetServerScreen.xml
+++ b/components/config/SetServerScreen.xml
@@ -108,11 +108,11 @@
       <Text
         id="errorMessage"
         text=""
-        font="font:SmallestSystemFont"
+        font="font:TinySystemFont"
         color="#ff0000FF"
         width="1120"
         horizAlign="center"
-        translation="[40, 270]" />
+        translation="[40, 255]" />
     </Poster>
 
     <Text

--- a/components/config/SigninScene.bs
+++ b/components/config/SigninScene.bs
@@ -17,7 +17,6 @@ sub init()
     m.errorContainer.color = "#CC0000"
 
     m.config = m.top.findNode("configOptions")
-    m.config.blendColor = "0x2a2e40FF"
     m.config.focusBitmapBlendColor = "0x00A4DCFF" ' Blue focus 
 
     username_field = CreateObject("roSGNode", "ConfigData")

--- a/components/config/SigninScene.bs
+++ b/components/config/SigninScene.bs
@@ -4,55 +4,21 @@ import "pkg:/source/enums/PosterLoadStatus.bs"
 import "pkg:/source/enums/String.bs"
 import "pkg:/source/utils/misc.bs"
 
-const blankUserAvatarUri = "pkg:/images/baseline_person_white_48dp.png"
-
-sub onProfileImageUriChange()
-    if not isValid(m.top.profileImageUri)
-        m.top.profileImageUri = blankUserAvatarUri
-    end if
-
-    if isStringEqual(m.top.profileImageUri, string.EMPTY)
-        m.top.profileImageUri = blankUserAvatarUri
-    end if
-
-    m.profileImage.uri = m.top.profileImageUri
-end sub
-
-sub onPosterLoadStatusChanged()
-    if m.profileImage.loadStatus <> PosterLoadStatus.LOADING
-        m.profileImage.unobserveField("loadStatus")
-    end if
-
-    if isStringEqual(m.profileImage.loadStatus, PosterLoadStatus.FAILED)
-        m.top.profileImageUri = blankUserAvatarUri
-    end if
-end sub
-
 sub init()
     m.top.setFocus(true)
     m.top.optionsAvailable = false
 
-    m.profileImage = m.top.findNode("overlayCurrentUserProfileImage")
-    m.profileImage.observeField("loadStatus", "onPosterLoadStatusChanged")
+    m.connectingTo = m.top.findNode("connectingTo")
 
     m.submit = m.top.findNode("submit")
-    m.submit.background = "0x292929FF" ' Dark grey
-    m.submit.color = "0xFFFFFFFF" ' White text
-    m.submit.focusBackground = "0x00A4DCFF" ' Blue on focus
-    m.submit.focusColor = "0xFFFFFFFF" ' White text
-
     m.quickConnect = m.top.findNode("quickConnect")
-    m.quickConnect.background = "0x292929FF" ' Dark grey
-    m.quickConnect.color = "0xFFFFFFFF" ' White text
-    m.quickConnect.focusBackground = "0x00A4DCFF" ' Blue on focus
-    m.quickConnect.focusColor = "0xFFFFFFFF" ' White text
 
     m.errorContainer = m.top.findNode("errorContainer")
     m.errorContainer.color = "#CC0000"
 
     m.config = m.top.findNode("configOptions")
-    m.config.focusBitmapBlendColor = "0x00A4DCFF" ' Blue focus
-    m.config.focusFootprintBlendColor = ColorPalette.TRANSPARENT
+    m.config.blendColor = "0x2a2e40FF"
+    m.config.focusBitmapBlendColor = "0x00A4DCFF" ' Blue focus 
 
     username_field = CreateObject("roSGNode", "ConfigData")
     username_field.label = tr("Username")
@@ -84,6 +50,29 @@ sub init()
 
     saveCredentials.uncheckedIconUri = "pkg:/images/icons/checkboxUnchecked.png"
     saveCredentials.focusedUncheckedIconUri = "pkg:/images/icons/checkboxUnchecked.png"
+
+    initServerName()
+end sub
+
+sub initServerName()
+    serverName = m.global.session.server.name
+    if not isValidAndNotEmpty(serverName)
+        serverUrl = get_setting("server") ?? ""
+        if serverUrl = ""
+            m.connectingTo.text = tr("")
+            return
+        end if
+
+        serverName = serverUrl.replace("https://", "").replace("http://", "")
+        colonPos = serverName.instr(":")
+        slashPos = serverName.instr("/")
+        endPos = serverName.len()
+        if colonPos >= 0 and colonPos < endPos then endPos = colonPos
+        if slashPos >= 0 and slashPos < endPos then endPos = slashPos
+        serverName = serverName.left(endPos)
+    end if
+
+    m.connectingTo.text = tr("Connecting to ") + serverName
 end sub
 
 sub onAlertChange()

--- a/components/config/SigninScene.xml
+++ b/components/config/SigninScene.xml
@@ -2,19 +2,20 @@
 <component name="SigninScene" extends="JFScreen">
   <children>
     <!-- Background -->
-    <Rectangle
+    <Poster
+      id="background"
+      uri="pkg:/images/bg_login_gradient.png"
       width="1920"
       height="1080"
-      color="0x030322FF" />
+      translation="[0, 0]" />
 
-    <Text
-      text="Sign In"
-      horizAlign="center"
-      font="font:LargeSystemFont"
-      height="100"
-      width="1920"
-      color="0xFFFFFFFF"
-      translation="[0, 100]" />
+    <Rectangle translation="[710, 70]" width="500" height="113" color="0x00000000">
+      <Poster
+        id="logo"
+        uri="pkg:/images/logo.png"
+        width="500"
+        height="113" />
+    </Rectangle>
 
     <Poster uri="pkg:/images/baseline_person_white_48dp.png" id="overlayCurrentUserProfileImage" width="256" height="256" loadDisplayMode="scaleToZoom" translation="[832, 190]" />
 

--- a/components/config/SigninScene.xml
+++ b/components/config/SigninScene.xml
@@ -17,46 +17,83 @@
         height="113" />
     </Rectangle>
 
-    <Poster uri="pkg:/images/baseline_person_white_48dp.png" id="overlayCurrentUserProfileImage" width="256" height="256" loadDisplayMode="scaleToZoom" translation="[832, 190]" />
+    <Poster
+      id="signInGroup"
+      translation="[360, 215]"
+      width="1200"
+      height="600"
+      uri="pkg:/images/surface.9.png">
 
-    <Rectangle id="errorContainer" visible="false" width="600" height="60" translation="[660, 386]">
-      <Text id="errorMessage" text="" wrap="true" width="600" font="font:MediumSystemFont" horizAlign="center" color="0xFF6B6BFF" translation="[10, 15]" />
-    </Rectangle>
+      <Rectangle id="errorContainer" visible="false" width="600" height="60" translation="[305, 135]">
+        <Text id="errorMessage" text="" wrap="true" width="600" font="font:MediumSystemFont" horizAlign="center" color="0xFF6B6BFF" translation="[10, 15]" />
+      </Rectangle>
 
-    <Rectangle id="signInFormContainer" color="0x00000080" width="870" height="280" translation="[525, 466]">
-      <FormList id="configOptions" translation="[60, 40]" itemSpacing="[0, 50]" />
-    </Rectangle>
+      <Label
+        text="Sign In"
+        horizAlign="center"
+        width="1200"
+        height="35"
+        font="font:MediumBoldSystemFont"
+        color="0xFFFFFFFF"
+        translation="[0, 60]" />
 
-    <CheckList
-      id="saveCredentials"
-      checkedState="[true]"
-      translation="[560, 771]"
-      focusFootprintBitmapUri=""
-      drawFocusFeedback="false">
-      <ContentNode role="content">
-        <ContentNode title="Save Credentials?" />
-      </ContentNode>
-    </CheckList>
+      <Label id="connectingTo"
+        text="Connecting to -----"
+        horizAlign="center"
+        width="1200"
+        height="35"
+        font="font:TinySystemFont"
+        color="0x9CA3AFFF"
+        translation="[0, 100]" />
 
-    <StandardButton
-      id="submit"
-      text="Submit"
-      height="85"
-      width="350"
-      translation="[595,900]" />
+      <!-- Hacky way to get rectangles behind configOptions form elements -->
+      <Rectangle color="0x2a2e40FF" width="1110" height="75" translation="[45, 212]" />
+      <Rectangle color="0x2a2e40FF" width="1110" height="75" translation="[45, 335]" />
 
-    <StandardButton
-      id="quickConnect"
-      text="Quick Connect"
-      height="85"
-      width="350"
-      translation="[975,900]" />
+      <Rectangle id="signInFormContainer" color="#ffffff00" width="1120" height="280" translation="[40, 170]">
+        <FormList id="configOptions" translation="[36, 40]" itemSpacing="[0, 50]" />
+      </Rectangle>
+
+      <CheckList
+        id="saveCredentials"
+        checkedState="[true]"
+        translation="[40, 420]"
+        focusFootprintBitmapUri=""
+        drawFocusFeedback="false">
+        <ContentNode role="content">
+          <ContentNode title="Save Credentials?" />
+        </ContentNode>
+      </CheckList>
+
+      <StandardButton
+        id="submit"
+        text="Submit"
+        height="50"
+        width="545"
+        translation="[40,500]"
+        background="0x2a2e40FF"
+        color="0xFFFFFFFF"
+        focusBackground="0x00A4DCFF"
+        focusColor="0xFFFFFFFF"
+        fontSize="24" />
+
+      <StandardButton
+        id="quickConnect"
+        text="Quick Connect"
+        height="50"
+        width="545"
+        translation="[610,500]"
+        background="0x2a2e40FF"
+        color="0xFFFFFFFF"
+        focusBackground="0x00A4DCFF"
+        focusColor="0xFFFFFFFF"
+        fontSize="24" />
+    </Poster>
 
     <Timer id="quickConnectTimer" duration="3" repeat="true" />
   </children>
   <interface>
     <field id="user" type="string" onchange="onUserChange" value="" />
-    <field id="profileImageUri" type="string" onchange="onProfileImageUriChange" value="" alwaysNotify="true" />
     <field id="alert" type="string" onchange="onAlertChange" value="" />
   </interface>
 </component>

--- a/components/login/UserItem.bs
+++ b/components/login/UserItem.bs
@@ -26,7 +26,7 @@ sub onFocusChanged()
         m.avatarRing.blendColor = "0x00A4DCFF"
         m.profileName.color = "0x00A4DCFF"
     else
-        m.avatarRing.blendColor = "0x6B728099"
+        m.avatarRing.blendColor = "0x6B728000"
         m.profileName.color = "0xD1D5DBFF"
     end if
 end sub

--- a/components/login/UserItem.bs
+++ b/components/login/UserItem.bs
@@ -23,8 +23,8 @@ sub onFocusChanged()
     if not isValid(m.top.itemContent) then return
 
     if m.top.itemHasFocus
-        m.avatarRing.blendColor = "0xFFFFFFFF"
-        m.profileName.color = "0xFFFFFFFF"
+        m.avatarRing.blendColor = "0x00A4DCFF"
+        m.profileName.color = "0x00A4DCFF"
     else
         m.avatarRing.blendColor = "0x6B728099"
         m.profileName.color = "0xD1D5DBFF"

--- a/components/login/UserItem.xml
+++ b/components/login/UserItem.xml
@@ -4,24 +4,24 @@
     <LayoutGroup layoutDirection="vert" horizAlignment="center" translation="[10, 10]" itemSpacings="[12]">
       <Group id="avatarContainer">
         <Poster id="avatarRing"
-          width="164"
-          height="164"
+          width="134"
+          height="134"
           uri="pkg:/images/icons/circle64.png"
           loadDisplayMode="scaleToFit"
           blendColor="0x6B728099" />
 
         <Poster id="avatarBg"
-          width="150"
-          height="150"
+          width="120"
+          height="120"
           translation="[7, 7]"
           uri="pkg:/images/icons/circle64.png"
           loadDisplayMode="scaleToFit"
           blendColor="0x1F2937FF" />
 
-        <MaskGroup maskUri="pkg:/images/icons/circle64.png" maskSize="[150, 150]" translation="[7, 7]">
+        <MaskGroup maskUri="pkg:/images/icons/circle64.png" maskSize="[120, 120]" translation="[7, 7]">
           <Poster id="profileImage"
-            width="150"
-            height="150"
+            width="120"
+            height="120"
             loadDisplayMode="scaleToZoom" />
         </MaskGroup>
       </Group>
@@ -29,7 +29,7 @@
       <Label id="profileName"
         horizAlign="center"
         vertAlign="center"
-        font="font:SmallBoldSystemFont"
+        font="font:TinyBoldSystemFont"
         color="0xD1D5DBFF"
         height="30"
         width="180" />

--- a/components/login/UserSelect.bs
+++ b/components/login/UserSelect.bs
@@ -17,20 +17,20 @@ sub init()
     m.hiddenUsers.color = "0xFFFFFFCC"
 
     m.editButton = m.top.findNode("editButton")
-    m.editButton.background = "0x374151FF"
+    m.editButton.background = "0x2a2e40FF"
     m.editButton.color = "0xFFFFFFFF"
-    m.editButton.focusBackground = "0x4B5563FF"
+    m.editButton.focusBackground = "0x00A4DCFF"
     m.editButton.focusColor = "0xFFFFFFFF"
     m.editButton.observeField("buttonSelected", "onEditButtonSelected")
 
     m.manualLogin = m.top.findNode("manualLogin")
-    m.manualLogin.background = "0x292929FF"
+    m.manualLogin.background = "0x2a2e40FF"
     m.manualLogin.color = "0xFFFFFFFF"
     m.manualLogin.focusBackground = "0x00A4DCFF"
     m.manualLogin.focusColor = "0xFFFFFFFF"
 
     m.changeServer = m.top.findNode("changeServer")
-    m.changeServer.background = "0x292929FF"
+    m.changeServer.background = "0x2a2e40FF"
     m.changeServer.color = "0xFFFFFFFF"
     m.changeServer.focusBackground = "0x00A4DCFF"
     m.changeServer.focusColor = "0xFFFFFFFF"
@@ -121,7 +121,7 @@ sub itemContentChanged()
     redraw()
 end sub
 
-const ITEM_WIDTH = 200
+const ITEM_WIDTH = 180
 const ITEM_SPACING = 30
 const CLIP_WIDTH = 1120
 

--- a/components/login/UserSelect.bs
+++ b/components/login/UserSelect.bs
@@ -193,21 +193,11 @@ function onKeyEvent(key as string, press as boolean) as boolean
             return true
         end if
 
-        if m.manualLogin.hasFocus()
-            m.changeServer.setFocus(true)
-            m.changeServer.focus = true
-            m.manualLogin.focus = false
-            return true
-        end if
+        return false
     end if
 
     if key = KeyCode.LEFT
-        if m.changeServer.hasFocus()
-            m.manualLogin.setFocus(true)
-            m.manualLogin.focus = true
-            m.changeServer.focus = false
-            return true
-        end if
+        return false
     end if
 
     if key = KeyCode.OK
@@ -248,10 +238,16 @@ function onKeyEvent(key as string, press as boolean) as boolean
             return false
         end if
 
-        if m.manualLogin.hasFocus() or m.changeServer.hasFocus()
+        if m.manualLogin.hasFocus()
             m.editButton.setFocus(true)
             m.editButton.focus = true
             m.manualLogin.focus = false
+            return true
+        end if
+
+        if m.changeServer.hasFocus()
+            m.manualLogin.setFocus(true)
+            m.manualLogin.focus = true
             m.changeServer.focus = false
             return true
         end if
@@ -270,6 +266,13 @@ function onKeyEvent(key as string, press as boolean) as boolean
             m.manualLogin.setFocus(true)
             m.manualLogin.focus = true
             m.editButton.focus = false
+            return true
+        end if
+
+        if m.manualLogin.hasFocus()
+            m.changeServer.setFocus(true)
+            m.changeServer.focus = true
+            m.manualLogin.focus = false
             return true
         end if
 

--- a/components/login/UserSelect.xml
+++ b/components/login/UserSelect.xml
@@ -1,11 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
 <component name="UserSelect" extends="JFScreen">
   <children>
-    <Rectangle
+    <Poster
       id="background"
+      uri="pkg:/images/bg_login_gradient.png"
       width="1920"
       height="1080"
-      color="0x030322FF" />
+      translation="[0, 0]" />
+
+    <Rectangle translation="[710, 70]" width="500" height="113" color="0x00000000">
+      <Poster
+        id="logo"
+        uri="pkg:/images/logo.png"
+        width="500"
+        height="113" />
+    </Rectangle>
 
     <Rectangle id="unhideUsers" translation="[-600, 0]" width="600" height="1080" color="0x000000E0">
       <Text
@@ -28,33 +37,31 @@
     </Rectangle>
 
     <Rectangle id="viewContent" translation="[0, 0]">
-      <Group id="userSelectionGroup">
-        <Poster
-          id="cardBg"
-          uri="pkg:/images/user_selection_bg.png"
-          width="1200"
-          height="580"
-          translation="[360, 140]"
-          loadDisplayMode="scaleToFill" />
+      <Poster
+        id="userSelectionGroup"
+        translation="[360, 215]"
+        width="1200"
+        height="660"
+        uri="pkg:/images/surface.9.png">
 
         <Label id="serverName"
           horizAlign="center"
           width="1200"
           height="35"
-          font="font:SmallSystemFont"
+          font="font:TinySystemFont"
           color="0x9CA3AFFF"
-          translation="[360, 180]" />
+          translation="[0, 60]" />
 
         <Label id="whoWatching"
           text="Who's watching?"
           horizAlign="center"
           width="1200"
-          height="55"
-          font="font:LargeBoldSystemFont"
+          height="35"
+          font="font:MediumBoldSystemFont"
           color="0xFFFFFFFF"
-          translation="[360, 210]" />
+          translation="[0, 100]" />
 
-        <Group id="userRowContainer" translation="[400, 300]" clippingRect="[0, 0, 1120, 240]">
+        <Group id="userRowContainer" translation="[40, 200]" clippingRect="[0, 0, 1120, 240]">
           <UserRow id="userRow" translation="[0, 0]" />
         </Group>
 
@@ -62,23 +69,26 @@
           id="editButton"
           text="Edit"
           height="50"
-          width="200"
-          translation="[860, 590]" />
-      </Group>
+          width="1120"
+          translation="[40, 435]"
+          fontSize="24" />
 
-      <StandardButton
-        id="manualLogin"
-        text="Manual Login"
-        height="50"
-        width="260"
-        translation="[570, 780]" />
+        <StandardButton
+          id="manualLogin"
+          text="Manual Login"
+          height="50"
+          width="1120"
+          translation="[40, 500]"
+          fontSize="24" />
 
-      <StandardButton
-        id="changeServer"
-        text="Change Server"
-        height="50"
-        width="260"
-        translation="[1090, 780]" />
+        <StandardButton
+          id="changeServer"
+          text="Select Server"
+          height="50"
+          width="1120"
+          translation="[40, 565]"
+          fontSize="24" />
+      </Poster>
 
     </Rectangle>
 

--- a/source/ShowScenes.bs
+++ b/source/ShowScenes.bs
@@ -129,17 +129,6 @@ function LoginFlow()
                         LoadUserAbilities()
                         return true
                     end if
-                else
-                    ' No auth token found
-                end if
-                'Try to login without password. If the token is valid, we're done
-                userData = get_token(userSelected, "")
-                if isValid(userData)
-                    session.user.Login(userData, true)
-                    LoadUserAbilities()
-                    return true
-                else
-                    ' Auth failed
                 end if
             end if
         else
@@ -169,18 +158,11 @@ function LoginFlow()
 
             currentUser = AboutMe()
             if currentUser = invalid
-                'Try to login without password. If the token is valid, we're done
-                userData = get_token(myUsername, "")
-                if isValid(userData)
-                    session.user.Login(userData, true)
-                    LoadUserAbilities()
-                    return true
-                else
-                    ' Auth failed
-                    unset_user_setting("token")
-                    unset_user_setting("username")
-                    goto start_login
-                end if
+                ' Token invalid - clear cached data and show sign-in screen
+                unset_user_setting("token")
+                unset_user_setting("username")
+                unset_setting("active_user")
+                goto start_login
             else
                 session.user.Login(currentUser, true)
             end if


### PR DESCRIPTION
# Pull Request

## Summary
Fixes an issue where elements on the `SetServerScreen` would not update when going to manual server entry. Also prevents a visual bug where discovered servers could appear underneath the `Add Server` screen if `Add Server` was pressed before `ServerDiscoveryTask` could finish. Additionally fixes a focus issue where both a discovered server and the Add Server button could be focused simultaneously.

## Related Issues
Brought up by `jdupac` on the Discord server.

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [X] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
- Call `applyManualLayout()` when manual mode is set. This forces the height of `mainGroup` and translation of the version to be correct.
- Prevent `addServerButton` from being focused when `setDiscoveredMode()` is called.
- Hide the server picker container when `updateDiscoveredLayout()` is triggered during manual entry mode.
- Adjust `errorMessage` font size and Y translation so it renders correctly inside `mainGroup` while in manual mode.

## Testing
Describe how this change was tested.

- [X] Tested on physical Roku device
- [X] Tested via sideload
- [X] Manual testing completed
- [ ] Not tested (explain why):

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
