### PR TITLE
fix Quick Connect authentication failing due to missing auth token

### DIFF
--- a/components/quickConnect/QuickConnect.bs
+++ b/components/quickConnect/QuickConnect.bs
@@ -12,6 +12,8 @@ sub monitorQuickConnect()
     if authenticated = true
         loggedIn = AuthenticateViaQuickConnect(m.top.secret)
         if loggedIn
+            session.setRuntimeRequestContextValue("moonfin.authToken", m.global.session.user.authToken)
+            
             currentUser = AboutMe()
             session.user.Login(currentUser, m.top.saveCredentials)
             session.user.LoadUserPreferences()

--- a/source/api/sdk.bs
+++ b/source/api/sdk.bs
@@ -1354,7 +1354,7 @@ namespace api
         ' Initiate a new quick connect request.
         function Initiate()
             req = APIRequest("/quickconnect/initiate")
-            return getJson(req)
+            return postJson(req)
         end function
     end namespace
 


### PR DESCRIPTION
# Pull Request

## Summary
Fix Quick Connect from failing to authenticate. It was successfully creating an auth token but subsequent API calls were failing because the token wasn't available in the runtime context.

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

- Replace `getJson()` with `postJson()` for the initiating a new quick connect request. This was taken from the [upstream repository](https://github.com/jellyfin/jellyfin-roku/commit/4b4c3d5370bf01a97e6f7fac6644ab38e792d85a).
- Set auth token in the runtime context after `AuthenticateViaQuickConnect()` succeeds, and before subsequent API calls are made.

## Testing

- [X] Tested on physical Roku device
- [X] Tested via sideload
- [X] Manual testing completed
- [ ] Not tested (explain why):

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
