### PR TITLE
fix What's New dialog not closing

### DIFF
--- a/components/WhatsNewDialog.bs
+++ b/components/WhatsNewDialog.bs
@@ -40,14 +40,14 @@ sub init()
 end sub
 
 sub onButtonActivated()
-    m.top.wasClosed = true
+    m.top.whatsNewClosed = true
 end sub
 
 function onKeyEvent(key as string, press as boolean) as boolean
     if not press then return false
 
     if key = "back"
-        m.top.wasClosed = true
+        m.top.whatsNewClosed = true
         return false
     end if
 

--- a/components/WhatsNewDialog.xml
+++ b/components/WhatsNewDialog.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <component name="WhatsNewDialog" extends="StandardMessageDialog">
   <interface>
-    <field id="wasClosed" type="boolean" alwaysNotify="true" />
+    <field id="whatsNewClosed" type="boolean" alwaysNotify="true" />
   </interface>
   <children>
     <StdDlgContentArea id="content" />

--- a/components/data/SceneManager.bs
+++ b/components/data/SceneManager.bs
@@ -359,7 +359,7 @@ end sub
 ' Display What's New dialog to user with an OK button
 sub whatsNewDialog()
     dialog = createObject("roSGNode", "WhatsNewDialog")
-    dialog.observeField("wasClosed", "onWhatsNewDialogClosed")
+    dialog.observeField("whatsNewClosed", "onWhatsNewDialogClosed")
     m.scene.dialog = dialog
 end sub
 


### PR DESCRIPTION
# Pull Request

## Summary
StandardMessageDialog has its own `wasClosed`, and was conflicting with the custom field `wasClosed`. This change simply renames the field, allowing the `What's New` dialog to be closed by pressing OK.

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
- Renamed `wasClosed` to `whatsNewClosed` to avoid a type mismatch

## Testing
- [X] Tested on physical Roku device
- [X] Tested via sideload
- [X] Manual testing completed
- [ ] Not tested (explain why):

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
