### PR TITLE
fix multiple subtitle download issues

### DIFF
--- a/components/data/SceneManager.bs
+++ b/components/data/SceneManager.bs
@@ -301,6 +301,15 @@ sub registerOverhangData(group)
         ' For any other screen types, show overhang by default
         setOverhangVisibility(true)
     end if
+
+    if group.isSubType("VideoPlayerView")
+        if group.state = "playing" or group.state = "paused"
+            setOverhangVisibility(false)
+        else
+            setOverhangVisibility(true)
+        end if
+        return
+    end if
 end sub
 
 '

--- a/components/subtitle/SubtitleSearchView.bs
+++ b/components/subtitle/SubtitleSearchView.bs
@@ -87,18 +87,21 @@ sub onSelectedCultureChanged()
 end sub
 
 sub OnScreenShown(_isReturning = false as boolean)
-    if isValid(m.top.lastFocus)
-        m.top.lastFocus.setFocus(true)
-        if m.top.lastFocus.isSubType("StandardButton") or m.top.lastFocus.isSubType("TextButton")
-            m.top.lastFocus.focus = true
-        end if
+    m.top.getScene().callFunc("delayedFocus")
+end sub
 
-        setLastFocus(m.top.lastFocus)
-    else
-        m.top.setFocus(true)
-        setLastFocus(m.searchButton)
-        m.searchButton.focus = true
-    end if
+sub delayedFocus()
+    m.global.sceneManager.callFunc("callFuncDelayed", 0.1, sub()
+        if isValid(m.top.lastFocus)
+            m.top.lastFocus.setFocus(true)
+            if m.top.lastFocus.isSubType("StandardButton") or m.top.lastFocus.isSubType("TextButton")
+                m.top.lastFocus.focus = true
+            end if
+        else
+            m.searchButton.setFocus(true)
+            m.searchButton.focus = true
+        end if
+    end sub)
 end sub
 
 ' Handle navigation input from the remote and act on it

--- a/components/subtitle/SubtitleSearchView.bs
+++ b/components/subtitle/SubtitleSearchView.bs
@@ -12,7 +12,7 @@ sub init()
     mySubtitleBackground = m.top.findNode("mySubtitleBackground")
     mySubtitleBackground.color = ColorPalette.ELEMENTBACKGROUND
 
-    m.languageButton.textColor = ColorPalette.DARKGREY
+    m.languageButton.textColor = ColorPalette.LIGHTGREY
     m.languageButton.focusTextColor = ColorPalette.WHITE
     m.languageButton.background = ColorPalette.WHITE
     m.languageButton.focusBackground = chainLookupReturn(m.global.session, "user.settings.colorCursor", ColorPalette.HIGHLIGHT)

--- a/components/subtitle/SubtitleSearchView.bs
+++ b/components/subtitle/SubtitleSearchView.bs
@@ -30,6 +30,8 @@ sub init()
 
     m.searchButton.focus = true
     m.searchButton.setFocus(true)
+
+    m.top.overhangVisible = false
 end sub
 
 sub onItemContentChanged()
@@ -101,6 +103,11 @@ end sub
 
 ' Handle navigation input from the remote and act on it
 function onKeyEvent(key as string, press as boolean) as boolean
+    if key = KeyCode.BACK
+        m.global.sceneManager.callFunc("popScene")
+        return true
+    end if
+
     if not press
         if key = KeyCode.REPLAY
             group = m.global.sceneManager.callFunc("getActiveScene")

--- a/source/MainEventHandlers.bs
+++ b/source/MainEventHandlers.bs
@@ -1328,7 +1328,7 @@ sub onSubtitleLanguageButtonSelectedEvent()
     for each culture in group.cultures
         culture.type = "cultureselect"
         culture.Track = {}
-        culture.Track.description = culture.displayname
+        culture.description = culture.DisplayName
 
         ' Put preferred subtitle language at the top of the language list
         if isValidAndNotEmpty(culture.ThreeLetterISOLanguageName)


### PR DESCRIPTION
# Pull Request

## Summary
This PR fixes multiple issues on the subtitle download interface. It hides the navigation bar, sets focus on the Search button when `SubtitleSearchView` becomes visible, and fixes a bug causing language names to not show on the languages radio dialog.

## Related Issues
- Fixes #85
- Fixes #84 
- Fixes #83

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
- Set visibility on `JFOverhang` to `false` when `VideoPlayerView` is visible
- Delayed focus logic when `SubtitleSearchView` is being initialized. The button wasn't yet available when the previous logic ran causing it to not have initial focus.
- Fixed name mismatch for radio button description, causing no languages to load in the radio list.

## Testing
- [X] Tested on physical Roku device
- [X] Tested via sideload
- [X] Manual testing completed
- [ ] Not tested (explain why):

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
