### PR TITLE
fix media bar settings checklist style

### DIFF
--- a/components/settings/MediaBarChecklistDialog.xml
+++ b/components/settings/MediaBarChecklistDialog.xml
@@ -8,6 +8,7 @@
             <CheckList
                 id="checklist"
                 numRows="8"
+                itemSize="[860, 62]"
                 vertFocusAnimationStyle="floatingFocus"
                 checkedIconUri="pkg:/images/icons/checkboxChecked.png"
                 focusedCheckedIconUri="pkg:/images/icons/checkboxChecked.png"


### PR DESCRIPTION
# Pull Request

## Summary
This simply adds an `itemSize` constraint to the media bar settings checklist. This prevents the checklist from overflowing vertically, as well as makes the width of the focus background wide and centred.

## Related Issues
- Fixes #95 

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [X] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
- Adds itemSize to `MediaBarChecklistDialog` checklist

## Testing
- [X] Tested on physical Roku device
- [X] Tested via sideload
- [X] Manual testing completed
- [ ] Not tested (explain why):

## Screenshots
<img width="1920" height="1080" alt="screenshot-2026-05-23-14 50 09 480" src="https://github.com/user-attachments/assets/c27611f6-1994-45ad-88cf-9038977dd888" />


## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
