### PR TITLE
improve audio track selection

### DIFF
--- a/components/details/ItemDetails.bs
+++ b/components/details/ItemDetails.bs
@@ -1784,6 +1784,16 @@ sub onAudioStreamIndexChanged()
         m.top.selectedAudioStreamIndex = m.audioSelector.audioStreamIndex
         m.global.queueManager.callFunc("setPreferredAudioTrackIndex", m.audioSelector.audioStreamIndex)
         m.global.queueManager.callFunc("setPreferredAudioTrackName", m.audioSelector.audioStreamName)
+
+        if isValid(m.top.itemContent)
+            m.top.itemContent.selectedAudioStreamIndex = m.top.selectedAudioStreamIndex
+        end if
+
+        if isValid(m.trackData.audios)
+            for each track in m.trackData.audios
+                track.Selected = (track.StreamIndex = m.top.selectedAudioStreamIndex)
+            end for
+        end if
     end if
 end sub
 

--- a/components/manager/ViewCreator.bs
+++ b/components/manager/ViewCreator.bs
@@ -53,11 +53,18 @@ sub CreateVideoPlayerView()
         m.global.audioPlayer.control = VideoControl.STOP
     end if
 
+    currentItem = m.global.queueManager.callFunc("getCurrentItem")
+
     ' If the user has set a preferred audio track index, use it
     preferredAudioTrackIndex = m.global.queueManager.callFunc("getPreferredAudioTrackIndex")
     if preferredAudioTrackIndex < 0 then preferredAudioTrackIndex = 0
 
-    m.global.queueManager.callFunc("setSelectedAudioStreamIndex", preferredAudioTrackIndex)
+    selectedAudioIndex = preferredAudioTrackIndex
+    if isValid(currentItem.selectedAudioStreamIndex) and currentItem.selectedAudioStreamIndex >= 0
+        selectedAudioIndex = currentItem.selectedAudioStreamIndex
+    end if
+
+    m.global.queueManager.callFunc("setSelectedAudioStreamIndex", selectedAudioIndex)
 
     m.view = CreateObject("roSGNode", "VideoPlayerView")
     m.view.observeField("state", "onStateChange")
@@ -65,7 +72,6 @@ sub CreateVideoPlayerView()
     m.view.observeField("selectSubtitlePressed", "onSelectSubtitlePressed")
     m.view.observeField("selectAudioPressed", "onSelectAudioPressed")
 
-    currentItem = m.global.queueManager.callFunc("getCurrentItem")
     mediaSourceId = currentItem.mediaSourceId
 
     if not isValid(mediaSourceId) or mediaSourceId = ""
@@ -97,6 +103,14 @@ sub onSelectAudioPressed()
 
     preferredAudioTrackName = m.global.queueManager.callFunc("getPreferredAudioTrackName")
 
+    currentItem = m.global.queueManager.callFunc("getCurrentItem")
+    selectedAudioIndex = m.view.audioIndex
+    if not isValid(selectedAudioIndex) or selectedAudioIndex < 0
+        if isValid(currentItem.selectedAudioStreamIndex)
+            selectedAudioIndex = currentItem.selectedAudioStreamIndex
+        end if
+    end if
+
     audioTracks = []
 
     for each item in m.view.fullAudioData
@@ -108,7 +122,7 @@ sub onSelectAudioPressed()
         }
 
         if isStringEqual(preferredAudioTrackName, string.EMPTY)
-            if m.view.audioIndex = item.Index
+            if selectedAudioIndex = item.Index
                 audioTrack.Selected = true
             end if
         else

--- a/components/movies/AudioSelector.bs
+++ b/components/movies/AudioSelector.bs
@@ -28,10 +28,11 @@ sub audioTracksSet()
         selectedAudioIndex = 0
 
         for each audio in m.top.audioTracks
-            entry = audioContent.CreateChild("ContentNode")
+            entry = audioContent.CreateChild("AudioTrackListData")
             entry.title = audio.Title
             entry.description = audio.Title
-            entry.StreamIndex = audio.StreamIndex
+            entry.streamName = audio.RokuTrackName
+            entry.streamIndex = audio.StreamIndex
             if isValid(audio.Selected) and audio.Selected
                 selectedAudioIndex = index
                 entry.selected = true
@@ -49,8 +50,8 @@ end sub
 sub onAudioItemSelected()
     selectedItem = m.audioMenu.content.getChild(m.audioMenu.itemSelected)
     if isValid(selectedItem)
-        m.top.audioStreamIndex = selectedItem.StreamIndex
-        m.top.audioStreamName = selectedItem.title
+        m.top.audioStreamIndex = selectedItem.streamIndex
+        m.top.audioStreamName = selectedItem.streamName
         m.top.visible = false
     end if
 end sub


### PR DESCRIPTION
# Pull Request

## Summary
This PR improves audio track selection persistence by retaining the user's selected audio stream index on an item when navigating between the `ItemDetails` view and `VideoPlayerView`. This ensures users don't lose their audio track preference when switching between between screens and reopening the audio track selection menu.

## Related Issues
- Fixes #96

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
- Updated `ItemDetails` to persist the selected audio stream index to `itemContent` and update track data when audio selection changes
- Updated `ViewCreator` to check if the current item has a saved `selectedAudioStreamIndex` and prioritize it over the global preferred audio track setting
- Updated `AudioSelector` to use proper `AudioTrackListData` node type and consistent property naming

## Testing
- [X] Tested on physical Roku device
- [X] Tested via sideload
- [X] Manual testing completed
- [ ] Not tested (explain why):

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
