### PR TITLE
backport upstream commits, adjust vertical navigation on OSD

### DIFF
--- a/components/video/OSD.bs
+++ b/components/video/OSD.bs
@@ -48,7 +48,7 @@ sub init()
     m.top.observeField("nextItemIcon", "onNextItemIconChanged")
     m.top.observeField("nextItemTitleText", "onNextItemTitleTextChanged")
 
-    m.defaultButtonIndex = 2
+    m.defaultButtonIndex = 1
     m.focusedButtonIndex = 0
     m.currentButtonGroup = "seekbar"
     m.logoMoved = false
@@ -576,7 +576,8 @@ function onKeyEvent(key as string, press as boolean) as boolean
         if m.currentButtonGroup = "seekbar"
             focusOnTransportControls()
         else if m.currentButtonGroup = "transport"
-            focusOnSecondaryControls()
+            checkDisplaySiblingItem("")
+            m.top.action = "hide"
         else if m.currentButtonGroup = "secondary"
             checkDisplaySiblingItem("")
             m.top.action = "hide"
@@ -587,7 +588,8 @@ function onKeyEvent(key as string, press as boolean) as boolean
 
     if key = "up"
         if m.currentButtonGroup = "secondary"
-            focusOnTransportControls()
+            focusOnSeekbar()
+
         else if m.currentButtonGroup = "transport"
             focusOnSeekbar()
         end if

--- a/components/video/VideoPlayerView.bs
+++ b/components/video/VideoPlayerView.bs
@@ -867,7 +867,6 @@ sub onVideoContentLoaded()
 
         if subtitle.Index = videoContent[0].selectedSubtitle
             selectedSubtitle = subtitle
-            exit for
         end if
     end for
 
@@ -890,9 +889,7 @@ sub onVideoContentLoaded()
         end if
     end if
 
-    if not (m.isTranscoded and burnInSubtitles)
-        m.top.selectedSubtitle = videoContent[0].selectedSubtitle
-    end if
+    m.top.selectedSubtitle = videoContent[0].selectedSubtitle
 
     m.top.observeField("selectedSubtitle", "onSubtitleChange")
 

--- a/source/api/userauth.bs
+++ b/source/api/userauth.bs
@@ -134,7 +134,7 @@ end sub
 
 function initQuickConnect()
     resp = APIRequest("QuickConnect/Initiate")
-    jsonResponse = getJson(resp)
+    jsonResponse = postJson(resp)
     if jsonResponse = invalid
         return invalid
     end if


### PR DESCRIPTION
# Pull Request

## Summary
This PR backports 2 commits made upstream to change the API for quick connect that will soon be deprecated, as well as fixes an issue where burned-in subtitles may not appear on the subtitle selection screen. This also changes the vertical navigation for the OSD.

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
- Changed `get` to `post` to initiate quick connect
- Removed the `exit for` statement and conditional check to allow the subtitle menu to show burned-in subtitle tracks on transcoded content
- Changed default button index to Play/Pause when moving DOWN from seek bar
- Changed DOWN on transport & secondary controls so it always hides the OSD
- Changed UP on secondary controls so it focuses on the seek bar instead of the transport controls

## Testing
- [X] Tested on physical Roku device
- [X] Tested via sideload
- [X] Manual testing completed
- [ ] Not tested (explain why):

## Screenshots (if applicable)
Include screenshots or recordings for UI changes.

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
