### PR TITLE
keep backdrop tint consistent, add backdrop fade to home items

### DIFF
--- a/components/home/Home.bs
+++ b/components/home/Home.bs
@@ -129,6 +129,7 @@ sub init()
             if isValid(m.backdrop)
                 m.backdrop.opacity = 1.0
             end if
+            m.backdropTargetOpacity = 1.0
         else
             ' Make sure media bar is hidden if disabled
             m.mediaBar.visible = false
@@ -264,6 +265,7 @@ sub onHomeRowsContentLoaded()
             if isValid(m.backdrop)
                 m.backdrop.opacity = 1.0
             end if
+            m.backdropTargetOpacity = 1.0
 
             ' Store focus state
             group = m.global.sceneManager.callFunc("getActiveScene")
@@ -642,6 +644,7 @@ sub OnScreenShown(_isReturning = false as boolean)
             if isValid(m.backdrop)
                 m.backdrop.opacity = 1.0
             end if
+            m.backdropTargetOpacity = 1.0
         else
             ' Default to home rows
             if isValid(m.homeRows)
@@ -843,6 +846,7 @@ function onKeyEvent(key as string, press as boolean) as boolean
                 if isValid(m.backdrop)
                     m.backdrop.opacity = 1.0
                 end if
+                m.backdropTargetOpacity = 1.0
                 return true
             end if
         end if
@@ -879,6 +883,7 @@ function onKeyEvent(key as string, press as boolean) as boolean
             if isValid(m.backdrop)
                 m.backdrop.opacity = 0.3
             end if
+            m.backdropTargetOpacity = 0.3
             return true
         end if
     end if

--- a/components/home/Home.bs
+++ b/components/home/Home.bs
@@ -219,7 +219,7 @@ sub onMediaBarBackdropChanged(event as object)
             ' Copy current image to prev layer
             if isValid(m.backdropPrev) and m.backdrop.uri <> ""
                 m.backdropPrev.uri = m.backdrop.uri
-                m.backdropPrev.opacity = 1.0
+                m.backdropPrev.opacity = m.backdropTargetOpacity
             end if
 
             ' Hide new backdrop until it's ready
@@ -481,11 +481,22 @@ sub onBackdropLoadStatusChange()
     if isValid(m.backdrop) and m.backdrop.loadStatus = "ready" and isValidAndNotEmpty(m.backdrop.uri)
         if m.backdropCrossfading
             targetOpacity = m.backdropTargetOpacity
+            
+            currentBackdropOpacity = 0.0
+            if isValid(m.backdrop)
+                currentBackdropOpacity = m.backdrop.opacity
+            end if
+            
+            currentPrevOpacity = 1.0
+            if isValid(m.backdropPrev)
+                currentPrevOpacity = m.backdropPrev.opacity
+            end if
+            
             if isValid(m.backdropFadeInInterp)
-                m.backdropFadeInInterp.keyValue = [0.0, targetOpacity]
+                m.backdropFadeInInterp.keyValue = [currentBackdropOpacity, targetOpacity]
             end if
             if isValid(m.backdropPrevFadeOutInterp)
-                m.backdropPrevFadeOutInterp.keyValue = [targetOpacity, 0.0]
+                m.backdropPrevFadeOutInterp.keyValue = [currentPrevOpacity, 0.0]
             end if
             if isValid(m.backdropFadeIn)
                 m.backdropFadeIn.control = "start"
@@ -494,10 +505,6 @@ sub onBackdropLoadStatusChange()
                 m.backdropPrevFadeOut.control = "start"
             end if
             m.backdropCrossfading = false
-        else
-            if isValid(m.backdropPrev)
-                m.backdropPrev.uri = m.backdrop.uri
-            end if
         end if
     end if
 end sub
@@ -1057,14 +1064,20 @@ sub onItemFocusChanged()
 
         if isValid(m.backdropPrev) and m.backdrop.uri <> ""
             m.backdropPrev.uri = m.backdrop.uri
-            m.backdropPrev.opacity = 1.0
+            m.backdropPrev.opacity = m.backdropTargetOpacity
         end if
 
         m.backdrop.opacity = 0.0
         m.backdrop.uri = focusedItem.backdropURL
         m.backdropCrossfading = true
     else
-        clearFocusedItemBackdrop()
+        if isValid(m.backdropFadeIn) then m.backdropFadeIn.control = "stop"
+        if isValid(m.backdropPrevFadeOut) then m.backdropPrevFadeOut.control = "stop"
+        m.backdropCrossfading = false
+        m.backdropTargetOpacity = 0.3
+        if isValid(m.backdropTint)
+            m.backdropTint.opacity = 1.0
+        end if
     end if
 
     m.currentFocusedItemId = ""
@@ -1147,8 +1160,20 @@ sub onItemDetailsLoaded()
         end if
 
         if isValidAndNotEmpty(backdropUri)
-            applyBackdropWithEffect(backdropUri)
+            if isValid(m.backdropPrev) and m.backdrop.uri <> ""
+                m.backdropPrev.uri = m.backdrop.uri
+                m.backdropPrev.opacity = m.backdropTargetOpacity
+            end if
+            m.backdrop.opacity = 0.0
+            m.backdrop.uri = backdropUri
+            m.backdropCrossfading = true
+            m.backdropTargetOpacity = 0.3
+
+            if isValid(m.backdropTint)
+                m.backdropTint.opacity = 1.0
+            end if
         end if
+        
     end if
 
     if isValid(json.Type)
@@ -1507,20 +1532,6 @@ function getBlurredImageURL(itemId as string, imageType as string, imageTag as s
     }
     return ImageURL(itemId, imageType, params)
 end function
-
-' Apply backdrop with blur and tint effect
-' Old backdrop stays visible until new backdrop loads
-sub applyBackdropWithEffect(backdropUri as string)
-    if isValid(m.backdrop) and isValidAndNotEmpty(backdropUri)
-        ' Set new backdrop URI - old one (backdropPrev) will stay visible until this loads
-        m.backdrop.uri = backdropUri
-    end if
-
-    ' Ensure tint overlay is visible
-    if isValid(m.backdropTint)
-        m.backdropTint.visible = true
-    end if
-end sub
 
 ' Helper function to check if a node is a child/descendant of a parent node
 ' Walks up the parent chain to see if we find the target parent


### PR DESCRIPTION
# Pull Request

## Summary
This PR fixes an issue where the backdrop tint would disappear when navigating between home items. Whenever the actual opacity property changes, `backdropTargetOpacity` also now changes, preventing a state mismatch. This also adds the backdrop fade used for the Media Bar to the home items, so the backdrop doesn't jump when switching focused items.

## Related Issues
- Fixes #99 

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [X] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
- Set `backdropTargetOpacity` across different functions so the backdrop tint doesn't disappear when moving between items
- Added the backdrop fade to the home items

## Testing
- [X] Tested on physical Roku device
- [X] Tested via sideload
- [X] Manual testing completed
- [ ] Not tested (explain why):

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
