### PR TITLE
hide runtime for tvshows, update settings style

### DIFF
--- a/components/home/MediaBar.bs
+++ b/components/home/MediaBar.bs
@@ -292,7 +292,7 @@ function processItem(item as object) as object
         if displayGenres.count() > 3
             displayGenres = [displayGenres[0], displayGenres[1], displayGenres[2]]
         end if
-        processed.genresDisplay = displayGenres.join(" • ")
+        processed.genresDisplay = displayGenres.join("  •  ")
     end if
 
     return processed
@@ -482,11 +482,14 @@ sub showMediaBarItem(index as integer)
         end if
     end if
 
-    if item.runtimeDisplay <> ""
+    if item.itemType = "Movie" and item.runtimeDisplay <> ""
         m.runtimeLabel.text = item.runtimeDisplay
+        m.separatorDot3.text = "  •  "
         hasRuntime = true
     else
         m.runtimeLabel.text = ""
+        m.separatorDot3.text = ""
+        hasRuntime = false
     end if
 
     ' Community rating with star
@@ -501,7 +504,7 @@ sub showMediaBarItem(index as integer)
 
     ' Show/hide separator dots based on what metadata exists
     m.separatorDot1.visible = (hasYear and hasRating)
-    m.separatorDot2.visible = (hasRating and hasRuntime)
+    m.separatorDot2.visible = (hasRating)
     m.separatorDot3.visible = (hasRuntime and hasStarRating)
 
     pluginRatingsEnabled = moonfinPlugin.IsRatingsEnabled()

--- a/components/home/MediaBar.xml
+++ b/components/home/MediaBar.xml
@@ -59,14 +59,13 @@
             <LayoutGroup
                 id="metadataRow"
                 layoutDirection="horiz"
-                itemSpacings="[18]"
             >
                 <Label id="yearLabel" font="font:SmallestBoldSystemFont" color="0xFFFFFFFF" text="" />
                 <Label
                     id="separatorDot1"
-                    font="font:SmallSystemFont"
+                    font="font:SmallestSystemFont"
                     color="0xFFFFFFFF"
-                    text="•"
+                    text="  •  "
                     visible="false"
                 />
                 <Group id="ratingGroup">
@@ -75,26 +74,26 @@
                 </Group>
                 <Label
                     id="separatorDot2"
-                    font="font:SmallSystemFont"
+                    font="font:SmallestSystemFont"
                     color="0xFFFFFFFF"
-                    text="•"
+                    text="  •  "
                     visible="false"
                 />
                 <Label id="runtimeLabel" font="font:SmallestBoldSystemFont" color="0xFFFFFFFF" text="" />
                 <Label
                     id="separatorDot3"
-                    font="font:SmallSystemFont"
+                    font="font:SmallestSystemFont"
                     color="0xFFFFFFFF"
-                    text="•"
+                    text="•  "
                     visible="false"
                 />
-                <Label id="starLabel" font="font:SmallestBoldSystemFont" color="0xFFD700FF" text="★" visible="false" />
+                <Label id="starLabel" font="font:SmallestBoldSystemFont" color="0xFFD700FF" text="★ " visible="false" />
                 <Label id="communityRatingLabel" font="font:SmallestBoldSystemFont" color="0xFFFFFFFF" text="" />
                 <Label
                     id="separatorDot4"
-                    font="font:SmallSystemFont"
+                    font="font:SmallestSystemFont"
                     color="0xFFFFFFFF"
-                    text="•"
+                    text="  •  "
                     visible="false"
                 />
                 <Label id="genresLabel" font="font:SmallestBoldSystemFont" color="0xFFFFFFFF" text="" />

--- a/components/settings/SettingsMenuItem.bs
+++ b/components/settings/SettingsMenuItem.bs
@@ -51,7 +51,7 @@ sub focusChanged()
         stopMarquee(m.settingTitle)
         stopMarquee(m.settingCurrentValue)
         stopMarquee(m.settingDescription)
-        m.buttonBackground.blendColor = ColorPalette.ELEMENTBACKGROUND
+        m.buttonBackground.blendColor = "#181818FF"
         m.focusOutline.visible = false
         m.settingTitle.color = ColorPalette.WHITE
         m.settingCurrentValue.color = focusColor

--- a/components/settings/settings.xml
+++ b/components/settings/settings.xml
@@ -7,26 +7,26 @@
   <children>
 
     <Rectangle id="panelBackdrop" translation="[0, 0]" width="1920" height="1080" color="#000000" opacity="0.70" />
-    <Rectangle id="panelBackground" translation="[1120, 0]" width="800" height="1080" color="#101826" />
+    <Rectangle id="panelBackground" translation="[1120, 0]" width="800" height="1080" color="#101010" />
 
-    <Text id="path" translation="[1140, 160]" font="font:SmallestBoldSystemFont" />
+    <ScrollingText id="path" translation="[1146, 22]" font="font:SmallBoldSystemFont" maxWidth="747" />
     <MultiStyleLabel id="version" translation="[1140, 1020]" />
 
     <MarkupList
-      translation="[1146, 220]"
+      translation="[1146, 80]"
       id="settingsMenu"
       itemComponentName="SettingsMenuItem"
       itemSize="[747, 120]"
       itemSpacing="[0,10]"
-      numRows="6"
+      numRows="7"
       vertFocusAnimationStyle="floatingFocus"
       skipFocusAnimations="true" />
 
-    <Text id="settingDesc" translation="[180, 180]" width="880" wrap="true" horizAlign="left" visible="false" />
+    <Text id="settingDesc" translation="[110, 180]" width="880" wrap="true" horizAlign="left" visible="false" />
 
-    <RadioButtonList id="radioSetting" numRows="6" vertFocusAnimationStyle="floatingFocus" translation="[280, 280]" visible="false" />
+    <RadioButtonList id="radioSetting" numRows="6" vertFocusAnimationStyle="floatingFocus" translation="[290, 350]" visible="false" />
 
-    <RadioButtonList id="boolSetting" vertFocusAnimationStyle="floatingFocus" translation="[560, 400]" visible="false">
+    <RadioButtonList id="boolSetting" vertFocusAnimationStyle="floatingFocus" translation="[290, 400]" visible="false">
       <ContentNode role="content">
         <ContentNode title="Disabled" />
         <ContentNode title="Enabled" />
@@ -35,7 +35,7 @@
 
     <ColorGrid
       id="colorgrid"
-      translation="[60, 240]"
+      translation="[60, 400]"
       itemComponentName="ColorOption"
       numColumns="15"
       numRows="9"

--- a/components/settings/settings.xml
+++ b/components/settings/settings.xml
@@ -19,7 +19,8 @@
       itemSize="[747, 120]"
       itemSpacing="[0,10]"
       numRows="6"
-      vertFocusAnimationStyle="floatingFocus" />
+      vertFocusAnimationStyle="floatingFocus"
+      skipFocusAnimations="true" />
 
     <Text id="settingDesc" translation="[180, 180]" width="880" wrap="true" horizAlign="left" visible="false" />
 


### PR DESCRIPTION
# Pull Request

## Summary
This PR makes a couple changes to both the media bar, and the settings menu. It fixes a bug where the item runtime wasn't hidden when the item didn't have a runtime (like a tv show) on the media bar. It also changes the colors and layout of the settings menu to further resemble the core app. It also fixed a bug in the settings menu that caused a delay when scrolling through items.

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [X] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
- Changed the display of the runtime on the media bar so the runtime is only displayed when the media item is a `Movie`. Previously, it would show "0 min" if the item was a TV show, which looked odd. This change required removing item spacings from `metadataRow` and then re-adding them using spaces around the separators.
- Added `skipFocusAnimations` to `settingsMenu` because the custom focus image wasn't compatible with the built-in animation.
- Changed colours of settings menu to look more like the core app.
- Changed the spacing and number of rows in the settings menu.
- Changed the translations of `settingsDesc`, `radioSetting`, `boolSetting`, and `colorgrid` so they stay centered within the backdrop area.

## Testing
- [X] Tested on physical Roku device
- [X] Tested via sideload
- [X] Manual testing completed
- [ ] Not tested (explain why):

## Screenshots (if applicable)
<img width="1920" height="1080" alt="screenshot-2026-06-13-00 20 38 606" src="https://github.com/user-attachments/assets/4546761d-d219-47d7-b720-e193c904d4eb" />



## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [ ] No new warnings introduced
