### PR TITLE
Sort merged continue watching row

### DIFF
--- a/components/home/LoadItemsTask.bs
+++ b/components/home/LoadItemsTask.bs
@@ -314,20 +314,145 @@ function loadMergedContinueWatching() as object
         end for
     end if
 
+    recentPlayedParams = {
+        includeItemTypes: "Episode",
+        filters: "IsPlayed",
+        recursive: true,
+        sortBy: "DatePlayed",
+        sortOrder: "Descending",
+        limit: 100,
+        fields: "UserData,SeriesId",
+        UserId: m.global.session.user.id
+    }
+    recentPlayedResponse = api.items.get(recentPlayedParams)
+
+    ' Create a lookup map of series LastPlayedDate to populate nextup
+    seriesLastPlayedMap = {}
+    'seriesLastPlayedIds = {}
+    if isChainValid(recentPlayedResponse, "Items")
+        for each item in recentPlayedResponse.Items
+            sId = item.LookupCI("SeriesId")
+            'if not seriesLastPlayedIds.DoesExist(sId)
+            lastPlayed = getNestedValue(item, "UserData.LastPlayedDate")
+            seriesLastPlayedMap[sId] = lastPlayed
+                'seriesLastPlayedIds[sId] = true
+            'end if
+        end for
+    end if
+
+
     ' Add Next Up items that aren't already in Continue Watching
     if isChainValid(nextUpData, "Items")
         for each item in nextUpData.Items
             itemId = item.LookupCI("Id")
+            seriesId = item.LookupCI("SeriesId")
+            userData = item.LookupCI("UserData")
+            'if userData["LastPlayedDate"] = invalid
+            userData["LastPlayedDate"] = seriesLastPlayedMap[seriesId]
+            'end if
             ' Only add if not already in resume items
             if not resumeItemIds.DoesExist(itemId)
                 tmp = createSGNode("HomeData")
-                tmp.json = item
+                tmp.json = {
+                Id: itemId,
+                name: item.LookupCI("name"),
+                Type: item.LookupCI("Type"),
+                SeriesName: item.LookupCI("SeriesName"),
+                SeriesId: seriesId,
+                SeasonId: item.LookupCI("SeasonId"),
+                ProductionYear: item.LookupCI("ProductionYear"),
+                Status: item.LookupCI("Status"),
+                EndDate: item.LookupCI("EndDate"),
+                ParentIndexNumber: item.LookupCI("ParentIndexNumber"),
+                IndexNumber: item.LookupCI("IndexNumber"),
+                IndexNumberEnd: item.LookupCI("IndexNumberEnd"),
+                OfficialRating: item.LookupCI("OfficialRating"),
+                CollectionType: item.LookupCI("CollectionType"),
+                ImageTags: item.LookupCI("ImageTags"),
+                UserData: userData,
+                ParentThumbItemId: item.LookupCI("ParentThumbItemId"),
+                ParentThumbImageTag: item.LookupCI("ParentThumbImageTag"),
+                ParentBackdropImageTags: item.LookupCI("ParentBackdropImageTags"),
+                ParentBackdropItemId: item.LookupCI("ParentBackdropItemId"),
+                SeriesPrimaryImageTag: item.LookupCI("SeriesPrimaryImageTag"),
+                BackdropImageTags: item.LookupCI("BackdropImageTags")
+            }
                 results.push(tmp)
             end if
         end for
     end if
 
-    return results
+    sortedResults = sortServerResultsByDate(results, "UserData.LastPlayedDate")
+    return sortedResults
+end function
+
+' sortServerResultsByDate: Sorts multi-server results by a date field (descending)
+'
+' @param {array} results - Array of items from multiple servers
+' @param {string} dateField - Dot-notation path to date field (e.g., "UserData.LastPlayedDate")
+' @return {array} Sorted array
+function sortServerResultsByDate(results as object, dateField as string) as object
+    if not isValidAndNotEmpty(results) then return []
+
+    ' Convert to array with sortable date values
+    sortableItems = []
+    for each item in results
+        dateValue = getNestedValue(item, dateField)
+        sortableItems.push({
+            item: item,
+            sortDate: dateValue
+        })
+    end for
+
+    ' Simple bubble sort (sufficient for small arrays)
+    n = sortableItems.count()
+    for i = 0 to n - 2
+        for j = 0 to n - i - 2
+            ' Compare dates (ISO strings compare correctly alphabetically for descending)
+            date1 = sortableItems[j].sortDate
+            date2 = sortableItems[j + 1].sortDate
+
+            ' Handle invalid dates
+            if not isValid(date1) then date1 = ""
+            if not isValid(date2) then date2 = ""
+
+            ' Swap if date1 < date2 (we want descending order)
+            if date1 < date2
+                temp = sortableItems[j]
+                sortableItems[j] = sortableItems[j + 1]
+                sortableItems[j + 1] = temp
+            end if
+        end for
+    end for
+
+    ' Extract sorted items
+    sortedResults = []
+    for each sortable in sortableItems
+        sortedResults.push(sortable.item)
+    end for
+
+    return sortedResults
+end function
+
+' getNestedValue: Gets a value from a nested object using dot notation
+'
+' @param {object} obj - Object to search
+' @param {string} path - Dot-notation path (e.g., "UserData.LastPlayedDate")
+' @return {dynamic} Value at path or invalid
+function getNestedValue(obj as object, path as string) as dynamic
+    if not isValid(obj) or path = "" then return invalid
+
+    parts = path.split(".")
+    current = obj
+
+    for each part in parts
+        if not isValid(current) then return invalid
+        if type(current) <> "roAssociativeArray" then return invalid
+        if not current.DoesExist(part) then return invalid
+        current = current[part]
+    end for
+
+    return current
 end function
 
 function loadSeasonOfEpisodes() as object

--- a/components/home/LoadItemsTask.bs
+++ b/components/home/LoadItemsTask.bs
@@ -326,27 +326,25 @@ function loadMergedContinueWatching() as object
     }
     recentPlayedResponse = api.items.get(recentPlayedParams)
 
-    ' Create a lookup map of series LastPlayedDate to populate nextup
+ ' Create a lookup map of series LastPlayedDate to populate nextup
     seriesLastPlayedMap = {}
-    'seriesLastPlayedIds = {}
     if isChainValid(recentPlayedResponse, "Items")
         for each item in recentPlayedResponse.Items
             sId = item.LookupCI("SeriesId")
-            if seriesLastPlayedMap[sId] = invalid
-                lastPlayed = item["UserData"]["LastPlayedDate"]
-                seriesLastPlayedMap[sId] = lastPlayed
+            userData = item.LookupCI("UserData")
+            if isValid(sId) and isValid(userData) and seriesLastPlayedMap[sId] = invalid
+                seriesLastPlayedMap[sId] = userData["LastPlayedDate"]
             end if
         end for
     end if
-
-
     ' Add Next Up items that aren't already in Continue Watching
     if isChainValid(nextUpData, "Items")
         for each item in nextUpData.Items
             itemId = item.LookupCI("Id")
             seriesId = item.LookupCI("SeriesId")
             userData = item.LookupCI("UserData")
-            if userData["LastPlayedDate"] = invalid
+            if not isValid(userData) then userData = {}
+            if userData["LastPlayedDate"] = invalid and isValid(seriesId)
                 userData["LastPlayedDate"] = seriesLastPlayedMap[seriesId]
             end if
             ' Only add if not already in resume items
@@ -395,8 +393,10 @@ function sortServerResultsByDate(results as object) as object
     ' Convert to array with sortable date values
     sortableItems = []
     for each item in results
-        dateValue = item.json["UserData"]["LastPlayedDate"]
-        ? "nested " ; dateValue
+        dateValue = invalid
+        if isValid(item.json) and isValid(item.json.UserData)
+            dateValue = item.json.UserData.LastPlayedDate
+        end if
         sortableItems.push({
             item: item,
             sortDate: dateValue

--- a/components/home/LoadItemsTask.bs
+++ b/components/home/LoadItemsTask.bs
@@ -332,11 +332,10 @@ function loadMergedContinueWatching() as object
     if isChainValid(recentPlayedResponse, "Items")
         for each item in recentPlayedResponse.Items
             sId = item.LookupCI("SeriesId")
-            'if not seriesLastPlayedIds.DoesExist(sId)
-            lastPlayed = getNestedValue(item, "UserData.LastPlayedDate")
-            seriesLastPlayedMap[sId] = lastPlayed
-                'seriesLastPlayedIds[sId] = true
-            'end if
+            if seriesLastPlayedMap[sId] = invalid
+                lastPlayed = item["UserData"]["LastPlayedDate"]
+                seriesLastPlayedMap[sId] = lastPlayed
+            end if
         end for
     end if
 
@@ -347,9 +346,9 @@ function loadMergedContinueWatching() as object
             itemId = item.LookupCI("Id")
             seriesId = item.LookupCI("SeriesId")
             userData = item.LookupCI("UserData")
-            'if userData["LastPlayedDate"] = invalid
-            userData["LastPlayedDate"] = seriesLastPlayedMap[seriesId]
-            'end if
+            if userData["LastPlayedDate"] = invalid
+                userData["LastPlayedDate"] = seriesLastPlayedMap[seriesId]
+            end if
             ' Only add if not already in resume items
             if not resumeItemIds.DoesExist(itemId)
                 tmp = createSGNode("HomeData")
@@ -382,22 +381,22 @@ function loadMergedContinueWatching() as object
         end for
     end if
 
-    sortedResults = sortServerResultsByDate(results, "UserData.LastPlayedDate")
+    sortedResults = sortServerResultsByDate(results)
     return sortedResults
 end function
 
 ' sortServerResultsByDate: Sorts multi-server results by a date field (descending)
 '
 ' @param {array} results - Array of items from multiple servers
-' @param {string} dateField - Dot-notation path to date field (e.g., "UserData.LastPlayedDate")
 ' @return {array} Sorted array
-function sortServerResultsByDate(results as object, dateField as string) as object
+function sortServerResultsByDate(results as object) as object
     if not isValidAndNotEmpty(results) then return []
 
     ' Convert to array with sortable date values
     sortableItems = []
     for each item in results
-        dateValue = getNestedValue(item, dateField)
+        dateValue = item.json["UserData"]["LastPlayedDate"]
+        ? "nested " ; dateValue
         sortableItems.push({
             item: item,
             sortDate: dateValue
@@ -432,27 +431,6 @@ function sortServerResultsByDate(results as object, dateField as string) as obje
     end for
 
     return sortedResults
-end function
-
-' getNestedValue: Gets a value from a nested object using dot notation
-'
-' @param {object} obj - Object to search
-' @param {string} path - Dot-notation path (e.g., "UserData.LastPlayedDate")
-' @return {dynamic} Value at path or invalid
-function getNestedValue(obj as object, path as string) as dynamic
-    if not isValid(obj) or path = "" then return invalid
-
-    parts = path.split(".")
-    current = obj
-
-    for each part in parts
-        if not isValid(current) then return invalid
-        if type(current) <> "roAssociativeArray" then return invalid
-        if not current.DoesExist(part) then return invalid
-        current = current[part]
-    end for
-
-    return current
 end function
 
 function loadSeasonOfEpisodes() as object


### PR DESCRIPTION
# Pull Request

## Summary
Sorts the merged cw/nu row to match core and smarttv clients

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #
- Related to #

## Type of Change
- [ ] Bug fix
- [X] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

- created lastPlayedMap and populated series last played dates
- if nextup item has invalid LastPlayedDate, replace with lastPlayedMap entry for same series
- sorted row with function copied from utils/multiserver

## Testing
Describe how this change was tested.

- [X] Tested on physical Roku device
- [X] Tested via sideload
- [ ] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1.
2.
3.

## Screenshots (if applicable)
Include screenshots or recordings for UI changes.
<img width="4000" height="3000" alt="image" src="https://github.com/user-attachments/assets/c345d1ad-3080-411f-9286-f81e7cef5ce0" />


## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
