### PR TITLE
trash container translation fix

### DIFF
--- a/components/config/JFServer.xml
+++ b/components/config/JFServer.xml
@@ -23,8 +23,8 @@
       <Label id="baseUrl" horizAlign="left" font="font:SmallestSystemFont" height="65" translation="[0,40]" color="#CCCCCCCC" />
     </Group>
 
-    <Rectangle id="trashContainer" translation="[500,0]" width="60" height="60">
-      <Poster id="trash" width="25" height="25" uri="pkg:/images/icons/trash.png" translation="[18,18]" />
+    <Rectangle id="trashContainer" translation="[1025,5]" width="90" height="90">
+      <Poster id="trash" width="32" height="32" uri="pkg:/images/icons/trash.png" translation="[18,18]" />
     </Rectangle>
   </children>
 

--- a/components/config/JFServer.xml
+++ b/components/config/JFServer.xml
@@ -24,7 +24,7 @@
     </Group>
 
     <Rectangle id="trashContainer" translation="[1025,5]" width="90" height="90">
-      <Poster id="trash" width="32" height="32" uri="pkg:/images/icons/trash.png" translation="[18,18]" />
+      <Poster id="trash" width="32" height="32" uri="pkg:/images/icons/trash.png" translation="[30,28]" />
     </Rectangle>
   </children>
 


### PR DESCRIPTION
# Pull Request

## Summary
This PR simply moves the `trashContainer` over and adjusts its size. I must have missed it when I changed the design of the set server screen.

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [X] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
- Moved `trashContainer` to the end of `JFServer`, and changed the height/width.
- Changed the height/width and translation of the trash icon.

## Testing
- [X] Tested on physical Roku device
- [X] Tested via sideload
- [ ] Manual testing completed
- [ ] Not tested (explain why):

## Screenshots
**Before**
<img width="1920" height="1080" alt="screenshot-2026-06-26-10 31 03 182" src="https://github.com/user-attachments/assets/8c6d3076-f347-4258-91ab-5147038e7b61" />
**After**
<img width="1920" height="1080" alt="screenshot-2026-06-26-10 36 28 815" src="https://github.com/user-attachments/assets/44a62643-cff9-4c44-a239-cd410a1ac1f2" />


## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
