### PR TITLE
change mediabar from toggle to menu to match core

### DIFF
--- a/components/home/HomeRows.bs
+++ b/components/home/HomeRows.bs
@@ -37,7 +37,7 @@ end function
 ' Helper function to check if Featured Media is enabled via toggle (not home sections)
 function isFeaturedMediaEnabled() as boolean
     ' Check the media bar enabled toggle in Moonfin settings
-    mediaBarEnabled = get_user_setting("ui.home.mediaBarEnabled")
+    mediaBarEnabled = (get_user_setting("ui.home.mediaBarMode") <> "off")
 
     ' Default to true if not set
     if not isValid(mediaBarEnabled)

--- a/settings/settings.json
+++ b/settings/settings.json
@@ -192,11 +192,21 @@
         "description": "Featured carousel content and overlay appearance.",
         "children": [
           {
-            "title": "Enable Media Bar",
+            "title": "Media Bar Mode",
             "description": "Display a featured content slideshow at the top of the home screen.",
-            "settingName": "ui.home.mediaBarEnabled",
-            "type": "bool",
-            "default": "true"
+            "settingName": "ui.home.mediaBarMode",
+            "type": "radio",
+            "default": "moonfin",
+            "options": [
+              {
+                "title": "Moonfin",
+                "id": "moonfin"
+              },
+              {
+                "title": "Off",
+                "id": "off"
+              }
+            ]
           },
           {
             "title": "Content Type",

--- a/source/utils/settingsSync.bs
+++ b/source/utils/settingsSync.bs
@@ -16,7 +16,7 @@ namespace settingsSync
             { pluginKey: "navbarColor", rokuKey: "navbar.color", type: "colorHex" },
             { pluginKey: "mergeContinueWatchingNextUp", rokuKey: "ui.home.mergeContinueWatchingNextUp", type: "bool" },
             { pluginKey: "enableMultiServerLibraries", rokuKey: "ui.home.enableMultiServer", type: "bool" },
-            { pluginKey: "mediaBarEnabled", rokuKey: "ui.home.mediaBarEnabled", type: "bool" },
+            { pluginKey: "mediaBarMode", rokuKey: "ui.home.mediaBarMode", type: "direct" },
             { pluginKey: "mediaBarSourceType", rokuKey: "ui.home.mediaBarSourceType", type: "direct" },
             { pluginKey: "mediaBarLibraryIds", rokuKey: "ui.home.mediaBarLibraryIds", type: "jsonArray" },
             { pluginKey: "mediaBarCollectionIds", rokuKey: "ui.home.mediaBarCollectionIds", type: "jsonArray" },


### PR DESCRIPTION
# Pull Request

## Summary
Replace media bar enabled toggle with media bar mode list to match core

for now the only options are "moonfin" or "off", but this will allow us to add new media bar modes eventually

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #
- Related to #125 

## Type of Change
- [ ] Bug fix
- [X] New feature
- [X] Refactor
- [ ] Performance improvement
- [ ] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

- replace mediaBarEnabled setting with mediaBarMode setting
- changed setting from bool to list 
- change isMediaBarEnabled elsewhere to evaluate to (mediaBarMode != off)

## Testing
Describe how this change was tested.

- [X] Tested on physical Roku device
- [ ] Tested via sideload
- [ ] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. Change mediabarmode to moonfin, see media bar
2. Change mediabarmode to off, no see media bar
3. Syncs with plugin (defaults to "moonfin" if plugin serves other mode for now)

## Screenshots (if applicable)
Include screenshots or recordings for UI changes.

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
