### PR TITLE
add video scrubbing functionality

### DIFF
--- a/components/video/VideoPlayerView.bs
+++ b/components/video/VideoPlayerView.bs
@@ -335,6 +335,9 @@ sub handleFastForwardAction()
     startScrubbing(1)
 end sub
 
+' startScrubbing: starts scrub mode, setting direction, speed, and UI state while pausing playback
+' and initializing scrub tracking
+'
 sub startScrubbing(direction as integer)
     if m.scrubActive then return
 
@@ -353,6 +356,9 @@ sub startScrubbing(direction as integer)
     m.scrubTimer.control = "start"
 end sub
 
+' stopScrubbing: stops scrub mode, applies the final seek position, restores playback state,
+' and hides scrub UI elements
+'
 sub stopScrubbing()
     m.scrubTimer.control = "stop"
     m.scrubActive = false
@@ -370,6 +376,8 @@ sub stopScrubbing()
     hideSegmentSkipButton()
 end sub
 
+' onScrubTimer: updates scrub position, UI, and speed indicator on each timer tick while scrubbing playback
+'
 sub onScrubTimer()
     if not m.scrubActive then return
 

--- a/components/video/VideoPlayerView.bs
+++ b/components/video/VideoPlayerView.bs
@@ -106,6 +106,21 @@ sub init()
 
     m.videoEndingTime = m.top.findNode("videoEndingTime")
 
+    ' Scrubbing
+    m.scrubActive = false
+    m.scrubDirection = 0
+    m.scrubSpeedIndex = 3
+    m.scrubSpeeds = [-168, -50, -10, 10, 50, 168]
+    m.scrubPosition = 0
+    m.scrubPositionStart = 0
+
+    m.scrubTimer = m.top.findNode("scrubTimer")
+    m.scrubTimer.observeField("fire", "onScrubTimer")
+
+    m.scrubTime = m.top.findNode("scrubTimeDisplay")
+    m.progressBar = m.top.findNode("scrubProgressBar")
+    m.scrubSpeed = m.top.findNode("scrubSpeedDisplay")
+
     m.subtitleSyncValue = m.top.findNode("subtitleSyncValue")
     m.subtitleSyncValue.font.size = 26
     m.subtitleSyncValue.text = `${tr("Current Offset")}: 0 ms`
@@ -284,26 +299,106 @@ sub handleItemSkipAction(action as string)
     end if
 end sub
 
-' handleRewindAction: Handles user command to rewind video by 10 seconds
+' handleRewindAction: Handles user command to start rewinding scrub
 '
 sub handleRewindAction()
-    newPosition = m.top.position - 10
-    if newPosition < 0 then newPosition = 0
+    if m.scrubActive
+        if m.scrubDirection = -1
+            if m.scrubSpeedIndex > 0
+                m.scrubSpeedIndex = m.scrubSpeedIndex - 1
+            end if
+        else
+            m.scrubDirection = -1
+            m.scrubSpeedIndex = 2
+        end if
+        return
+    end if
 
-    m.top.seek = newPosition
-    setVideoEndingTime(newPosition)
-    m.positionText.text = secondsToHuman(newPosition, true)
+    startScrubbing(-1)
 end sub
 
-' handleFastForwardAction: Handles user command to fast forward video by 10 seconds
+' handleFastForwardAction: Handles user command to start fast forward scrub
 '
 sub handleFastForwardAction()
-    newPosition = m.top.position + 10
-    if newPosition > m.top.duration then newPosition = m.top.duration
+    if m.scrubActive
+        if m.scrubDirection = 1
+            if m.scrubSpeedIndex < m.scrubSpeeds.count() - 1
+                m.scrubSpeedIndex = m.scrubSpeedIndex + 1
+            end if
+        else
+            m.scrubDirection = 1
+            m.scrubSpeedIndex = 3
+        end if
+        return
+    end if
 
-    m.top.seek = newPosition
-    setVideoEndingTime(newPosition)
-    m.positionText.text = secondsToHuman(newPosition, true)
+    startScrubbing(1)
+end sub
+
+sub startScrubbing(direction as integer)
+    if m.scrubActive then return
+
+    m.scrubActive = true
+    m.scrubDirection = direction
+    m.scrubSpeedIndex = direction = 1 ? 3 : 2
+    m.scrubPositionStart = m.top.position
+    m.scrubPosition = m.top.position
+
+    m.top.control = VideoControl.PAUSE
+
+    m.pauseOverlay.visible = true
+    m.scrubInfo = m.top.findNode("scrubInfo")
+    m.scrubInfo.visible = true
+
+    m.scrubTimer.control = "start"
+end sub
+
+sub stopScrubbing()
+    m.scrubTimer.control = "stop"
+    m.scrubActive = false
+    m.scrubDirection = 0
+
+    m.top.seek = m.scrubPosition
+
+    m.scrubInfo = m.top.findNode("scrubInfo")
+    if isValid(m.scrubInfo)
+        m.scrubInfo.visible = false
+    end if
+
+    m.top.control = VideoControl.RESUME
+    m.pauseOverlay.visible = false
+    hideSegmentSkipButton()
+end sub
+
+sub onScrubTimer()
+    if not m.scrubActive then return
+
+    speed = m.scrubSpeeds[m.scrubSpeedIndex]
+    m.scrubPosition = m.scrubPosition + speed * m.scrubTimer.duration
+
+    if m.scrubPosition < 0 then m.scrubPosition = 0
+    if m.scrubPosition > m.top.duration then m.scrubPosition = m.top.duration
+
+    
+    if isValid(m.scrubTime)
+        m.scrubTime.text = secondsToHuman(m.scrubPosition, true) + " / " + secondsToHuman(m.top.duration, true)
+    end if
+
+    if isValid(m.progressBar) and m.top.duration > 0
+        scrubPct = m.scrubPosition / m.top.duration
+        m.progressBar.width = 1714 * scrubPct
+    end if
+
+    if m.scrubSpeedIndex = 3 or m.scrubSpeedIndex = 2
+        m.scrubSpeed.text = tr("3x")
+    else if m.scrubSpeedIndex = 4 or m.scrubSpeedIndex = 1
+        m.scrubSpeed.text = tr("15x")
+    else if m.scrubSpeedIndex = 5 or m.scrubSpeedIndex = 0
+        m.scrubSpeed.text = tr("50x")
+    end if
+
+    m.positionText.text = secondsToHuman(m.scrubPosition, true)
+    setVideoEndingTime(m.scrubPosition)
 end sub
 
 ' handleHideAction: Handles action to hide OSD menu
@@ -1171,8 +1266,10 @@ sub onState()
     ' Handle OSD visibility based on playback state
     if isStringEqual(m.top.state, MediaPlaybackState.PAUSED)
         ' Keep OSD visible when paused
-        if not m.osd.visible
-            showOSD()
+        if not m.scrubActive
+            if not m.osd.visible
+                showOSD()
+            end if
         end if
         ' Disable auto-hide timer when paused
         m.osd.inactiveTimeout = 0
@@ -1749,6 +1846,36 @@ function onKeyEvent(key as string, press as boolean) as boolean
 
     if not press then return false
 
+    if m.scrubActive
+        if key = KeyCode.OK or key = KeyCode.PLAY
+            stopScrubbing()
+            return true
+        end if
+
+        if key = KeyCode.LEFT or key = KeyCode.RIGHT
+            stopScrubbing()
+            return true
+        end if
+
+        if key = KeyCode.REWIND
+            if m.scrubDirection = 1
+                stopScrubbing()
+            else
+                handleRewindAction()
+            end if
+            return true
+        end if
+
+        if key = KeyCode.FASTFORWRD
+            if m.scrubDirection = -1
+                stopScrubbing()
+            else
+                handleFastForwardAction()
+            end if
+            return true
+        end if
+    end if
+
     ' Handle rewind/fast forward/replay remote buttons
     if key = KeyCode.REWIND or key = KeyCode.FASTFORWRD or key = KeyCode.REPLAY
         if not m.top.trickPlayBar.visible
@@ -1769,11 +1896,16 @@ function onKeyEvent(key as string, press as boolean) as boolean
             if not stateAllowsOSD() then return true
 
             if key = KeyCode.RIGHT
-                handleFastForwardAction()
+                newPosition = m.top.position + 10
+                if newPosition > m.top.duration then newPosition = m.top.duration
             else
-                handleRewindAction()
+                newPosition = m.top.position - 10
+                if newPosition < 0 then newPosition = 0
             end if
 
+            m.top.seek = newPosition
+            setVideoEndingTime(newPosition)
+            m.positionText.text = secondsToHuman(newPosition, true)
             return true
         end if
     end if
@@ -1825,6 +1957,11 @@ function onKeyEvent(key as string, press as boolean) as boolean
     end if
 
     if key = KeyCode.BACK
+        if m.scrubActive
+            stopScrubbing()
+            return true
+        end if
+
         if m.skipSegmentButton.visible
             if isValid(m.currentSegmentType)
                 m.mediaSegmentDismissed[m.currentSegmentType] = true

--- a/components/video/VideoPlayerView.xml
+++ b/components/video/VideoPlayerView.xml
@@ -34,6 +34,7 @@
     <Group id="captionGroup" translation="[0,0]" />
     <timer id="playbackTimer" repeat="true" duration="30" />
     <timer id="bufferCheckTimer" repeat="true" />
+    <timer id="scrubTimer" repeat="true" duration="0.3" />
     <OSD id="osd" visible="false" inactiveTimeout="0" />
 
     <Rectangle id="chapterList" visible="false" color="0x00000098" width="400" height="380" translation="[103,210]">
@@ -54,6 +55,14 @@
     </Rectangle>
 
     <StandardButton id="skipSegment" visible="false" height="85" width="250" translation="[1500, 900]" />
+
+    <Group id="scrubInfo" visible="false" translation="[103,900]">
+      <Text id="scrubSpeedDisplay" font="font:MediumSystemFont" color="0xffffffFF" horizAlign="right" width="100" translation="[1612,55]" />
+      <Rectangle id="scrubProgressBackground" width="1714" height="6" color="0x555555AA" translation="[0,30]">
+        <Rectangle id="scrubProgressBar" width="0" height="6" color="0x00a4dcFF" />
+      </Rectangle>
+      <Text id="scrubTimeDisplay" font="font:MediumSystemFont" color="0xffffffFF" horizAlign="left" width="400" translation="[0,55]" />
+    </Group>
 
     <Rectangle id="subtitleTimingButtons" height="120" width="560" translation="[100, 900]" visible="false">
       <Text id="subtitleSyncValue" translation="[10, 20]" />


### PR DESCRIPTION
# Pull Request

## Summary
This PR returns the functionality of video scrubbing. By using the Fast Forward and Rewind buttons on the Roku remote, this allows you to scrub through videos with multiple levels of speed. Left/Right continues to skip the video forward/backward.

Pressing Ok, Play/Pause, Left/Right, or the opposite scrubbing direction stops the scrub operation.

## Related Issues
- Closes #134
- Related to #129 

## Type of Change
- [ ] Bug fix
- [X] New feature
- [ ] Refactor
- [ ] Performance improvement
- [X] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
- Added new group, `scrubInfo`, which shows a progress bar, time display, and how fast scrubbing is happening. The levels are **3x**, **15x**, and **50x** both ways.
- Added new functions to handle starting, stopping, and every tick for scrubbing. 
- Changed `handleFastForwardAction` and `handleRewindAction` to instead start scrubbing OR increase scrub speed.

## Testing
- [X] Tested on physical Roku device
- [X] Tested via sideload
- [X] Manual testing completed
- [ ] Not tested (explain why):

## Screenshots
<img width="1920" height="1080" alt="screenshot-2026-07-02-15 14 51 719" src="https://github.com/user-attachments/assets/f68f48e3-e286-45a7-9648-5b4dd402bb53" />

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced