### PR TITLE
fix wrong backdrop showing on fast home navigation

### DIFF
--- a/components/home/Home.bs
+++ b/components/home/Home.bs
@@ -643,6 +643,9 @@ sub OnScreenShown(_isReturning = false as boolean)
 
         if shouldShowMediaBar
             ' Focus media bar if it's enabled
+            m.currentFocusedItemId = ""
+            m.currentFocusedItemServerUrl = invalid
+
             m.mediaBar.visible = true
             m.mediaBar.hasFocus = true
             m.mediaBar.setFocus(true)

--- a/components/home/Home.bs
+++ b/components/home/Home.bs
@@ -249,6 +249,9 @@ sub onHomeRowsContentLoaded()
         ' On first run only, set focus to media bar
         ' DON'T set focus if we're returning from another screen (OnScreenShown handles focus restoration)
         if m.shouldFocusMediaBarOnLoad = true and isValid(m.mediaBar)
+            m.currentFocusedItemId = ""
+            m.currentFocusedItemServerUrl = invalid
+
             ' Show MediaBar and hide HomeRows only when setting initial focus
             m.mediaBar.visible = true
             m.homeRows.visible = false
@@ -571,6 +574,9 @@ sub OnScreenShown(_isReturning = false as boolean)
             end if
             ' Check if the saved focus was mediaBar itself or a child of mediaBar
         else if isValid(m.mediaBar) and (scenePreviousFocus.isSameNode(m.mediaBar) or isChildOf(scenePreviousFocus, m.mediaBar))
+            m.currentFocusedItemId = ""
+            m.currentFocusedItemServerUrl = invalid
+
             m.mediaBar.hasFocus = true
             m.mediaBar.setFocus(true)
             focusRestored = true
@@ -836,6 +842,9 @@ function onKeyEvent(key as string, press as boolean) as boolean
 
             ' If Media Bar is enabled, show it instead of overhang
             if mediaBarEnabled and isValid(m.mediaBar)
+                m.currentFocusedItemId = ""
+                m.currentFocusedItemServerUrl = invalid
+
                 m.homeRows.visible = false
                 m.homeRows.setFocus(false)
                 m.mediaBar.visible = true


### PR DESCRIPTION
# Pull Request

## Summary
This PR fixes a bug where the `homeRows` backdrop would show after navigating to the media bar. When navigating up/down quickly, if you navigate UP back to the Media Bar before the item in `homeRows` finishes loading its backdrop, the `homeRows` item backdrop would display on the Media Bar instead of the proper backdrop for the media bar item.

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
- Set `currentFocusedItemID` to an empty string, and `currentFocusedItemServerUrl` to invalid. A check is done in `onItemDetailsLoaded()` which checks the `currentFocusedItemID` and exits early if there is a mismatch.

## Testing
- [X] Tested on physical Roku device
- [X] Tested via sideload
- [X] Manual testing completed
- [ ] Not tested (explain why):

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
