### PR TITLE
separate recently released row by library type

### DIFF
--- a/components/home/HomeRows.bs
+++ b/components/home/HomeRows.bs
@@ -631,6 +631,11 @@ function getExpectedRowContribution(sectionName as string) as integer
         if isMultiServerEnabled()
             sessions = getAllServerSessions()
             if sessions.Count() > 0
+                ' Multi-server latest media builds 5 rows per server, while
+                ' recently released aggregates every server into a single row
+                if sectionName = "recentlyreleased"
+                    return 1
+                end if
                 return sessions.Count() * 5
             end if
         end if
@@ -2223,7 +2228,7 @@ sub updateRecentlyReleasedItems(msg)
         return
     end if
 
-    m.top.content.insertChild(row, getOriginalSectionIndex("latestmedia"))
+    m.top.content.insertChild(row, getOriginalSectionIndex("recentlyreleased"))
     setRowItemSize()
 end sub
 

--- a/components/home/HomeRows.bs
+++ b/components/home/HomeRows.bs
@@ -627,7 +627,7 @@ function getExpectedRowContribution(sectionName as string) as integer
     end if
 
 
-    if sectionName = "latestmedia"
+    if sectionName = "latestmedia" or sectionName = "recentlyreleased"
         if isMultiServerEnabled()
             sessions = getAllServerSessions()
             if sessions.Count() > 0
@@ -1129,19 +1129,46 @@ end sub
 ' createRecentlyReleasedRow: Creates a row displaying recently released items sorted by premiere date
 '
 sub createRecentlyReleasedRow()
-    sectionName = tr("Recently Released")
+    ' create a Recently Added in row for each library
+    for each lib in m.filteredLatest
+        if not isStringEqual(lib.collectionType, "boxsets") and not isStringEqual(lib.collectionType, "livetv") and not isStringEqual(lib.json.CollectionType, "Program")
+            sectionName = `${tr("Recently Released in")} ${lib.name}`
 
-    if not sectionExists(sectionName)
-        recentlyReleasedRow = m.top.content.CreateChild("HomeRow")
-        recentlyReleasedRow.title = sectionName
-        recentlyReleasedRow.imageWidth = getPosterSize(false)[0]
-        recentlyReleasedRow.cursorSize = getPosterSize(false)
-    end if
+            ' Determine poster size based on content type and user preference
+            imagesize = getPosterSize(false) ' Default to portrait, but respect thumbnail toggle
 
-    ' Load the Recently Released Data (lazy task creation)
-    task = getOrCreateTask("recentlyReleased")
-    task.observeField("content", "updateRecentlyReleasedItems")
-    task.control = "RUN"
+            if isValid(lib.json.CollectionType)
+                if isStringEqual(lib.json.CollectionType, "movies")
+                    imagesize = getPosterSize(false) ' Movies use portrait, or wide if thumbnails enabled
+                else if isStringEqual(lib.json.CollectionType, "music")
+                    imagesize = homeRowItemSizes.MUSIC_ALBUM
+                end if
+            end if
+
+            if not sectionExists(sectionName)
+                row = m.top.content.CreateChild("HomeRow")
+                row.title = sectionName
+                row.imageWidth = imagesize[0]
+                row.cursorSize = imagesize
+            end if
+
+            try
+                loadLatest = createObject("roSGNode", "LoadItemsTask")
+                loadLatest.itemsToLoad = "recentlyReleased"
+                loadLatest.itemId = lib.id
+
+                metadata = { "title": lib.name }
+                metadata.Append({ "contentType": lib.json.CollectionType })
+                loadLatest.metadata = metadata
+
+                loadLatest.observeField("content", "updateRecentlyReleasedItems")
+                loadLatest.control = TaskControl.RUN
+            catch e
+                removeHomeSection(sectionName)
+                m.global.sceneManager.callFunc("standardDialog", `Error creating Recently Released rows`, { data: ["<p>" + `Error Message: ${e.message}` + "</p>"] })
+            end try
+        end if
+    end for
 end sub
 
 ' sectionExists: Checks if passed section exists in home row content
@@ -2150,22 +2177,37 @@ end sub
 
 ' updateRecentlyReleasedItems: Processes LoadItemsTask content for recently released items
 '
-sub updateRecentlyReleasedItems()
+' @param {dynamic} msg - LoadItemsTask
+sub updateRecentlyReleasedItems(msg)
     m.processedRowCount++
-    itemData = getTaskContentAndCleanup("recentlyReleased")
+    itemData = msg.GetData()
 
-    sectionName = tr("Recently Released")
+    node = msg.getRoSGNode()
+    node.unobserveField("content")
+    node.content = []
+
+    sectionName = tr("Recently Released in") + " " + node.metadata.title
 
     if not isValidAndNotEmpty(itemData)
         removeHomeSection(sectionName)
         return
     end if
 
-    ' Create row using the new data
+    imagesize = getPosterSize(false)
+
+    if isValid(node.metadata.contentType)
+        if LCase(node.metadata.contentType) = "movies"
+            imagesize = getPosterSize(false)
+        else if LCase(node.metadata.contentType) = "music"
+            imagesize = homeRowItemSizes.MUSIC_ALBUM
+        end if
+    end if
+
+    ' remake row using new data
     row = CreateObject("roSGNode", "HomeRow")
     row.title = sectionName
-    row.imageWidth = getPosterSize(false)[0]
-    row.cursorSize = getPosterSize(false)
+    row.imageWidth = imagesize[0]
+    row.cursorSize = imagesize
     row.usePoster = true
 
     for each item in itemData
@@ -2174,14 +2216,13 @@ sub updateRecentlyReleasedItems()
         row.appendChild(item)
     end for
 
-    ' Row already exists, replace it with new content
     if sectionExists(sectionName)
+        ' Row already exists, replace it with new content
         m.top.content.replaceChild(row, getSectionIndex(sectionName))
         setRowItemSize()
         return
     end if
 
-    ' Row does not exist, insert it after latest media
     m.top.content.insertChild(row, getOriginalSectionIndex("latestmedia"))
     setRowItemSize()
 end sub

--- a/components/home/LoadItemsTask.bs
+++ b/components/home/LoadItemsTask.bs
@@ -119,11 +119,12 @@ function loadRecentlyReleased() as object
     params = {
         userId: m.global.session.user.id,
         limit: 50,
+        parentId: m.top.itemId,
         recursive: true,
         fields: "PrimaryImageAspectRatio,Genres,Overview",
         enableImageTypes: `${ImageType.PRIMARY}, ${ImageType.BACKDROP}, ${ImageType.THUMB}`,
         imageTypeLimit: 1,
-        includeItemTypes: `${ItemType.MOVIE}, ${ItemType.SERIES}`,
+        includeItemTypes: `${ItemType.MOVIE}, ${ItemType.SERIES}, ${ItemType.BOOK}, ${ItemType.AUDIOBOOK}, ${ItemType.MUSICALBUM}`,
         sortBy: "PremiereDate,ProductionYear,SortName",
         sortOrder: "Descending",
         enableTotalRecordCount: false


### PR DESCRIPTION
# Pull Request

## Summary
Recently Released home row will now display separate rows for each library, to match what I did for core/smarttv

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #
- Related to #

## Type of Change
- [ ] Bug fix
- [X] New feature
- [ ] Refactor
- [ ] Performance improvement
- [X] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

- create individual rows for each library, similar to recently added rows
- pass parentID to the recently released api call
- 

## Testing
Describe how this change was tested.

- [X] Tested on physical Roku device
- [ ] Tested via sideload
- [ ] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1.
2.
3.

## Screenshots (if applicable)
Include screenshots or recordings for UI changes.
<img width="4000" height="3000" alt="20260707_184208" src="https://github.com/user-attachments/assets/0dea7c0c-d47d-466f-b94e-b2c4b0fd1fb1" />


## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
