### PR TITLE
feat: port imdb list custom row changes from core

### DIFF
--- a/components/home/HomeRows.bs
+++ b/components/home/HomeRows.bs
@@ -2466,15 +2466,22 @@ function getNestedValue(obj as object, path as string) as dynamic
     return current
 end function
 
+' Maps an imdb_ server row id to its localized section title, or "" if unknown.
+function imdbSectionName(rowId as string) as string
+    if rowId = "imdb_top_250_movies" then return tr("IMDb Top 250 Movies")
+    if rowId = "imdb_top_250_tv_shows" then return tr("IMDb Top 250 TV Shows")
+    if rowId = "imdb_most_popular_movies" then return tr("IMDb Most Popular Movies")
+    if rowId = "imdb_most_popular_tv_shows" then return tr("IMDb Most Popular TV Shows")
+    if rowId = "imdb_lowest_rated_movies" then return tr("IMDb Lowest Rated Movies")
+    if rowId = "imdb_top_english_movies" then return tr("IMDb Top Rated English Movies")
+    return ""
+end function
+
 function createImdbRow(rowId as string, title as string) as boolean
     sectionName = title
     if not isValidAndNotEmpty(sectionName) or sectionName.startsWith("imdb_")
-        if rowId = "imdb_top_250_movies" then sectionName = tr("IMDb Top 250 Movies")
-        if rowId = "imdb_top_250_tv_shows" then sectionName = tr("IMDb Top 250 TV Shows")
-        if rowId = "imdb_most_popular_movies" then sectionName = tr("IMDb Most Popular Movies")
-        if rowId = "imdb_most_popular_tv_shows" then sectionName = tr("IMDb Most Popular TV Shows")
-        if rowId = "imdb_lowest_rated_movies" then sectionName = tr("IMDb Lowest Rated Movies")
-        if rowId = "imdb_top_english_movies" then sectionName = tr("IMDb Top Rated English Movies")
+        mappedName = imdbSectionName(rowId)
+        if isValidAndNotEmpty(mappedName) then sectionName = mappedName
     end if
 
     if not sectionExists(sectionName)
@@ -2498,13 +2505,9 @@ sub updateImdbRowItems(event as object)
     rowId = task.itemsToLoad
     itemData = getTaskContentAndCleanup(rowId)
 
-    sectionName = ""
-    if rowId = "imdb_top_250_movies" then sectionName = tr("IMDb Top 250 Movies")
-    if rowId = "imdb_top_250_tv_shows" then sectionName = tr("IMDb Top 250 TV Shows")
-    if rowId = "imdb_most_popular_movies" then sectionName = tr("IMDb Most Popular Movies")
-    if rowId = "imdb_most_popular_tv_shows" then sectionName = tr("IMDb Most Popular TV Shows")
-    if rowId = "imdb_lowest_rated_movies" then sectionName = tr("IMDb Lowest Rated Movies")
-    if rowId = "imdb_top_english_movies" then sectionName = tr("IMDb Top Rated English Movies")
+    ' The row only exists here because the server sent it, so per-list enable
+    ' gating already happened server-side. No client-side gating needed.
+    sectionName = imdbSectionName(rowId)
 
     if not isValidAndNotEmpty(itemData)
         removeHomeSection(sectionName)

--- a/components/home/HomeRows.bs
+++ b/components/home/HomeRows.bs
@@ -717,6 +717,11 @@ function addServerHomeRow(row as object) as boolean
 
     sectionType = mapBuiltinSectionFromServerRow(row)
     if not isValidAndNotEmpty(sectionType) or sectionType = "none"
+        rowId = chainLookupReturn(row, "id", "")
+        if isValidAndNotEmpty(rowId) and rowId.startsWith("imdb_")
+            return createImdbRow(rowId, chainLookupReturn(row, "title", rowId))
+        end if
+
         m.processedRowCount++
         return false
     end if
@@ -2460,3 +2465,70 @@ function getNestedValue(obj as object, path as string) as dynamic
 
     return current
 end function
+
+function createImdbRow(rowId as string, title as string) as boolean
+    sectionName = title
+    if not isValidAndNotEmpty(sectionName) or sectionName.startsWith("imdb_")
+        if rowId = "imdb_top_250_movies" then sectionName = tr("IMDb Top 250 Movies")
+        if rowId = "imdb_top_250_tv_shows" then sectionName = tr("IMDb Top 250 TV Shows")
+        if rowId = "imdb_most_popular_movies" then sectionName = tr("IMDb Most Popular Movies")
+        if rowId = "imdb_most_popular_tv_shows" then sectionName = tr("IMDb Most Popular TV Shows")
+        if rowId = "imdb_lowest_rated_movies" then sectionName = tr("IMDb Lowest Rated Movies")
+        if rowId = "imdb_top_english_movies" then sectionName = tr("IMDb Top Rated English Movies")
+    end if
+
+    if not sectionExists(sectionName)
+        imdbRow = m.top.content.CreateChild("HomeRow")
+        imdbRow.title = sectionName
+        imdbRow.imageWidth = getPosterSize(false)[0]
+        imdbRow.cursorSize = getPosterSize(false)
+        imdbRow.usePoster = true
+    end if
+
+    task = getOrCreateTask(rowId)
+    task.observeField("content", "updateImdbRowItems")
+    task.control = "RUN"
+    return true
+end function
+
+sub updateImdbRowItems(event as object)
+    m.processedRowCount++
+
+    task = event.getRoSGNode()
+    rowId = task.itemsToLoad
+    itemData = getTaskContentAndCleanup(rowId)
+
+    sectionName = ""
+    if rowId = "imdb_top_250_movies" then sectionName = tr("IMDb Top 250 Movies")
+    if rowId = "imdb_top_250_tv_shows" then sectionName = tr("IMDb Top 250 TV Shows")
+    if rowId = "imdb_most_popular_movies" then sectionName = tr("IMDb Most Popular Movies")
+    if rowId = "imdb_most_popular_tv_shows" then sectionName = tr("IMDb Most Popular TV Shows")
+    if rowId = "imdb_lowest_rated_movies" then sectionName = tr("IMDb Lowest Rated Movies")
+    if rowId = "imdb_top_english_movies" then sectionName = tr("IMDb Top Rated English Movies")
+
+    if not isValidAndNotEmpty(itemData)
+        removeHomeSection(sectionName)
+        return
+    end if
+
+    row = CreateObject("roSGNode", "HomeRow")
+    row.title = sectionName
+    row.imageWidth = getPosterSize(false)[0]
+    row.cursorSize = getPosterSize(false)
+    row.usePoster = true
+
+    for each item in itemData
+        item.usePoster = row.usePoster
+        item.imageWidth = row.imageWidth
+        row.appendChild(item)
+    end for
+
+    if sectionExists(sectionName)
+        m.top.content.replaceChild(row, getSectionIndex(sectionName))
+        setRowItemSize()
+        return
+    end if
+
+    m.top.content.appendChild(row)
+    setRowItemSize()
+end sub

--- a/components/home/LoadItemsTask.bs
+++ b/components/home/LoadItemsTask.bs
@@ -1314,43 +1314,42 @@ end sub
 function loadImdbList(listName as string) as object
     results = []
 
-    data = APIRequest(`/Moonfin/CustomRow/imdb/${listName}`)
+    ' The server rejects the request with 400 unless params is a non-empty
+    ' JSON string, so send a minimal payload echoing the source and chart type.
+    requestParams = FormatJson({ source: "imdb", type: listName })
 
-    if not isValid(data) or not isValid(data.Items) then return results
+    data = getJson(APIRequest("/Moonfin/CustomRows/Items", {
+        source: "imdb",
+        type: listName,
+        params: requestParams
+    }))
 
-    for each item in data.Items
+    ' External list responses report success plus a lowercase items array.
+    if not isValid(data) or chainLookupReturn(data, "success", false) <> true then return results
+    if not isChainValid(data, "items") then return results
+
+    for each item in data.LookupCI("items")
+        if not isValid(item) then continue for
+
+        ' These are external IMDb entries with no matching Jellyfin item, so we
+        ' set the display fields directly and skip the json/setData image
+        ' pipeline. posterUrl/backdropUrl are absolute external URLs, used as-is.
         tmp = createSGNode("HomeData")
+        ' These sit in a poster row, so show the poster art first.
+        tmp.usePoster = true
 
-        params = {
-            Tags: item.PrimaryImageTag,
-            MaxWidth: 234,
-            MaxHeight: 330
-        }
-        tmp.posterURL = ImageUrl(item.Id, "Primary", params)
-        tmp.json = {
-            Id: item.LookupCI("Id"),
-            name: item.LookupCI("name"),
-            Type: item.LookupCI("Type"),
-            SeriesName: item.LookupCI("SeriesName"),
-            SeriesId: item.LookupCI("SeriesId"),
-            SeasonId: item.LookupCI("SeasonId"),
-            ProductionYear: item.LookupCI("ProductionYear"),
-            Status: item.LookupCI("Status"),
-            EndDate: item.LookupCI("EndDate"),
-            ParentIndexNumber: item.LookupCI("ParentIndexNumber"),
-            IndexNumberEnd: item.LookupCI("IndexNumberEnd"),
-            IndexNumber: item.LookupCI("IndexNumber"),
-            OfficialRating: item.LookupCI("OfficialRating"),
-            CollectionType: item.LookupCI("CollectionType"),
-            ImageTags: item.LookupCI("ImageTags"),
-            UserData: item.LookupCI("UserData"),
-            ParentThumbItemId: item.LookupCI("ParentThumbItemId"),
-            ParentThumbImageTag: item.LookupCI("ParentThumbImageTag"),
-            ParentBackdropImageTags: item.LookupCI("ParentBackdropImageTags"),
-            ParentBackdropItemId: item.LookupCI("ParentBackdropItemId"),
-            SeriesPrimaryImageTag: item.LookupCI("SeriesPrimaryImageTag"),
-            BackdropImageTags: item.LookupCI("BackdropImageTags")
-        }
+        name = item.LookupCI("name")
+        if isValidAndNotEmpty(name) then tmp.name = name
+
+        itemType = item.LookupCI("type")
+        if isValidAndNotEmpty(itemType) then tmp.type = itemType
+
+        posterUrl = item.LookupCI("posterUrl")
+        if isValidAndNotEmpty(posterUrl) then tmp.posterURL = posterUrl
+
+        backdropUrl = item.LookupCI("backdropUrl")
+        if isValidAndNotEmpty(backdropUrl) then tmp.backdropURL = backdropUrl
+
         results.push(tmp)
     end for
 

--- a/components/home/LoadItemsTask.bs
+++ b/components/home/LoadItemsTask.bs
@@ -1161,6 +1161,11 @@ sub loadItems()
         return
     end if
 
+    if m.top.itemsToLoad.startsWith("imdb_")
+        m.top.content = loadImdbList(m.top.itemsToLoad)
+        return
+    end if
+
     if isStringEqual(m.top.itemsToLoad, "libraries")
         m.top.content = loadLibraries()
         return
@@ -1305,3 +1310,49 @@ sub loadItems()
 
     m.top.content = []
 end sub
+
+function loadImdbList(listName as string) as object
+    results = []
+
+    data = APIRequest(`/Moonfin/CustomRow/imdb/${listName}`)
+
+    if not isValid(data) or not isValid(data.Items) then return results
+
+    for each item in data.Items
+        tmp = createSGNode("HomeData")
+
+        params = {
+            Tags: item.PrimaryImageTag,
+            MaxWidth: 234,
+            MaxHeight: 330
+        }
+        tmp.posterURL = ImageUrl(item.Id, "Primary", params)
+        tmp.json = {
+            Id: item.LookupCI("Id"),
+            name: item.LookupCI("name"),
+            Type: item.LookupCI("Type"),
+            SeriesName: item.LookupCI("SeriesName"),
+            SeriesId: item.LookupCI("SeriesId"),
+            SeasonId: item.LookupCI("SeasonId"),
+            ProductionYear: item.LookupCI("ProductionYear"),
+            Status: item.LookupCI("Status"),
+            EndDate: item.LookupCI("EndDate"),
+            ParentIndexNumber: item.LookupCI("ParentIndexNumber"),
+            IndexNumberEnd: item.LookupCI("IndexNumberEnd"),
+            IndexNumber: item.LookupCI("IndexNumber"),
+            OfficialRating: item.LookupCI("OfficialRating"),
+            CollectionType: item.LookupCI("CollectionType"),
+            ImageTags: item.LookupCI("ImageTags"),
+            UserData: item.LookupCI("UserData"),
+            ParentThumbItemId: item.LookupCI("ParentThumbItemId"),
+            ParentThumbImageTag: item.LookupCI("ParentThumbImageTag"),
+            ParentBackdropImageTags: item.LookupCI("ParentBackdropImageTags"),
+            ParentBackdropItemId: item.LookupCI("ParentBackdropItemId"),
+            SeriesPrimaryImageTag: item.LookupCI("SeriesPrimaryImageTag"),
+            BackdropImageTags: item.LookupCI("BackdropImageTags")
+        }
+        results.push(tmp)
+    end for
+
+    return results
+end function


### PR DESCRIPTION
# Pull Request

## Summary
Ported the IMDb list custom home row changes to the Roku client. This translates the working core client code to BrighterScript components, enabling display and reordering of IMDb rows.

*Note: This is a translation of working core code (linked below) but still requires testing on a physical Roku device.*

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #
- Related to # https://github.com/Moonfin-Client/Moonfin-Core/pull/763

## Type of Change
- [ ] Bug fix
- [X] New feature
- [ ] Refactor
- [ ] Performance improvement
- [X] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

- Intercepted dynamic row IDs starting with `imdb_` in `HomeRows.bs` to trigger row creation and caching.
- Implemented `createImdbRow` and observer `updateImdbRowItems` in `HomeRows.bs` to populate HomeRow content nodes.
- Added `loadImdbList` helper to `LoadItemsTask.bs` querying the custom `/Moonfin/CustomRow/imdb/{type}` endpoint.

## Testing
Describe how this change was tested.

- [ ] Tested on physical Roku device
- [ ] Tested via sideload
- [ ] Manual testing completed
- [X] Not tested (explain why): Verified successful compilation using the BrighterScript compiler (`npx bsc`) with 0 errors/warnings. Requires testing on physical Roku device.

### Test Steps
1. Build and deploy to Roku device.
2. Follow steps in core PR.

## Screenshots (if applicable)
Include screenshots or recordings for UI changes.

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
