### PR TITLE
change extras item played checkmark translation

### DIFF
--- a/components/extras/ExtrasItem.bs
+++ b/components/extras/ExtrasItem.bs
@@ -211,12 +211,8 @@ sub showContent()
                     if isValid(m.epDuration) then m.epDuration.visible = false
                 end if
 
-                ' Adjust played indicator position for wide images
-                if posterWidth >= 400
-                    m.playedIndicator.translation = [posterWidth - 60, 0]
-                else
-                    m.playedIndicator.translation = [174, 0]
-                end if
+                ' Adjust played indicator position
+                m.playedIndicator.translation = [posterWidth - 50, 10]
             else
                 ' Default to portrait poster size
                 m.posterImgRect.width = 234
@@ -231,7 +227,7 @@ sub showContent()
                 m.name.translation = [0, 382]
                 m.role.translation = [0, 422]
                 m.role.visible = true
-                m.playedIndicator.translation = [174, 0]
+                m.playedIndicator.translation = [130, 10]
 
                 if isValid(m.epNumber) then m.epNumber.visible = false
                 if isValid(m.epDuration) then m.epDuration.visible = false

--- a/components/extras/ExtrasItem.xml
+++ b/components/extras/ExtrasItem.xml
@@ -18,7 +18,7 @@
         visible="false"
         loadDisplayMode="scaleToZoom"
         translation="[0, 0]">
-        <PlayedCheckmark id="playedIndicator" translation="[174, 0]" />
+        <PlayedCheckmark id="playedIndicator" translation="[130, 10]" />
       </Poster>
 
       <!-- Rectangular focus border overlay -->


### PR DESCRIPTION
# Pull Request

## Summary
This PR fixes an issue where the played checkmark translation would not properly adjust on extras items on the details page. This issue was present before the modern details. This change fixes the played indicator for both styles.

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [X] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
- Use `posterWidth - 50` instead of [174, 0]
- Increase y translation to 10 to match home

## Testing
- [X] Tested on physical Roku device
- [X] Tested via sideload
- [X] Manual testing completed
- [ ] Not tested (explain why):

## Screenshots (if applicable)
Before
<img width="217" height="282" alt="screenshot-2026-07-14-13 38 08 974" src="https://github.com/user-attachments/assets/f5b2b9f1-7f0e-4e02-9008-92cc1784c8dc" />

After
<img width="197" height="279" alt="screenshot-2026-07-14-13 33 13 241" src="https://github.com/user-attachments/assets/4cb63c7f-ddff-426f-8f69-b972679a4b98" />


## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [ ] No new warnings introduced
