### PR TITLE
Reorganize visual settings to match core

### DIFF
--- a/components/settings/settings.bs
+++ b/components/settings/settings.bs
@@ -1481,6 +1481,7 @@ function reorderSettingsForFlutter(configTree as object) as object
     colors = findSettingsChildByTitle(userInterface, "Colors")
     general = findSettingsChildByTitle(userInterface, "General")
     libraries = findSettingsChildByTitle(userInterface, "Libraries")
+    detailsScreen = findSettingsChildByTitle(userInterface, "Details Screen")
 
     enablePlugin = findSettingsChildByTitle(pluginRootSection, "Enable Plugin")
     pluginSettingsSync = findSettingsChildByTitle(pluginRootSection, "Settings Sync")
@@ -1511,7 +1512,7 @@ function reorderSettingsForFlutter(configTree as object) as object
     personalizationChildren = []
     pushSettingIfValid(personalizationChildren, colors)
     pushSettingIfValid(personalizationChildren, general)
-    'MISSING FROM CORE: DETAILS SCREEN
+    pushSettingIfValid(personalizationChildren, detailsScreen)
     pushSettingIfValid(personalizationChildren, navigationBar)
     pushSettingIfValid(personalizationChildren, homeScreen)
     pushSettingIfValid(personalizationChildren, libraries)
@@ -1578,7 +1579,7 @@ function reorderSettingsForFlutter(configTree as object) as object
     pluginMappedTitles = ["Enable Plugin", "Settings Sync", "Metadata & Ratings", "Seerr"]
     pushUnmappedChildrenByTitle(additionalChildren, pluginRootSection, pluginMappedTitles)
 
-    userInterfaceMappedTitles = ["Colors", "General", "Libraries"]
+    userInterfaceMappedTitles = ["Colors", "General", "Libraries", "Details Screen"]
     pushUnmappedChildrenByTitle(additionalChildren, userInterface, userInterfaceMappedTitles)
 
     if additionalChildren.count() > 0

--- a/components/settings/settings.bs
+++ b/components/settings/settings.bs
@@ -1476,7 +1476,6 @@ function reorderSettingsForFlutter(configTree as object) as object
     featuredMediaBar = findSettingsChildByTitle(moonfinSettings, "Media Bar")
     themeMusic = findSettingsChildByTitle(moonfinSettings, "Theme Music")
     shuffle = findSettingsChildByTitle(moonfinSettings, "Shuffle")
-    visualEffects = findSettingsChildByTitle(moonfinSettings, "Visual Effects")
     supportMoonfin = findSettingsChildByTitle(moonfinSettings, "Support Moonfin")
 
     colors = findSettingsChildByTitle(userInterface, "Colors")
@@ -1517,7 +1516,6 @@ function reorderSettingsForFlutter(configTree as object) as object
     pushSettingIfValid(personalizationChildren, homeScreen)
     pushSettingIfValid(personalizationChildren, libraries)
     pushSettingIfValid(personalizationChildren, featuredMediaBar)
-    pushSettingIfValid(personalizationChildren, visualEffects)
     pushSettingIfValid(personalizationChildren, themeMusic)
     pushSettingIfValid(personalizationChildren, shuffle)
     if personalizationChildren.count() > 0
@@ -1574,7 +1572,7 @@ function reorderSettingsForFlutter(configTree as object) as object
 
     additionalChildren = []
 
-    moonfinMappedTitles = ["Navigation", "Home Screen", "Libraries", "Media Bar", "Theme Music", "Shuffle", "Visual Effects", "Support Moonfin"]
+    moonfinMappedTitles = ["Navigation", "Home Screen", "Libraries", "Media Bar", "Theme Music", "Shuffle", "Support Moonfin"]
     pushUnmappedChildrenByTitle(additionalChildren, moonfinSettings, moonfinMappedTitles)
 
     pluginMappedTitles = ["Enable Plugin", "Settings Sync", "Metadata & Ratings", "Seerr"]

--- a/settings/settings.json
+++ b/settings/settings.json
@@ -676,93 +676,105 @@
             ]
           },
           {
-            "title": "Since You Watched Rows",
-            "description": "How many Since You Watched rows to show when the section is enabled.",
-            "settingName": "ui.home.sinceYouWatchedNumRows",
-            "type": "radio",
-            "default": "1",
-            "options": [
-              { "title": "1", "id": "1" },
-              { "title": "2", "id": "2" },
-              { "title": "3", "id": "3" },
-              { "title": "4", "id": "4" },
-              { "title": "5", "id": "5" }
+            "title": "Since You Watched Rows Settings",
+            "description": "Settings for \"since you watched\" rows",
+            "children": [
+              {
+                "title": "Since You Watched Rows",
+                "description": "How many Since You Watched rows to show when the section is enabled.",
+                "settingName": "ui.home.sinceYouWatchedNumRows",
+                "type": "radio",
+                "default": "1",
+                "options": [
+                  { "title": "1", "id": "1" },
+                  { "title": "2", "id": "2" },
+                  { "title": "3", "id": "3" },
+                  { "title": "4", "id": "4" },
+                  { "title": "5", "id": "5" }
+                ]
+              },
+              {
+                "title": "Since You Watched Source",
+                "description": "Use local library recommendations or online recommendations through Seerr.",
+                "settingName": "ui.home.sinceYouWatchedSource",
+                "type": "radio",
+                "default": "local",
+                "options": [
+                  { "title": "Local", "id": "local" },
+                  { "title": "Online", "id": "online" }
+                ]
+              },
+              {
+                "title": "Since You Watched Seed",
+                "description": "Which watched items seed the Since You Watched rows.",
+                "settingName": "ui.home.sinceYouWatchedSourceItem",
+                "type": "radio",
+                "default": "recentlyWatched",
+                "options": [
+                  { "title": "Recently Watched", "id": "recentlyWatched" },
+                  { "title": "Favorites", "id": "favorites" },
+                  { "title": "Random", "id": "random" }
+                ]
+              },
+              {
+                "title": "Since You Watched Content",
+                "description": "Which content types the Since You Watched rows use.",
+                "settingName": "ui.home.sinceYouWatchedSourceType",
+                "type": "radio",
+                "default": "movies",
+                "options": [
+                  { "title": "Movies", "id": "movies" },
+                  { "title": "TV Shows", "id": "shows" },
+                  { "title": "Movies & TV Shows", "id": "both" }
+                ]
+              },
+              {
+                "title": "Include Watched Titles",
+                "description": "Show titles you have already played in Since You Watched rows.",
+                "settingName": "ui.home.sinceYouWatchedIncludeWatched",
+                "type": "bool",
+                "default": "false"
+              }
             ]
           },
           {
-            "title": "Since You Watched Source",
-            "description": "Use local library recommendations or online recommendations through Seerr.",
-            "settingName": "ui.home.sinceYouWatchedSource",
-            "type": "radio",
-            "default": "local",
-            "options": [
-              { "title": "Local", "id": "local" },
-              { "title": "Online", "id": "online" }
+            "title": "Rewatch Row Settings",
+            "description": "Settings for \"rewatch\" row",
+            "children": [
+              {
+                "title": "Rewatch Movies",
+                "description": "Include finished movies in the Rewatch row.",
+                "settingName": "ui.home.rewatchIncludeMovies",
+                "type": "bool",
+                "default": "true"
+              },
+              {
+                "title": "Rewatch TV Shows",
+                "description": "Include finished shows in the Rewatch row.",
+                "settingName": "ui.home.rewatchIncludeShows",
+                "type": "bool",
+                "default": "true"
+              },
+              {
+                "title": "Rewatch Collections",
+                "description": "Include finished collections in the Rewatch row.",
+                "settingName": "ui.home.rewatchIncludeCollections",
+                "type": "bool",
+                "default": "true"
+              },
+              {
+                "title": "Rewatch Sorting",
+                "description": "Order the Rewatch row by most recently watched or at random.",
+                "settingName": "ui.home.rewatchSortBy",
+                "type": "radio",
+                "default": "recentlyWatched",
+                "options": [
+                  { "title": "Recently Watched", "id": "recentlyWatched" },
+                  { "title": "Random", "id": "random" }
+                ]
+              }
             ]
           },
-          {
-            "title": "Since You Watched Seed",
-            "description": "Which watched items seed the Since You Watched rows.",
-            "settingName": "ui.home.sinceYouWatchedSourceItem",
-            "type": "radio",
-            "default": "recentlyWatched",
-            "options": [
-              { "title": "Recently Watched", "id": "recentlyWatched" },
-              { "title": "Favorites", "id": "favorites" },
-              { "title": "Random", "id": "random" }
-            ]
-          },
-          {
-            "title": "Since You Watched Content",
-            "description": "Which content types the Since You Watched rows use.",
-            "settingName": "ui.home.sinceYouWatchedSourceType",
-            "type": "radio",
-            "default": "movies",
-            "options": [
-              { "title": "Movies", "id": "movies" },
-              { "title": "TV Shows", "id": "shows" },
-              { "title": "Movies & TV Shows", "id": "both" }
-            ]
-          },
-          {
-            "title": "Include Watched Titles",
-            "description": "Show titles you have already played in Since You Watched rows.",
-            "settingName": "ui.home.sinceYouWatchedIncludeWatched",
-            "type": "bool",
-            "default": "false"
-          },
-          {
-            "title": "Rewatch Movies",
-            "description": "Include finished movies in the Rewatch row.",
-            "settingName": "ui.home.rewatchIncludeMovies",
-            "type": "bool",
-            "default": "true"
-          },
-          {
-            "title": "Rewatch TV Shows",
-            "description": "Include finished shows in the Rewatch row.",
-            "settingName": "ui.home.rewatchIncludeShows",
-            "type": "bool",
-            "default": "true"
-          },
-          {
-            "title": "Rewatch Collections",
-            "description": "Include finished collections in the Rewatch row.",
-            "settingName": "ui.home.rewatchIncludeCollections",
-            "type": "bool",
-            "default": "true"
-          },
-          {
-            "title": "Rewatch Sorting",
-            "description": "Order the Rewatch row by most recently watched or at random.",
-            "settingName": "ui.home.rewatchSortBy",
-            "type": "radio",
-            "default": "recentlyWatched",
-            "options": [
-              { "title": "Recently Watched", "id": "recentlyWatched" },
-              { "title": "Random", "id": "random" }
-            ]
-          }
         ]
       },
       {

--- a/settings/settings.json
+++ b/settings/settings.json
@@ -1068,95 +1068,6 @@
         ]
       },
       {
-        "title": "Visual Effects",
-        "description": "Backdrop and visual customization.",
-        "icon": "effects.png",
-        "children": [
-          {
-            "title": "Detail Screen Backdrop Blur",
-            "description": "Control the blur effect for movie, TV show, and episode detail screens. Higher values create a more frosted glass effect.",
-            "settingName": "ui.backdrop.detailBlurAmount",
-            "type": "radio",
-            "default": "10",
-            "options": [
-              {
-                "title": "No Blur",
-                "id": "0"
-              },
-              {
-                "title": "Light (5)",
-                "id": "5"
-              },
-              {
-                "title": "Medium (10)",
-                "id": "10"
-              },
-              {
-                "title": "Heavy (15)",
-                "id": "15"
-              },
-              {
-                "title": "Very Heavy (20)",
-                "id": "20"
-              }
-            ]
-          },
-          {
-            "title": "Home & Seerr Backdrop Blur",
-            "description": "Control the blur effect for home screen and discovery (genres/favorites) screens. Lower values improve visibility and performance.",
-            "settingName": "ui.backdrop.homeBlurAmount",
-            "type": "radio",
-            "default": "10",
-            "options": [
-              {
-                "title": "No Blur",
-                "id": "0"
-              },
-              {
-                "title": "Light (5)",
-                "id": "5"
-              },
-              {
-                "title": "Medium (10)",
-                "id": "10"
-              },
-              {
-                "title": "Heavy (15)",
-                "id": "15"
-              },
-              {
-                "title": "Very Heavy (20)",
-                "id": "20"
-              }
-            ]
-          },
-          {
-            "title": "Detail Screen Style",
-            "description": "Choose between the classic detail layout and a modern cinematic layout with tabs.",
-            "settingName": "ui.itemdetail.style",
-            "type": "radio",
-            "default": "modern",
-            "options": [
-              {
-                "title": "Modern",
-                "id": "modern"
-              },
-              {
-                "title": "Classic",
-                "id": "classic"
-              }
-            ]
-          },
-          {
-            "title": "Expanded Tabs",
-            "description": "Keep the modern detail tabs open and follow focus. Turn off to open a tab only when you select it.",
-            "settingName": "ui.itemdetail.expandedTabs",
-            "type": "bool",
-            "default": "true"
-          }
-        ]
-      },
-      {
         "title": "Support Moonfin",
         "description": "Help support continued development of Moonfin. Press OK to learn more or visit https://buymeacoffee.com/moonfin.",
         "settingName": "moonfin.showDonation",
@@ -1864,6 +1775,88 @@
             "settingName": "useFallbackFont",
             "type": "bool",
             "default": "false"
+          },
+          {
+            "title": "Browsing Backdrop Blur",
+            "description": "Control the blur effect for home screen. Lower values improve visibility and performance.",
+            "settingName": "ui.backdrop.homeBlurAmount",
+            "type": "radio",
+            "default": "10",
+            "options": [
+              {
+                "title": "No Blur",
+                "id": "0"
+              },
+              {
+                "title": "Light (5)",
+                "id": "5"
+              },
+              {
+                "title": "Medium (10)",
+                "id": "10"
+              },
+              {
+                "title": "Heavy (15)",
+                "id": "15"
+              },
+              {
+                "title": "Very Heavy (20)",
+                "id": "20"
+              }
+            ]
+          },
+          {
+            "title": "Detail Screen Style",
+            "description": "Choose between the classic detail layout and a modern cinematic layout with tabs.",
+            "settingName": "ui.itemdetail.style",
+            "type": "radio",
+            "default": "modern",
+            "options": [
+              {
+                "title": "Modern",
+                "id": "modern"
+              },
+              {
+                "title": "Classic",
+                "id": "classic"
+              }
+            ]
+          },
+          {
+            "title": "Classic Detail Screen Backdrop Blur",
+            "description": "Control the blur effect for movie, TV show, and episode detail screens. Higher values create a more frosted glass effect.",
+            "settingName": "ui.backdrop.detailBlurAmount",
+            "type": "radio",
+            "default": "10",
+            "options": [
+              {
+                "title": "No Blur",
+                "id": "0"
+              },
+              {
+                "title": "Light (5)",
+                "id": "5"
+              },
+              {
+                "title": "Medium (10)",
+                "id": "10"
+              },
+              {
+                "title": "Heavy (15)",
+                "id": "15"
+              },
+              {
+                "title": "Very Heavy (20)",
+                "id": "20"
+              }
+            ]
+          },
+          {
+            "title": "Modern Detail Screen Expanded Tabs",
+            "description": "Keep the modern detail tabs open and follow focus. Turn off to open a tab only when you select it.",
+            "settingName": "ui.itemdetail.expandedTabs",
+            "type": "bool",
+            "default": "true"
           }
         ]
       },

--- a/settings/settings.json
+++ b/settings/settings.json
@@ -1804,7 +1804,14 @@
                 "id": "20"
               }
             ]
-          },
+          }
+        ]
+      },
+      {
+        "title": "Details Screen",
+        "description": "Style, background blur, and tab behavior",
+        "icon": "dynamiccontent.png",
+        "children": [
           {
             "title": "Detail Screen Style",
             "description": "Choose between the classic detail layout and a modern cinematic layout with tabs.",

--- a/settings/settings.json
+++ b/settings/settings.json
@@ -677,7 +677,7 @@
           },
           {
             "title": "Since You Watched Rows Settings",
-            "description": "Settings for \"since you watched\" rows",
+            "description": "Customize the Since You Watched rows.",
             "children": [
               {
                 "title": "Since You Watched Rows",
@@ -739,7 +739,7 @@
           },
           {
             "title": "Rewatch Row Settings",
-            "description": "Settings for \"rewatch\" row",
+            "description": "Customize the Rewatch row.",
             "children": [
               {
                 "title": "Rewatch Movies",
@@ -774,7 +774,7 @@
                 ]
               }
             ]
-          },
+          }
         ]
       },
       {
@@ -1790,7 +1790,7 @@
           },
           {
             "title": "Browsing Backdrop Blur",
-            "description": "Control the blur effect for home screen. Lower values improve visibility and performance.",
+            "description": "Control the blur effect for the home and favorites screens. Lower values improve visibility and performance.",
             "settingName": "ui.backdrop.homeBlurAmount",
             "type": "radio",
             "default": "10",
@@ -1821,8 +1821,8 @@
       },
       {
         "title": "Details Screen",
-        "description": "Style, background blur, and tab behavior",
-        "icon": "dynamiccontent.png",
+        "description": "Style, background blur, and tab behavior.",
+        "icon": "effects.png",
         "children": [
           {
             "title": "Detail Screen Style",


### PR DESCRIPTION
# Pull Request

## Summary
The "visual settings" in roku did not match core at all I realized, so renamed/reorganized a bit to match

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #
- Related to #

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [X] Refactor
- [ ] Performance improvement
- [X] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

- renamed "home & seerr blur" to "browsing blur" and removed references to seerr since it doesn't actually apply on that screen (same as core), moved it to "general"
- created missing detail screen section of personalization settings
- 

## Testing
Describe how this change was tested.

- [X] Tested on physical Roku device
- [ ] Tested via sideload
- [ ] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1.
2.
3.

## Screenshots (if applicable)
<img width="3000" height="4000" alt="20260716_231901" src="https://github.com/user-attachments/assets/6c0a48d7-c471-4175-a224-5dd24e72af41" />
<img width="3000" height="4000" alt="20260716_231910" src="https://github.com/user-attachments/assets/710f40c8-5053-40f4-bff3-51b45d5f030b" />
<img width="3000" height="4000" alt="20260716_231906" src="https://github.com/user-attachments/assets/20934883-9016-479e-85e6-31c04bfcc703" />



## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
