### PR TITLE
Fix nextUpTimeout unit mismatch (seconds vs milliseconds)

### DIFF
--- a/source/utils/settingsSync.bs
+++ b/source/utils/settingsSync.bs
@@ -50,8 +50,8 @@ namespace settingsSync
             { pluginKey: "cinemaModeEnabled", rokuKey: "playback.cinemamode", type: "bool" },
             { pluginKey: "autoplayNextEpisode", rokuKey: "playback.showNextUpAfterFinish", type: "bool" },
             { pluginKey: "seerrBlockNsfw", rokuKey: "seerr.blockNsfw", type: "bool" },
-            ' The server counts this in milliseconds, this setting is named for seconds.
-            { pluginKey: "nextUpTimeout", rokuKey: "playback.nextupbuttonseconds", type: "msToSeconds" },
+            ' Roku registry stores seconds as an integer, matching the server's representation.
+            { pluginKey: "nextUpTimeout", rokuKey: "playback.nextupbuttonseconds", type: "intToStr" },
             { pluginKey: "seerrEnabled", rokuKey: "seerr.enabled", type: "bool" },
             { pluginKey: "hiddenContinueWatchingItems", rokuKey: "ui.home.hiddenContinueWatchingItems", type: "direct" },
             { pluginKey: "hiddenNextUpSeries", rokuKey: "ui.home.hiddenNextUpSeries", type: "direct" },
@@ -204,10 +204,7 @@ namespace settingsSync
             if rounded = 0 then return "0.1"
             if rounded >= 1 then return "1.0"
             return rounded.toStr()
-        else if conversionType = "msToSeconds"
-            ms = pluginValue
-            if Type(ms) = "roString" or Type(ms) = "String" then ms = val(ms.toStr())
-            return int(ms / 1000).toStr()
+
         else if conversionType = "colorHex"
             colorStr = pluginValue.toStr()
             if colorStr.left(1) = "#"
@@ -249,8 +246,7 @@ namespace settingsSync
         else if conversionType = "opacityToPercent"
             rokuFloat = val(rokuStr)
             return int(rokuFloat * 100 + 0.5)
-        else if conversionType = "msToSeconds"
-            return int(val(rokuStr) * 1000)
+
         else if conversionType = "colorHex"
             ' Roku writes colours as 0xRRGGBB, the server and the other clients read
             ' #RRGGBB. Without turning it back the pushed value reaches them unusable.


### PR DESCRIPTION
The server and other clients (Core and Smart-TV) all represent nextUpTimeout in seconds. Roku client's settingsSync.bs was mapping it with type 'msToSeconds', which divided by 1000 on pull and multiplied by 1000 on push. This would cause the value to blow up by 1000x on sync and potentialy corrupt settings profiles. Changed type to 'intToStr' to match the unit.