### PR TITLE
feat-homerows - Port custom Seerr, IMDb, TMDb, and Upcoming Calendar rows to Roku

### DIFF
--- a/components/home/HomeRows.bs
+++ b/components/home/HomeRows.bs
@@ -737,13 +737,15 @@ end function
 
 
 function addServerHomeRow(row as object) as boolean
-
-
     sectionType = mapBuiltinSectionFromServerRow(row)
     if not isValidAndNotEmpty(sectionType) or sectionType = "none"
         rowId = chainLookupReturn(row, "id", "")
-        if isValidAndNotEmpty(rowId) and rowId.startsWith("imdb_")
-            return createImdbRow(rowId, chainLookupReturn(row, "title", rowId))
+        rowSource = chainLookupReturn(row, "source", "")
+
+        isCustomRow = (isValidAndNotEmpty(rowId) and (rowId.startsWith("imdb_") or rowId.startsWith("tmdb_") or rowId.startsWith("seerr_") or rowId.startsWith("pluginDynamic:"))) or (rowSource = "custom" or rowSource = "seerr" or rowSource = "tmdb" or rowSource = "letterboxd" or rowSource = "mdblist")
+
+        if isCustomRow
+            return createCustomDynamicRow(row)
         end if
 
         m.processedRowCount++
@@ -2749,6 +2751,88 @@ sub updateImdbRowItems(event as object)
     ' The row only exists here because the server sent it, so per-list enable
     ' gating already happened server-side. No client-side gating needed.
     sectionName = imdbSectionName(rowId)
+
+    if not isValidAndNotEmpty(itemData)
+        removeHomeSection(sectionName)
+        return
+    end if
+
+    row = CreateObject("roSGNode", "HomeRow")
+    row.title = sectionName
+    row.imageWidth = getPosterSize(false)[0]
+    row.cursorSize = getPosterSize(false)
+    row.usePoster = true
+
+    for each item in itemData
+        item.usePoster = row.usePoster
+        item.imageWidth = row.imageWidth
+        row.appendChild(item)
+    end for
+
+    if sectionExists(sectionName)
+        m.top.content.replaceChild(row, getSectionIndex(sectionName))
+        setRowItemSize()
+        return
+    end if
+
+    m.top.content.appendChild(row)
+    setRowItemSize()
+end sub
+
+function createCustomDynamicRow(row as object) as boolean
+    rowId = chainLookupReturn(row, "id", "")
+    sectionName = chainLookupReturn(row, "title", rowId)
+
+    if not isValidAndNotEmpty(sectionName) or sectionName.startsWith("imdb_")
+        mappedName = imdbSectionName(rowId)
+        if isValidAndNotEmpty(mappedName) then sectionName = mappedName
+    end if
+
+    if not sectionExists(sectionName)
+        customRow = m.top.content.CreateChild("HomeRow")
+        customRow.title = sectionName
+        customRow.imageWidth = getPosterSize(false)[0]
+        customRow.cursorSize = getPosterSize(false)
+        customRow.usePoster = true
+    end if
+
+    task = getOrCreateTask(rowId)
+    
+    additionalDataVal = row.additionalData
+    if type(additionalDataVal) = "String" or type(additionalDataVal) = "roString"
+        additionalDataVal = ParseJson(additionalDataVal)
+    end if
+    if isValid(additionalDataVal) and type(additionalDataVal) = "roAssociativeArray"
+        task.additionalData = additionalDataVal
+    end if
+
+    task.observeField("content", "updateCustomDynamicRowItems")
+    task.control = "RUN"
+    return true
+end function
+
+sub updateCustomDynamicRowItems(event as object)
+    m.processedRowCount++
+
+    task = event.getRoSGNode()
+    rowId = task.itemsToLoad
+    itemData = getTaskContentAndCleanup(rowId)
+
+    sectionName = ""
+    for each r in m.serverHomeRows
+        if r.id = rowId
+            sectionName = r.title
+            exit for
+        end if
+    end for
+
+    if not isValidAndNotEmpty(sectionName)
+        if rowId.startsWith("imdb_")
+            sectionName = imdbSectionName(rowId)
+        else
+            sectionName = rowId
+        end if
+    end if
 
     if not isValidAndNotEmpty(itemData)
         removeHomeSection(sectionName)

--- a/components/home/HomeRows.bs
+++ b/components/home/HomeRows.bs
@@ -904,6 +904,124 @@ function getOriginalSectionIndex(sectionName as string) as integer
     return sectionIndex
 end function
 
+' addOrUpdateHomeRow: Sets the row ID, inserts or replaces it in the home view, and sorts the home rows
+'
+' @param {object} row - The HomeRow node we're adding or updating
+' @param {string} sectionName - The localized title of the row
+' @param {string} originalSectionKey - The setting key associated with the section
+sub addOrUpdateHomeRow(row as object, sectionName as string, originalSectionKey as string)
+    row.id = originalSectionKey
+    if sectionExists(sectionName)
+        m.top.content.replaceChild(row, getSectionIndex(sectionName))
+    else
+        m.top.content.insertChild(row, getOriginalSectionIndex(originalSectionKey))
+    end if
+    sortHomeRows()
+    setRowItemSize()
+end sub
+
+' sortHomeRows: Sorts all home rows based on their settings-configured order
+'
+sub sortHomeRows()
+    if not isValid(m.top.content) then return
+
+    children = m.top.content.getChildren(-1, 0)
+    numChildren = children.count()
+    if numChildren <= 1 then return
+
+    ' Stable insertion sort based on settings index
+    for i = 1 to numChildren - 1
+        keyNode = children[i]
+        keyIndex = getOriginalSettingIndexForNode(keyNode)
+        j = i - 1
+        while j >= 0
+            compareNode = children[j]
+            compareIndex = getOriginalSettingIndexForNode(compareNode)
+            if compareIndex > keyIndex
+                children[j + 1] = children[j]
+                j = j - 1
+            else
+                exit while
+            end if
+        end while
+        children[j + 1] = keyNode
+    end for
+
+    m.top.content.removeChildren(children)
+    m.top.content.appendChildren(children)
+end sub
+
+' getOriginalSettingIndexForNode: Helper function to get the user configuration index of a row
+'
+' @param {object} node - The HomeRow node we're checking
+' @return {integer} index of the row setting (0 to 7) or 99 if not found
+function getOriginalSettingIndexForNode(node as object) as integer
+    if node = invalid then return 99
+
+    nodeId = LCase(node.id).Replace(" ", "")
+    nodeTitle = LCase(node.title).Replace(" ", "")
+
+    for i = 0 to 7
+        settingSectionName = getResolvedSectionName(i)
+
+        ' Direct ID matches
+        if settingSectionName = nodeId
+            return i
+        end if
+
+        ' Localized title matches for standard sections
+        if settingSectionName = "collections" and (nodeId = "collections" or nodeTitle = LCase(tr("Collections")).Replace(" ", ""))
+            return i
+        end if
+        if settingSectionName = "genres" and (nodeId = "genres" or nodeTitle = LCase(tr("Genres")).Replace(" ", ""))
+            return i
+        end if
+        if settingSectionName = "playlists" and (nodeId = "playlists" or nodeTitle = LCase(tr("Playlists")).Replace(" ", ""))
+            return i
+        end if
+        if settingSectionName = "audio" and (nodeId = "audio" or nodeTitle = LCase(tr("Audio")).Replace(" ", ""))
+            return i
+        end if
+        if settingSectionName = "favorites" and (nodeId = "favorites" or nodeTitle = LCase(tr("Favorites")).Replace(" ", ""))
+            return i
+        end if
+        if settingSectionName = "mylist" and (nodeId = "mylist" or nodeTitle = LCase(tr("My List")).Replace(" ", ""))
+            return i
+        end if
+        if settingSectionName = "nextup" and (nodeId = "nextup" or nodeTitle = LCase(tr("Next Up")).Replace(" ", ""))
+            return i
+        end if
+        if settingSectionName = "resume" and (nodeId = "resume" or nodeTitle = LCase(tr("Continue Watching")).Replace(" ", ""))
+            return i
+        end if
+        if settingSectionName = "resumeaudio" and (nodeId = "resumeaudio" or nodeTitle = LCase(tr("Continue Listening")).Replace(" ", ""))
+            return i
+        end if
+        if settingSectionName = "livetv" and (nodeId = "livetv" or nodeTitle = LCase(tr("On Now")).Replace(" ", ""))
+            return i
+        end if
+        if settingSectionName = "smalllibrarytiles" and (nodeId = "smalllibrarytiles" or nodeTitle = LCase(tr("My Media")).Replace(" ", ""))
+            return i
+        end if
+
+        ' Prefix checks for dynamic library rows
+        if settingSectionName = "latestmedia"
+            prefix = LCase(tr("Recently Added in")).Replace(" ", "")
+            if nodeId = "latestmedia" or Left(nodeTitle, prefix.Len()) = prefix
+                return i
+            end if
+        end if
+        if settingSectionName = "recentlyreleased"
+            prefix = LCase(tr("Recently Released in")).Replace(" ", "")
+            if nodeId = "recentlyreleased" or Left(nodeTitle, prefix.Len()) = prefix
+                return i
+            end if
+        end if
+    end for
+
+    return 99
+end function
+
 ' removeHomeSection: Removes a home section from the home rows
 '
 ' @param {string} sectionToRemove - Title property of section we're removing
@@ -1157,16 +1275,7 @@ sub createLibraryRow()
         row.appendChild(item)
     end for
 
-    ' Row already exists, replace it with new content
-    if sectionExists(sectionName)
-        m.top.content.replaceChild(row, getSectionIndex(sectionName))
-        setRowItemSize()
-        return
-    end if
-
-    ' Row does not exist, insert it into the home view
-    m.top.content.insertChild(row, getOriginalSectionIndex("smalllibrarytiles"))
-    setRowItemSize()
+    addOrUpdateHomeRow(row, sectionName, "smalllibrarytiles")
 end sub
 
 ' createLatestInRows: Creates a row displaying latest items in each of the user's libraries
@@ -2174,14 +2283,7 @@ sub updateFavoritesItems()
         row.appendChild(item)
     end for
 
-    if sectionExists(sectionName)
-        m.top.content.replaceChild(row, getSectionIndex(sectionName))
-        setRowItemSize()
-        return
-    end if
-
-    m.top.content.insertChild(row, getOriginalSectionIndex("favorites"))
-    setRowItemSize()
+    addOrUpdateHomeRow(row, sectionName, "favorites")
 end sub
 
 ' updateMyListItems: Processes LoadMyListTask content. Removes, Creates, or Updates My List row as needed
@@ -2215,14 +2317,7 @@ sub updateMyListItems()
         row.appendChild(item)
     end for
 
-    if sectionExists(sectionName)
-        m.top.content.replaceChild(row, getSectionIndex(sectionName))
-        setRowItemSize()
-        return
-    end if
-
-    m.top.content.insertChild(row, getOriginalSectionIndex("mylist"))
-    setRowItemSize()
+    addOrUpdateHomeRow(row, sectionName, "mylist")
 end sub
 
 sub buildContinueWatchingRow(taskKey as string)
@@ -2263,14 +2358,7 @@ sub buildContinueWatchingRow(taskKey as string)
         row.appendChild(item)
     end for
 
-    if sectionExists(sectionName)
-        m.top.content.replaceChild(row, getSectionIndex(sectionName))
-        setRowItemSize()
-        return
-    end if
-
-    m.top.content.insertChild(row, getOriginalSectionIndex("resume"))
-    setRowItemSize()
+    addOrUpdateHomeRow(row, sectionName, "resume")
 end sub
 
 sub updateContinueWatchingItems()
@@ -2310,16 +2398,7 @@ sub updateContinueListeningItems()
         row.appendChild(item)
     end for
 
-    ' Row already exists, replace it with new content
-    if sectionExists(sectionName)
-        m.top.content.replaceChild(row, getSectionIndex(sectionName))
-        setRowItemSize()
-        return
-    end if
-
-    ' Row does not exist, insert it into the home view
-    m.top.content.insertChild(row, getOriginalSectionIndex("resumeaudio"))
-    setRowItemSize()
+    addOrUpdateHomeRow(row, sectionName, "resumeaudio")
 end sub
 
 ' updateNextUpItems: Processes LoadNextUpTask content. Removes, Creates, or Updates next up row as needed
@@ -2352,16 +2431,7 @@ sub updateNextUpItems()
         row.appendChild(item)
     end for
 
-    ' Row already exists, replace it with new content
-    if sectionExists(sectionName)
-        m.top.content.replaceChild(row, getSectionIndex(sectionName))
-        setRowItemSize()
-        return
-    end if
-
-    ' Row does not exist, insert it into the home view
-    m.top.content.insertChild(row, getOriginalSectionIndex("nextup"))
-    setRowItemSize()
+    addOrUpdateHomeRow(row, sectionName, "nextup")
 end sub
 
 ' updateLatestItems: Processes LoadItemsTask content. Removes, Creates, or Updates Recently Added in {library} row as needed
@@ -2405,15 +2475,7 @@ sub updateLatestItems(msg)
         row.appendChild(item)
     end for
 
-    if sectionExists(sectionName)
-        ' Row already exists, replace it with new content
-        m.top.content.replaceChild(row, getSectionIndex(sectionName))
-        setRowItemSize()
-        return
-    end if
-
-    m.top.content.insertChild(row, getOriginalSectionIndex("latestmedia"))
-    setRowItemSize()
+    addOrUpdateHomeRow(row, sectionName, "latestmedia")
 end sub
 
 ' updateRecentlyReleasedItems: Processes LoadItemsTask content for recently released items
@@ -2457,15 +2519,7 @@ sub updateRecentlyReleasedItems(msg)
         row.appendChild(item)
     end for
 
-    if sectionExists(sectionName)
-        ' Row already exists, replace it with new content
-        m.top.content.replaceChild(row, getSectionIndex(sectionName))
-        setRowItemSize()
-        return
-    end if
-
-    m.top.content.insertChild(row, getOriginalSectionIndex("recentlyreleased"))
-    setRowItemSize()
+    addOrUpdateHomeRow(row, sectionName, "recentlyreleased")
 end sub
 
 
@@ -2909,12 +2963,5 @@ sub updateCustomDynamicRowItems(event as object)
         row.appendChild(item)
     end for
 
-    if sectionExists(sectionName)
-        m.top.content.replaceChild(row, getSectionIndex(sectionName))
-        setRowItemSize()
-        return
-    end if
-
-    m.top.content.insertChild(row, getOriginalSectionIndex(rowId))
-    setRowItemSize()
+    addOrUpdateHomeRow(row, sectionName, rowId)
 end sub

--- a/components/home/HomeRows.bs
+++ b/components/home/HomeRows.bs
@@ -1735,7 +1735,7 @@ sub onMultiServerNextUpComplete()
     if sectionExists(sectionName)
         m.top.content.replaceChild(row, getSectionIndex(sectionName))
     else
-        m.top.content.insertChild(row, getSectionIndex(sectionName))
+        m.top.content.insertChild(row, getOriginalSectionIndex("favorites"))
     end if
     setRowItemSize()
 end sub
@@ -2180,7 +2180,7 @@ sub updateFavoritesItems()
         return
     end if
 
-    m.top.content.insertChild(row, getSectionIndex(sectionName))
+    m.top.content.insertChild(row, getOriginalSectionIndex("favorites"))
     setRowItemSize()
 end sub
 
@@ -2221,7 +2221,7 @@ sub updateMyListItems()
         return
     end if
 
-    m.top.content.insertChild(row, getSectionIndex(sectionName))
+    m.top.content.insertChild(row, getOriginalSectionIndex("mylist"))
     setRowItemSize()
 end sub
 
@@ -2360,7 +2360,7 @@ sub updateNextUpItems()
     end if
 
     ' Row does not exist, insert it into the home view
-    m.top.content.insertChild(row, getSectionIndex(sectionName))
+    m.top.content.insertChild(row, getOriginalSectionIndex("nextup"))
     setRowItemSize()
 end sub
 
@@ -2915,6 +2915,6 @@ sub updateCustomDynamicRowItems(event as object)
         return
     end if
 
-    m.top.content.appendChild(row)
+    m.top.content.insertChild(row, getOriginalSectionIndex(rowId))
     setRowItemSize()
 end sub

--- a/components/home/HomeRows.bs
+++ b/components/home/HomeRows.bs
@@ -1081,6 +1081,44 @@ function addHomeSection(sectionType as string) as boolean
         return true
     end if
 
+    ' Custom / dynamic home row configuration
+    isCustomRow = (sectionType.startsWith("imdb_") or sectionType.startsWith("tmdb_") or sectionType.startsWith("seerr_") or sectionType.startsWith("plugindynamic:"))
+    if isCustomRow
+        fakeRow = {
+            id: sectionType,
+            title: sectionType,
+            source: "custom"
+        }
+        
+        if sectionType.startsWith("imdb_")
+            fakeRow.source = "imdb"
+            fakeRow.title = imdbSectionName(sectionType)
+        else if sectionType.startsWith("tmdb_")
+            fakeRow.source = "tmdb"
+            if sectionType = "tmdb_popular_movies" then fakeRow.title = tr("TMDb Popular Movies")
+            if sectionType = "tmdb_top_rated_movies" then fakeRow.title = tr("TMDb Top Rated Movies")
+            if sectionType = "tmdb_now_playing_movies" then fakeRow.title = tr("TMDb Now Playing Movies")
+            if sectionType = "tmdb_upcoming_movies" then fakeRow.title = tr("TMDb Upcoming Movies")
+            if sectionType = "tmdb_popular_tv" then fakeRow.title = tr("TMDb Popular TV Shows")
+            if sectionType = "tmdb_top_rated_tv" then fakeRow.title = tr("TMDb Top Rated TV Shows")
+            if sectionType = "tmdb_airing_today_tv" then fakeRow.title = tr("TMDb Airing Today TV Shows")
+            if sectionType = "tmdb_on_the_air_tv" then fakeRow.title = tr("TMDb On The Air TV Shows")
+            if sectionType = "tmdb_trending_movie_daily" then fakeRow.title = tr("TMDb Trending Movies Daily")
+            if sectionType = "tmdb_trending_movie_weekly" then fakeRow.title = tr("TMDb Trending Movies Weekly")
+            if sectionType = "tmdb_trending_tv_daily" then fakeRow.title = tr("TMDb Trending TV Daily")
+            if sectionType = "tmdb_trending_tv_weekly" then fakeRow.title = tr("TMDb Trending TV Weekly")
+            if sectionType = "tmdb_trending_all_weekly" then fakeRow.title = tr("TMDb Trending All Weekly")
+        else if sectionType.startsWith("seerr_")
+            fakeRow.source = "seerr"
+            if sectionType = "seerr_trending" then fakeRow.title = tr("Seerr Trending")
+            if sectionType = "seerr_popular_movies" then fakeRow.title = tr("Seerr Popular Movies")
+            if sectionType = "seerr_popular_series" then fakeRow.title = tr("Seerr Popular TV Shows")
+            if sectionType = "seerr_upcoming_movies" then fakeRow.title = tr("Seerr Upcoming Movies")
+            if sectionType = "seerr_upcoming_series" then fakeRow.title = tr("Seerr Upcoming TV Shows")
+        end if
+
+        return createCustomDynamicRow(fakeRow)
+    end if
 
     ' Featured Media Carousel - now handled by separate toggle in Moonfin settings
     ' Skip creating a row for it, as it's controlled by ui.home.mediaBarEnabled
@@ -2829,6 +2867,26 @@ sub updateCustomDynamicRowItems(event as object)
     if not isValidAndNotEmpty(sectionName)
         if rowId.startsWith("imdb_")
             sectionName = imdbSectionName(rowId)
+        else if rowId.startsWith("tmdb_")
+            if rowId = "tmdb_popular_movies" then sectionName = tr("TMDb Popular Movies")
+            if rowId = "tmdb_top_rated_movies" then sectionName = tr("TMDb Top Rated Movies")
+            if rowId = "tmdb_now_playing_movies" then sectionName = tr("TMDb Now Playing Movies")
+            if rowId = "tmdb_upcoming_movies" then sectionName = tr("TMDb Upcoming Movies")
+            if rowId = "tmdb_popular_tv" then sectionName = tr("TMDb Popular TV Shows")
+            if rowId = "tmdb_top_rated_tv" then sectionName = tr("TMDb Top Rated TV Shows")
+            if rowId = "tmdb_airing_today_tv" then sectionName = tr("TMDb Airing Today TV Shows")
+            if rowId = "tmdb_on_the_air_tv" then sectionName = tr("TMDb On The Air TV Shows")
+            if rowId = "tmdb_trending_movie_daily" then sectionName = tr("TMDb Trending Movies Daily")
+            if rowId = "tmdb_trending_movie_weekly" then sectionName = tr("TMDb Trending Movies Weekly")
+            if rowId = "tmdb_trending_tv_daily" then sectionName = tr("TMDb Trending TV Daily")
+            if rowId = "tmdb_trending_tv_weekly" then sectionName = tr("TMDb Trending TV Weekly")
+            if rowId = "tmdb_trending_all_weekly" then sectionName = tr("TMDb Trending All Weekly")
+        else if rowId.startsWith("seerr_")
+            if rowId = "seerr_trending" then sectionName = tr("Seerr Trending")
+            if rowId = "seerr_popular_movies" then sectionName = tr("Seerr Popular Movies")
+            if rowId = "seerr_popular_series" then sectionName = tr("Seerr Popular TV Shows")
+            if rowId = "seerr_upcoming_movies" then sectionName = tr("Seerr Upcoming Movies")
+            if rowId = "seerr_upcoming_series" then sectionName = tr("Seerr Upcoming TV Shows")
         else
             sectionName = rowId
         end if

--- a/components/home/HomeRows.bs
+++ b/components/home/HomeRows.bs
@@ -742,7 +742,10 @@ function addServerHomeRow(row as object) as boolean
         rowId = chainLookupReturn(row, "id", "")
         rowSource = chainLookupReturn(row, "source", "")
 
-        isCustomRow = (isValidAndNotEmpty(rowId) and (rowId.startsWith("imdb_") or rowId.startsWith("tmdb_") or rowId.startsWith("seerr_") or rowId.startsWith("pluginDynamic:"))) or (rowSource = "custom" or rowSource = "seerr" or rowSource = "tmdb" or rowSource = "letterboxd" or rowSource = "mdblist")
+        lowerRowId = LCase(rowId)
+        hasCustomPrefix = isValidAndNotEmpty(rowId) and (lowerRowId.startsWith("imdb_") or lowerRowId.startsWith("tmdb_") or lowerRowId.startsWith("seerr_") or lowerRowId.startsWith("plugindynamic:"))
+        hasCustomSource = (rowSource = "custom" or rowSource = "seerr" or rowSource = "tmdb" or rowSource = "letterboxd" or rowSource = "mdblist")
+        isCustomRow = hasCustomPrefix or hasCustomSource
 
         if isCustomRow
             return createCustomDynamicRow(row)
@@ -929,93 +932,112 @@ sub sortHomeRows()
     numChildren = children.count()
     if numChildren <= 1 then return
 
+    ' Resolve the section names and localized titles once so scoring stays cheap
+    matchers = buildSectionMatchers()
+
+    ' Score every row once rather than recomputing during each comparison
+    indexes = []
+    for each child in children
+        indexes.push(getOriginalSettingIndexForNode(child, matchers))
+    end for
+
     ' Stable insertion sort based on settings index
     for i = 1 to numChildren - 1
         keyNode = children[i]
-        keyIndex = getOriginalSettingIndexForNode(keyNode)
+        keyIndex = indexes[i]
         j = i - 1
         while j >= 0
-            compareNode = children[j]
-            compareIndex = getOriginalSettingIndexForNode(compareNode)
-            if compareIndex > keyIndex
+            if indexes[j] > keyIndex
                 children[j + 1] = children[j]
+                indexes[j + 1] = indexes[j]
                 j = j - 1
             else
                 exit while
             end if
         end while
         children[j + 1] = keyNode
+        indexes[j + 1] = keyIndex
     end for
+
+    ' Rebuilding the row list drops focus, so only do it when the order actually changed
+    existingChildren = m.top.content.getChildren(-1, 0)
+    orderChanged = false
+    for i = 0 to numChildren - 1
+        if not existingChildren[i].isSameNode(children[i])
+            orderChanged = true
+            exit for
+        end if
+    end for
+    if not orderChanged then return
 
     m.top.content.removeChildren(children)
     m.top.content.appendChildren(children)
 end sub
 
+' buildSectionMatchers: Collects everything needed to match a row against the configured sections
+'
+' @return {object} the configured section names plus the localized titles and prefixes rows use
+function buildSectionMatchers() as object
+    sectionNames = []
+    for i = 0 to 7
+        sectionNames.push(getResolvedSectionName(i))
+    end for
+
+    return {
+        sectionNames: sectionNames,
+        ' Rows built from a library name carry a localized prefix rather than an exact title
+        titlePrefixes: {
+            latestmedia: LCase(tr("Recently Added in")).Replace(" ", ""),
+            recentlyreleased: LCase(tr("Recently Released in")).Replace(" ", "")
+        },
+        ' Some rows carry no id, so they can only be matched on their localized title
+        localizedTitles: {
+            collections: LCase(tr("Collections")).Replace(" ", ""),
+            genres: LCase(tr("Genres")).Replace(" ", ""),
+            playlists: LCase(tr("Playlists")).Replace(" ", ""),
+            audio: LCase(tr("Audio")).Replace(" ", ""),
+            favorites: LCase(tr("Favorites")).Replace(" ", ""),
+            mylist: LCase(tr("My List")).Replace(" ", ""),
+            nextup: LCase(tr("Next Up")).Replace(" ", ""),
+            resume: LCase(tr("Continue Watching")).Replace(" ", ""),
+            resumeaudio: LCase(tr("Continue Listening")).Replace(" ", ""),
+            livetv: LCase(tr("On Now")).Replace(" ", ""),
+            smalllibrarytiles: LCase(tr("My Media")).Replace(" ", "")
+        }
+    }
+end function
+
 ' getOriginalSettingIndexForNode: Helper function to get the user configuration index of a row
 '
 ' @param {object} node - The HomeRow node we're checking
+' @param {object} matchers - The section matchers from buildSectionMatchers
 ' @return {integer} index of the row setting (0 to 7) or 99 if not found
-function getOriginalSettingIndexForNode(node as object) as integer
+function getOriginalSettingIndexForNode(node as object, matchers as object) as integer
     if node = invalid then return 99
 
     nodeId = LCase(node.id).Replace(" ", "")
     nodeTitle = LCase(node.title).Replace(" ", "")
+    titlePrefixes = matchers.titlePrefixes
+    localizedTitles = matchers.localizedTitles
 
-    for i = 0 to 7
-        settingSectionName = getResolvedSectionName(i)
+    for i = 0 to matchers.sectionNames.Count() - 1
+        settingSectionName = matchers.sectionNames[i]
 
-        ' Direct ID matches
         if settingSectionName = nodeId
             return i
         end if
 
-        ' Localized title matches for standard sections
-        if settingSectionName = "collections" and (nodeId = "collections" or nodeTitle = LCase(tr("Collections")).Replace(" ", ""))
-            return i
-        end if
-        if settingSectionName = "genres" and (nodeId = "genres" or nodeTitle = LCase(tr("Genres")).Replace(" ", ""))
-            return i
-        end if
-        if settingSectionName = "playlists" and (nodeId = "playlists" or nodeTitle = LCase(tr("Playlists")).Replace(" ", ""))
-            return i
-        end if
-        if settingSectionName = "audio" and (nodeId = "audio" or nodeTitle = LCase(tr("Audio")).Replace(" ", ""))
-            return i
-        end if
-        if settingSectionName = "favorites" and (nodeId = "favorites" or nodeTitle = LCase(tr("Favorites")).Replace(" ", ""))
-            return i
-        end if
-        if settingSectionName = "mylist" and (nodeId = "mylist" or nodeTitle = LCase(tr("My List")).Replace(" ", ""))
-            return i
-        end if
-        if settingSectionName = "nextup" and (nodeId = "nextup" or nodeTitle = LCase(tr("Next Up")).Replace(" ", ""))
-            return i
-        end if
-        if settingSectionName = "resume" and (nodeId = "resume" or nodeTitle = LCase(tr("Continue Watching")).Replace(" ", ""))
-            return i
-        end if
-        if settingSectionName = "resumeaudio" and (nodeId = "resumeaudio" or nodeTitle = LCase(tr("Continue Listening")).Replace(" ", ""))
-            return i
-        end if
-        if settingSectionName = "livetv" and (nodeId = "livetv" or nodeTitle = LCase(tr("On Now")).Replace(" ", ""))
-            return i
-        end if
-        if settingSectionName = "smalllibrarytiles" and (nodeId = "smalllibrarytiles" or nodeTitle = LCase(tr("My Media")).Replace(" ", ""))
-            return i
+        prefix = titlePrefixes[settingSectionName]
+        if isValid(prefix)
+            if Left(nodeTitle, prefix.Len()) = prefix
+                return i
+            end if
+            continue for
         end if
 
-        ' Prefix checks for dynamic library rows
-        if settingSectionName = "latestmedia"
-            prefix = LCase(tr("Recently Added in")).Replace(" ", "")
-            if nodeId = "latestmedia" or Left(nodeTitle, prefix.Len()) = prefix
-                return i
-            end if
-        end if
-        if settingSectionName = "recentlyreleased"
-            prefix = LCase(tr("Recently Released in")).Replace(" ", "")
-            if nodeId = "recentlyreleased" or Left(nodeTitle, prefix.Len()) = prefix
-                return i
-            end if
+        localizedTitle = localizedTitles[settingSectionName]
+        if isValid(localizedTitle) and nodeTitle = localizedTitle
+            return i
         end if
     end for
 
@@ -1199,43 +1221,10 @@ function addHomeSection(sectionType as string) as boolean
         return true
     end if
 
-    ' Custom / dynamic home row configuration
-    isCustomRow = (sectionType.startsWith("imdb_") or sectionType.startsWith("tmdb_") or sectionType.startsWith("seerr_") or sectionType.startsWith("plugindynamic:"))
-    if isCustomRow
-        fakeRow = {
-            id: sectionType,
-            title: sectionType,
-            source: "custom"
-        }
-        
-        if sectionType.startsWith("imdb_")
-            fakeRow.source = "imdb"
-            fakeRow.title = imdbSectionName(sectionType)
-        else if sectionType.startsWith("tmdb_")
-            fakeRow.source = "tmdb"
-            if sectionType = "tmdb_popular_movies" then fakeRow.title = tr("TMDb Popular Movies")
-            if sectionType = "tmdb_top_rated_movies" then fakeRow.title = tr("TMDb Top Rated Movies")
-            if sectionType = "tmdb_now_playing_movies" then fakeRow.title = tr("TMDb Now Playing Movies")
-            if sectionType = "tmdb_upcoming_movies" then fakeRow.title = tr("TMDb Upcoming Movies")
-            if sectionType = "tmdb_popular_tv" then fakeRow.title = tr("TMDb Popular TV Shows")
-            if sectionType = "tmdb_top_rated_tv" then fakeRow.title = tr("TMDb Top Rated TV Shows")
-            if sectionType = "tmdb_airing_today_tv" then fakeRow.title = tr("TMDb Airing Today TV Shows")
-            if sectionType = "tmdb_on_the_air_tv" then fakeRow.title = tr("TMDb On The Air TV Shows")
-            if sectionType = "tmdb_trending_movie_daily" then fakeRow.title = tr("TMDb Trending Movies Daily")
-            if sectionType = "tmdb_trending_movie_weekly" then fakeRow.title = tr("TMDb Trending Movies Weekly")
-            if sectionType = "tmdb_trending_tv_daily" then fakeRow.title = tr("TMDb Trending TV Daily")
-            if sectionType = "tmdb_trending_tv_weekly" then fakeRow.title = tr("TMDb Trending TV Weekly")
-            if sectionType = "tmdb_trending_all_weekly" then fakeRow.title = tr("TMDb Trending All Weekly")
-        else if sectionType.startsWith("seerr_")
-            fakeRow.source = "seerr"
-            if sectionType = "seerr_trending" then fakeRow.title = tr("Seerr Trending")
-            if sectionType = "seerr_popular_movies" then fakeRow.title = tr("Seerr Popular Movies")
-            if sectionType = "seerr_popular_series" then fakeRow.title = tr("Seerr Popular TV Shows")
-            if sectionType = "seerr_upcoming_movies" then fakeRow.title = tr("Seerr Upcoming Movies")
-            if sectionType = "seerr_upcoming_series" then fakeRow.title = tr("Seerr Upcoming TV Shows")
-        end if
-
-        return createCustomDynamicRow(fakeRow)
+    ' Section names arrive lowercased from settings, so match the prefix case-insensitively
+    lowerSectionType = LCase(sectionType)
+    if lowerSectionType.startsWith("imdb_") or lowerSectionType.startsWith("tmdb_") or lowerSectionType.startsWith("seerr_") or lowerSectionType.startsWith("plugindynamic:")
+        return createCustomDynamicRow({ id: sectionType })
     end if
 
     ' Featured Media Carousel - now handled by separate toggle in Moonfin settings
@@ -2801,96 +2790,52 @@ function getNestedValue(obj as object, path as string) as dynamic
     return current
 end function
 
-' Maps an imdb_ server row id to its localized section title, or "" if unknown.
-function imdbSectionName(rowId as string) as string
-    if rowId = "imdb_top_250_movies" then return tr("IMDb Top 250 Movies")
-    if rowId = "imdb_top_250_tv_shows" then return tr("IMDb Top 250 TV Shows")
-    if rowId = "imdb_most_popular_movies" then return tr("IMDb Most Popular Movies")
-    if rowId = "imdb_most_popular_tv_shows" then return tr("IMDb Most Popular TV Shows")
-    if rowId = "imdb_lowest_rated_movies" then return tr("IMDb Lowest Rated Movies")
-    if rowId = "imdb_top_english_movies" then return tr("IMDb Top Rated English Movies")
-    return ""
+' customDynamicRowTitle: Resolves the display title for an external list row id
+'
+' @param {string} rowId - The row id, for example "imdb_top_250_movies" or "tmdb_popular_tv"
+' @return {string} localized row title, or an empty string when the id isn't recognized
+function customDynamicRowTitle(rowId as string) as string
+    titles = {
+        imdb_top_250_movies: tr("IMDb Top 250 Movies"),
+        imdb_top_250_tv_shows: tr("IMDb Top 250 TV Shows"),
+        imdb_most_popular_movies: tr("IMDb Most Popular Movies"),
+        imdb_most_popular_tv_shows: tr("IMDb Most Popular TV Shows"),
+        imdb_lowest_rated_movies: tr("IMDb Lowest Rated Movies"),
+        imdb_top_english_movies: tr("IMDb Top Rated English Movies"),
+        tmdb_popular_movies: tr("TMDb Popular Movies"),
+        tmdb_top_rated_movies: tr("TMDb Top Rated Movies"),
+        tmdb_now_playing_movies: tr("TMDb Now Playing Movies"),
+        tmdb_upcoming_movies: tr("TMDb Upcoming Movies"),
+        tmdb_popular_tv: tr("TMDb Popular TV Shows"),
+        tmdb_top_rated_tv: tr("TMDb Top Rated TV Shows"),
+        tmdb_airing_today_tv: tr("TMDb Airing Today TV Shows"),
+        tmdb_on_the_air_tv: tr("TMDb On The Air TV Shows"),
+        tmdb_trending_movie_daily: tr("TMDb Trending Movies Daily"),
+        tmdb_trending_movie_weekly: tr("TMDb Trending Movies Weekly"),
+        tmdb_trending_tv_daily: tr("TMDb Trending TV Daily"),
+        tmdb_trending_tv_weekly: tr("TMDb Trending TV Weekly"),
+        tmdb_trending_all_weekly: tr("TMDb Trending All Weekly"),
+        seerr_trending: tr("Seerr Trending"),
+        seerr_popular_movies: tr("Seerr Popular Movies"),
+        seerr_popular_series: tr("Seerr Popular TV Shows"),
+        seerr_upcoming_movies: tr("Seerr Upcoming Movies"),
+        seerr_upcoming_series: tr("Seerr Upcoming TV Shows")
+    }
+
+    return titles[rowId] ?? ""
 end function
 
-function createImdbRow(rowId as string, title as string) as boolean
-    sectionName = title
-    if not isValidAndNotEmpty(sectionName) or sectionName.startsWith("imdb_")
-        mappedName = imdbSectionName(rowId)
-        if isValidAndNotEmpty(mappedName) then sectionName = mappedName
-    end if
-
-    if not sectionExists(sectionName)
-        imdbRow = m.top.content.CreateChild("HomeRow")
-        imdbRow.title = sectionName
-        imdbRow.imageWidth = getPosterSize(false)[0]
-        imdbRow.cursorSize = getPosterSize(false)
-        imdbRow.usePoster = true
-    end if
-
-    task = getOrCreateTask(rowId)
-    task.observeField("content", "updateImdbRowItems")
-    task.control = "RUN"
-    return true
-end function
-
-sub updateImdbRowItems(event as object)
-    m.processedRowCount++
-
-    task = event.getRoSGNode()
-    rowId = task.itemsToLoad
-    itemData = getTaskContentAndCleanup(rowId)
-
-    ' The row only exists here because the server sent it, so per-list enable
-    ' gating already happened server-side. No client-side gating needed.
-    sectionName = imdbSectionName(rowId)
-
-    if not isValidAndNotEmpty(itemData)
-        removeHomeSection(sectionName)
-        return
-    end if
-
-    row = CreateObject("roSGNode", "HomeRow")
-    row.title = sectionName
-    row.imageWidth = getPosterSize(false)[0]
-    row.cursorSize = getPosterSize(false)
-    row.usePoster = true
-
-    for each item in itemData
-        item.usePoster = row.usePoster
-        item.imageWidth = row.imageWidth
-        row.appendChild(item)
-    end for
-
-    if sectionExists(sectionName)
-        m.top.content.replaceChild(row, getSectionIndex(sectionName))
-        setRowItemSize()
-        return
-    end if
-
-    m.top.content.appendChild(row)
-    setRowItemSize()
-end sub
-
+' createCustomDynamicRow: Starts the load for an external list row
+' The row is built once the task reports back, so nothing is added to the home view here
+'
+' @param {object} row - Row descriptor carrying an id and optional additionalData
+' @return {boolean} true once the load has been started
 function createCustomDynamicRow(row as object) as boolean
     rowId = chainLookupReturn(row, "id", "")
-    sectionName = chainLookupReturn(row, "title", rowId)
-
-    if not isValidAndNotEmpty(sectionName) or sectionName.startsWith("imdb_")
-        mappedName = imdbSectionName(rowId)
-        if isValidAndNotEmpty(mappedName) then sectionName = mappedName
-    end if
-
-    if not sectionExists(sectionName)
-        customRow = m.top.content.CreateChild("HomeRow")
-        customRow.title = sectionName
-        customRow.imageWidth = getPosterSize(false)[0]
-        customRow.cursorSize = getPosterSize(false)
-        customRow.usePoster = true
-    end if
 
     task = getOrCreateTask(rowId)
-    
-    additionalDataVal = row.additionalData
+
+    additionalDataVal = chainLookupReturn(row, "additionalData", invalid)
     if type(additionalDataVal) = "String" or type(additionalDataVal) = "roString"
         additionalDataVal = ParseJson(additionalDataVal)
     end if
@@ -2911,39 +2856,16 @@ sub updateCustomDynamicRowItems(event as object)
     itemData = getTaskContentAndCleanup(rowId)
 
     sectionName = ""
-    for each r in m.serverHomeRows
-        if r.id = rowId
-            sectionName = r.title
+    for each serverRow in m.serverHomeRows
+        if serverRow.id = rowId
+            sectionName = serverRow.title
             exit for
         end if
     end for
 
-    if not isValidAndNotEmpty(sectionName)
-        if rowId.startsWith("imdb_")
-            sectionName = imdbSectionName(rowId)
-        else if rowId.startsWith("tmdb_")
-            if rowId = "tmdb_popular_movies" then sectionName = tr("TMDb Popular Movies")
-            if rowId = "tmdb_top_rated_movies" then sectionName = tr("TMDb Top Rated Movies")
-            if rowId = "tmdb_now_playing_movies" then sectionName = tr("TMDb Now Playing Movies")
-            if rowId = "tmdb_upcoming_movies" then sectionName = tr("TMDb Upcoming Movies")
-            if rowId = "tmdb_popular_tv" then sectionName = tr("TMDb Popular TV Shows")
-            if rowId = "tmdb_top_rated_tv" then sectionName = tr("TMDb Top Rated TV Shows")
-            if rowId = "tmdb_airing_today_tv" then sectionName = tr("TMDb Airing Today TV Shows")
-            if rowId = "tmdb_on_the_air_tv" then sectionName = tr("TMDb On The Air TV Shows")
-            if rowId = "tmdb_trending_movie_daily" then sectionName = tr("TMDb Trending Movies Daily")
-            if rowId = "tmdb_trending_movie_weekly" then sectionName = tr("TMDb Trending Movies Weekly")
-            if rowId = "tmdb_trending_tv_daily" then sectionName = tr("TMDb Trending TV Daily")
-            if rowId = "tmdb_trending_tv_weekly" then sectionName = tr("TMDb Trending TV Weekly")
-            if rowId = "tmdb_trending_all_weekly" then sectionName = tr("TMDb Trending All Weekly")
-        else if rowId.startsWith("seerr_")
-            if rowId = "seerr_trending" then sectionName = tr("Seerr Trending")
-            if rowId = "seerr_popular_movies" then sectionName = tr("Seerr Popular Movies")
-            if rowId = "seerr_popular_series" then sectionName = tr("Seerr Popular TV Shows")
-            if rowId = "seerr_upcoming_movies" then sectionName = tr("Seerr Upcoming Movies")
-            if rowId = "seerr_upcoming_series" then sectionName = tr("Seerr Upcoming TV Shows")
-        else
-            sectionName = rowId
-        end if
+    if not isValidAndNotEmpty(sectionName) or sectionName = rowId
+        mappedName = customDynamicRowTitle(rowId)
+        sectionName = isValidAndNotEmpty(mappedName) ? mappedName : rowId
     end if
 
     if not isValidAndNotEmpty(itemData)

--- a/components/home/LoadItemsTask.bs
+++ b/components/home/LoadItemsTask.bs
@@ -2038,7 +2038,7 @@ function loadCustomDynamicList(listName as string, additionalData as dynamic) as
 
     source = "imdb"
     chartType = listName
-    paramsJson = ""
+    paramsJson = "{}"
 
     ' Try to parse the parameters
     rowConfig = {}

--- a/components/home/LoadItemsTask.bs
+++ b/components/home/LoadItemsTask.bs
@@ -1839,8 +1839,8 @@ sub loadItems()
         return
     end if
 
-    if m.top.itemsToLoad.startsWith("imdb_")
-        m.top.content = loadImdbList(m.top.itemsToLoad)
+    if m.top.itemsToLoad.startsWith("imdb_") or m.top.itemsToLoad.startsWith("tmdb_") or m.top.itemsToLoad.startsWith("seerr_") or m.top.itemsToLoad.startsWith("pluginDynamic:")
+        m.top.content = loadCustomDynamicList(m.top.itemsToLoad, m.top.additionalData)
         return
     end if
 
@@ -1999,47 +1999,291 @@ sub loadItems()
     m.top.content = []
 end sub
 
-function loadImdbList(listName as string) as object
+function decodeSeerrBase64(base64String as string) as string
+    if base64String = invalid or base64String = ""
+        return ""
+    end if
+    ba = CreateObject("roByteArray")
+    ba.FromBase64String(base64String)
+    return ba.ToAsciiString()
+end function
+
+function unwrapSeerrProxyResponse(data as object) as object
+    if not isValid(data) or type(data) <> "roAssociativeArray"
+        return invalid
+    end if
+    if isValidStringValue(data.FileContents)
+        decoded = decodeSeerrBase64(data.FileContents)
+        if decoded <> ""
+            return ParseJson(decoded)
+        end if
+    end if
+    return data
+end function
+
+function toNormalizedString(val as dynamic) as string
+    if not isValid(val) then return ""
+    valType = type(val)
+    if valType = "String" or valType = "roString"
+        return val
+    end if
+    if valType = "Integer" or valType = "roInt" or valType = "roInteger" or valType = "Float" or valType = "roFloat" or valType = "Double" or valType = "LongInteger"
+        return val.toStr()
+    end if
+    return ""
+end function
+
+function loadCustomDynamicList(listName as string, additionalData as dynamic) as object
     results = []
 
-    ' The server rejects the request with 400 unless params is a non-empty
-    ' JSON string, so send a minimal payload echoing the source and chart type.
-    requestParams = FormatJson({ source: "imdb", type: listName })
+    source = "imdb"
+    chartType = listName
+    paramsJson = ""
 
-    data = getJson(APIRequest("/Moonfin/CustomRows/Items", {
-        source: "imdb",
-        type: listName,
-        params: requestParams
-    }))
+    ' Try to parse the parameters
+    rowConfig = {}
+    if isValid(additionalData)
+        if type(additionalData) = "String" or type(additionalData) = "roString"
+            rowConfig = ParseJson(additionalData)
+        else if type(additionalData) = "roAssociativeArray" or type(additionalData) = "AssociativeArray"
+            rowConfig = additionalData
+        end if
+    end if
 
-    ' External list responses report success plus a lowercase items array.
-    if not isValid(data) or chainLookupReturn(data, "success", false) <> true then return results
-    if not isChainValid(data, "items") then return results
+    if listName.startsWith("pluginDynamic:")
+        source = chainLookupReturn(rowConfig, "source", "imdb")
+        chartType = chainLookupReturn(rowConfig, "type", "")
+        paramsMap = chainLookupReturn(rowConfig, "params", {})
+        paramsJson = FormatJson(paramsMap)
+    else if listName.startsWith("tmdb_")
+        source = "tmdb_chart"
+        chartType = listName
+        if listName = "tmdb_popular_movies" then chartType = "movie/popular"
+        if listName = "tmdb_top_rated_movies" then chartType = "movie/top_rated"
+        if listName = "tmdb_now_playing_movies" then chartType = "movie/now_playing"
+        if listName = "tmdb_upcoming_movies" then chartType = "movie/upcoming"
+        if listName = "tmdb_popular_tv" then chartType = "tv/popular"
+        if listName = "tmdb_top_rated_tv" then chartType = "tv/top_rated"
+        if listName = "tmdb_airing_today_tv" then chartType = "tv/airing_today"
+        if listName = "tmdb_on_the_air_tv" then chartType = "tv/on_the_air"
+        if listName = "tmdb_trending_movie_daily" then chartType = "trending/movie/day"
+        if listName = "tmdb_trending_movie_weekly" then chartType = "trending/movie/week"
+        if listName = "tmdb_trending_tv_daily" then chartType = "trending/tv/day"
+        if listName = "tmdb_trending_tv_weekly" then chartType = "trending/tv/week"
+        if listName = "tmdb_trending_all_weekly" then chartType = "trending/all/week"
 
-    for each item in data.LookupCI("items")
-        if not isValid(item) then continue for
+        paramsJson = FormatJson({ source: source, type: chartType })
+    else if listName.startsWith("seerr_")
+        source = "seerr"
+        chartType = listName
+    end if
 
-        ' These are external IMDb entries with no matching Jellyfin item, so we
-        ' set the display fields directly and skip the json/setData image
-        ' pipeline. posterUrl/backdropUrl are absolute external URLs, used as-is.
-        tmp = createSGNode("HomeData")
-        ' These sit in a poster row, so show the poster art first.
-        tmp.usePoster = true
+    if source = "seerr"
+        ' Map Seerr chart types to endpoints and parameters
+        endpoint = ""
+        queryParams = {}
+        isRequests = false
 
-        name = item.LookupCI("name")
-        if isValidAndNotEmpty(name) then tmp.name = name
+        if chartType = "seerr_recent_requests" or chartType = "recentrequests" or chartType = "recentRequests"
+            endpoint = "/api/v1/request"
+            queryParams = { take: "20", skip: "0", sort: "modified", filter: "all" }
+            isRequests = true
+        else if chartType = "seerr_recently_added" or chartType = "recentlyadded" or chartType = "recentlyAdded"
+            endpoint = "/api/v1/media"
+            queryParams = { filter: "allavailable", sort: "mediaAdded", take: "20" }
+        else if chartType = "seerr_trending" or chartType = "trending"
+            endpoint = "/api/v1/discover/trending"
+            queryParams = { page: "1", language: "en" }
+        else if chartType = "seerr_popular_movies" or chartType = "popularmovies" or chartType = "popularMovies"
+            endpoint = "/api/v1/discover/movies"
+            queryParams = { page: "1", language: "en" }
+        else if chartType = "seerr_upcoming_movies" or chartType = "upcomingmovies" or chartType = "upcomingMovies"
+            endpoint = "/api/v1/discover/movies/upcoming"
+            queryParams = { language: "en" }
+        else if chartType = "seerr_popular_series" or chartType = "popularseries" or chartType = "popularSeries"
+            endpoint = "/api/v1/discover/tv"
+            queryParams = { page: "1", language: "en" }
+        else if chartType = "seerr_upcoming_series" or chartType = "upcomingseries" or chartType = "upcomingSeries"
+            endpoint = "/api/v1/discover/tv/upcoming"
+            queryParams = { language: "en" }
+        end if
 
-        itemType = item.LookupCI("type")
-        if isValidAndNotEmpty(itemType) then tmp.type = itemType
+        if endpoint <> ""
+            if Left(endpoint, 7) = "/api/v1"
+                proxyPath = Mid(endpoint, 8)
+            else
+                proxyPath = endpoint
+            end if
+            if Left(proxyPath, 1) <> "/" then proxyPath = "/" + proxyPath
 
-        posterUrl = item.LookupCI("posterUrl")
-        if isValidAndNotEmpty(posterUrl) then tmp.posterURL = posterUrl
+            req = APIRequest("/Moonfin/Seerr/Api" + proxyPath, queryParams)
+            response = unwrapSeerrProxyResponse(getJson(req))
 
-        backdropUrl = item.LookupCI("backdropUrl")
-        if isValidAndNotEmpty(backdropUrl) then tmp.backdropURL = backdropUrl
+            if response <> invalid and isChainValid(response, "results")
+                resultsArray = response.results
+                for each item in resultsArray
+                    if not isValid(item) then continue for
 
-        results.push(tmp)
-    end for
+                    resItem = item
+                    if isRequests
+                        if item.media <> invalid
+                            resItem = item.media
+                            resItem.mediaType = item.type
+                        else
+                            continue for
+                        end if
+                    end if
+
+                    mediaType = resItem.LookupCI("mediaType")
+                    if not isValidAndNotEmpty(mediaType) then mediaType = resItem.LookupCI("media_type")
+                    if not isValidAndNotEmpty(mediaType) then mediaType = (resItem.type = "Series" or resItem.type = "tv") ? "tv" : "movie"
+
+                    tmdbId = resItem.LookupCI("tmdbId")
+                    if not isValid(tmdbId) then tmdbId = resItem.LookupCI("id")
+                    if not isValid(tmdbId) then continue for
+
+                    title = resItem.LookupCI("title")
+                    if not isValidAndNotEmpty(title) then title = resItem.LookupCI("name")
+                    title = toNormalizedString(title)
+                    if title = "" then title = "Unknown"
+
+                    posterPath = resItem.LookupCI("posterPath")
+                    if not isValidAndNotEmpty(posterPath) then posterPath = resItem.LookupCI("poster_path")
+
+                    posterUrl = ""
+                    if isValidAndNotEmpty(posterPath)
+                        if posterPath.startsWith("http")
+                            posterUrl = posterPath
+                        else
+                            tmdbUrls = GetTmdbImageBaseUrls()
+                            posterUrl = tmdbUrls.posterW342 + posterPath
+                        end if
+                    end if
+
+                    backdropPath = resItem.LookupCI("backdropPath")
+                    if not isValidAndNotEmpty(backdropPath) then backdropPath = resItem.LookupCI("backdrop_path")
+
+                    backdropUrl = ""
+                    if isValidAndNotEmpty(backdropPath)
+                        if backdropPath.startsWith("http")
+                            backdropUrl = backdropPath
+                        else
+                            tmdbUrls = GetTmdbImageBaseUrls()
+                            backdropUrl = tmdbUrls.backdropW1280 + backdropPath
+                        end if
+                    end if
+
+                    resItem.mediaType = mediaType
+
+                    tmp = createSGNode("HomeData")
+                    tmp.name = title
+                    tmp.type = (mediaType = "tv") ? "Series" : "Movie"
+                    tmp.usePoster = true
+                    if posterUrl <> "" then tmp.posterURL = posterUrl
+                    if backdropUrl <> "" then tmp.backdropURL = backdropUrl
+
+                    tmp.json = {
+                        Id: toNormalizedString(tmdbId),
+                        name: title,
+                        Type: tmp.type,
+                        SeerrTmdbId: toNormalizedString(tmdbId),
+                        SeerrMediaType: mediaType,
+                        SeerrPosterURL: posterUrl,
+                        SeerrItem: resItem
+                    }
+                    results.push(tmp)
+                end for
+            end if
+        end if
+    else
+        data = getJson(APIRequest("/Moonfin/CustomRows/Items", {
+            source: source,
+            type: chartType,
+            params: paramsJson
+        }))
+
+        if data <> invalid and chainLookupReturn(data, "success", false) = true and isChainValid(data, "items")
+            for each item in data.items
+                if not isValid(item) then continue for
+
+                tmdbId = item.LookupCI("tmdbId")
+                if not isValidAndNotEmpty(tmdbId) then tmdbId = item.LookupCI("id")
+
+                imdbId = ""
+                providerIds = item.LookupCI("providerIds")
+                if isValid(providerIds)
+                    imdbId = providerIds.LookupCI("imdb")
+                    if not isValidAndNotEmpty(tmdbId) then tmdbId = providerIds.LookupCI("tmdb")
+                end if
+
+                if not isValidAndNotEmpty(tmdbId) and not isValidAndNotEmpty(imdbId)
+                    continue for
+                end if
+
+                title = item.LookupCI("name")
+                if not isValidAndNotEmpty(title) then title = item.LookupCI("title")
+                title = toNormalizedString(title)
+                if title = "" then title = "Unknown"
+
+                itemType = item.LookupCI("type")
+                if not isValidAndNotEmpty(itemType) then itemType = "Movie"
+
+                posterPath = item.LookupCI("posterUrl")
+                if not isValidAndNotEmpty(posterPath) then posterPath = item.LookupCI("poster_path")
+
+                posterUrl = ""
+                if isValidAndNotEmpty(posterPath)
+                    if posterPath.startsWith("http")
+                        posterUrl = posterPath
+                    else
+                        tmdbUrls = GetTmdbImageBaseUrls()
+                        posterUrl = tmdbUrls.posterW342 + posterPath
+                    end if
+                end if
+
+                backdropPath = item.LookupCI("backdropUrl")
+                if not isValidAndNotEmpty(backdropPath) then backdropPath = item.LookupCI("backdrop_path")
+
+                backdropUrl = ""
+                if isValidAndNotEmpty(backdropPath)
+                    if backdropPath.startsWith("http")
+                        backdropUrl = backdropPath
+                    else
+                        tmdbUrls = GetTmdbImageBaseUrls()
+                        backdropUrl = tmdbUrls.backdropW1280 + backdropPath
+                    end if
+                end if
+
+                seerrItem = {
+                    id: tmdbId,
+                    title: title,
+                    type: (itemType = "Series") ? "tv" : "movie",
+                    mediaType: (itemType = "Series") ? "tv" : "movie",
+                    posterPath: posterPath,
+                    backdropPath: backdropPath,
+                    productionYear: item.LookupCI("productionYear")
+                }
+
+                tmp = createSGNode("HomeData")
+                tmp.name = title
+                tmp.type = (itemType = "Series") ? "Series" : "Movie"
+                tmp.usePoster = true
+                if posterUrl <> "" then tmp.posterURL = posterUrl
+                if backdropUrl <> "" then tmp.backdropURL = backdropUrl
+
+                tmp.json = {
+                    Id: toNormalizedString(tmdbId),
+                    name: title,
+                    Type: tmp.type,
+                    SeerrTmdbId: toNormalizedString(tmdbId),
+                    SeerrMediaType: seerrItem.mediaType,
+                    SeerrPosterURL: posterUrl,
+                    SeerrItem: seerrItem
+                }
+                results.push(tmp)
+            end for
+        end if
+    end if
 
     return results
 end function

--- a/components/home/LoadItemsTask.bs
+++ b/components/home/LoadItemsTask.bs
@@ -1839,7 +1839,10 @@ sub loadItems()
         return
     end if
 
-    if m.top.itemsToLoad.startsWith("imdb_") or m.top.itemsToLoad.startsWith("tmdb_") or m.top.itemsToLoad.startsWith("seerr_") or m.top.itemsToLoad.startsWith("pluginDynamic:")
+    ' Row ids reach us lowercased when they come from settings and camel cased when they
+    ' come from the server, so match the prefix case-insensitively
+    lowerItemsToLoad = LCase(m.top.itemsToLoad)
+    if lowerItemsToLoad.startsWith("imdb_") or lowerItemsToLoad.startsWith("tmdb_") or lowerItemsToLoad.startsWith("seerr_") or lowerItemsToLoad.startsWith("plugindynamic:")
         m.top.content = loadCustomDynamicList(m.top.itemsToLoad, m.top.additionalData)
         return
     end if
@@ -2000,7 +2003,7 @@ sub loadItems()
 end sub
 
 function decodeSeerrBase64(base64String as string) as string
-    if base64String = invalid or base64String = ""
+    if base64String = ""
         return ""
     end if
     ba = CreateObject("roByteArray")
@@ -2040,7 +2043,9 @@ function loadCustomDynamicList(listName as string, additionalData as dynamic) as
     chartType = listName
     paramsJson = "{}"
 
-    ' Try to parse the parameters
+    ' Ids arrive lowercased from settings and camel cased from the server
+    lowerListName = LCase(listName)
+
     rowConfig = {}
     if isValid(additionalData)
         if type(additionalData) = "String" or type(additionalData) = "roString"
@@ -2050,12 +2055,12 @@ function loadCustomDynamicList(listName as string, additionalData as dynamic) as
         end if
     end if
 
-    if listName.startsWith("pluginDynamic:")
+    if lowerListName.startsWith("plugindynamic:")
         source = chainLookupReturn(rowConfig, "source", "imdb")
         chartType = chainLookupReturn(rowConfig, "type", "")
         paramsMap = chainLookupReturn(rowConfig, "params", {})
         paramsJson = FormatJson(paramsMap)
-    else if listName.startsWith("tmdb_")
+    else if lowerListName.startsWith("tmdb_")
         source = "tmdb_chart"
         chartType = listName
         if listName = "tmdb_popular_movies" then chartType = "movie/popular"
@@ -2073,7 +2078,7 @@ function loadCustomDynamicList(listName as string, additionalData as dynamic) as
         if listName = "tmdb_trending_all_weekly" then chartType = "trending/all/week"
 
         paramsJson = FormatJson({ source: source, type: chartType })
-    else if listName.startsWith("seerr_")
+    else if lowerListName.startsWith("seerr_")
         source = "seerr"
         chartType = listName
     end if

--- a/components/home/LoadItemsTask.xml
+++ b/components/home/LoadItemsTask.xml
@@ -12,5 +12,6 @@
     <field id="serverUrl" type="string" value="" />
     <field id="serverUserId" type="string" value="" />
     <field id="serverAuthToken" type="string" value="" />
+    <field id="additionalData" type="assocarray" />
   </interface>
 </component>

--- a/components/settings/settings.bs
+++ b/components/settings/settings.bs
@@ -1487,9 +1487,7 @@ function reorderSettingsForFlutter(configTree as object) as object
     pluginSettingsSync = findSettingsChildByTitle(pluginRootSection, "Settings Sync")
     ratings = findSettingsChildByTitle(pluginRootSection, "Metadata & Ratings")
     seerr = findSettingsChildByTitle(pluginRootSection, "Seerr")
-    if not isValid(seerr)
-        seerr = findSettingsChildByTitle(pluginRootSection, "Seerr")
-    end if
+    externalLists = findSettingsChildByTitle(pluginRootSection, "External Lists")
 
     reordered = []
 
@@ -1551,6 +1549,7 @@ function reorderSettingsForFlutter(configTree as object) as object
 
     pushSettingIfValid(integrationsChildren, ratings)
     pushSettingIfValid(integrationsChildren, seerr)
+    pushSettingIfValid(integrationsChildren, externalLists)
     
     if integrationsChildren.count() > 0
         reordered.push({
@@ -1577,7 +1576,7 @@ function reorderSettingsForFlutter(configTree as object) as object
     moonfinMappedTitles = ["Navigation", "Home Screen", "Libraries", "Media Bar", "Theme Music", "Shuffle", "Visual Effects", "Support Moonfin"]
     pushUnmappedChildrenByTitle(additionalChildren, moonfinSettings, moonfinMappedTitles)
 
-    pluginMappedTitles = ["Enable Plugin", "Settings Sync", "Metadata & Ratings", "Seerr"]
+    pluginMappedTitles = ["Enable Plugin", "Settings Sync", "Metadata & Ratings", "Seerr", "External Lists"]
     pushUnmappedChildrenByTitle(additionalChildren, pluginRootSection, pluginMappedTitles)
 
     userInterfaceMappedTitles = ["Colors", "General", "Libraries"]

--- a/components/settings/settings.bs
+++ b/components/settings/settings.bs
@@ -1809,6 +1809,93 @@ sub settingSelected()
                 for each option in selectedItem.options
                     filteredOptions.push(option)
                 end for
+
+                ' Dynamically append enabled custom dynamic rows
+                if normalizeBoolSettingValue(getUserSettingValue("imdb.top250movies", false))
+                    filteredOptions.push({ title: "IMDb Top 250 Movies", id: "imdb_top_250_movies" })
+                end if
+                if normalizeBoolSettingValue(getUserSettingValue("imdb.top250tvshows", false))
+                    filteredOptions.push({ title: "IMDb Top 250 TV Shows", id: "imdb_top_250_tv_shows" })
+                end if
+                if normalizeBoolSettingValue(getUserSettingValue("imdb.mostpopularmovies", false))
+                    filteredOptions.push({ title: "IMDb Most Popular Movies", id: "imdb_most_popular_movies" })
+                end if
+                if normalizeBoolSettingValue(getUserSettingValue("imdb.mostpopulartvshows", false))
+                    filteredOptions.push({ title: "IMDb Most Popular TV Shows", id: "imdb_most_popular_tv_shows" })
+                end if
+                if normalizeBoolSettingValue(getUserSettingValue("imdb.lowestratedmovies", false))
+                    filteredOptions.push({ title: "IMDb Lowest Rated Movies", id: "imdb_lowest_rated_movies" })
+                end if
+                if normalizeBoolSettingValue(getUserSettingValue("imdb.topenglishmovies", false))
+                    filteredOptions.push({ title: "IMDb Top Rated English Movies", id: "imdb_top_english_movies" })
+                end if
+
+                if normalizeBoolSettingValue(getUserSettingValue("tmdb.popularmovies", false))
+                    filteredOptions.push({ title: "TMDb Popular Movies", id: "tmdb_popular_movies" })
+                end if
+                if normalizeBoolSettingValue(getUserSettingValue("tmdb.topratedmovies", false))
+                    filteredOptions.push({ title: "TMDb Top Rated Movies", id: "tmdb_top_rated_movies" })
+                end if
+                if normalizeBoolSettingValue(getUserSettingValue("tmdb.nowplayingmovies", false))
+                    filteredOptions.push({ title: "TMDb Now Playing Movies", id: "tmdb_now_playing_movies" })
+                end if
+                if normalizeBoolSettingValue(getUserSettingValue("tmdb.upcomingmovies", false))
+                    filteredOptions.push({ title: "TMDb Upcoming Movies", id: "tmdb_upcoming_movies" })
+                end if
+                if normalizeBoolSettingValue(getUserSettingValue("tmdb.populartv", false))
+                    filteredOptions.push({ title: "TMDb Popular TV Shows", id: "tmdb_popular_tv" })
+                end if
+                if normalizeBoolSettingValue(getUserSettingValue("tmdb.topratedtv", false))
+                    filteredOptions.push({ title: "TMDb Top Rated TV Shows", id: "tmdb_top_rated_tv" })
+                end if
+                if normalizeBoolSettingValue(getUserSettingValue("tmdb.airingtodaytv", false))
+                    filteredOptions.push({ title: "TMDb Airing Today TV Shows", id: "tmdb_airing_today_tv" })
+                end if
+                if normalizeBoolSettingValue(getUserSettingValue("tmdb.ontheairtv", false))
+                    filteredOptions.push({ title: "TMDb On The Air TV Shows", id: "tmdb_on_the_air_tv" })
+                end if
+                if normalizeBoolSettingValue(getUserSettingValue("tmdb.trendingmoviedaily", false))
+                    filteredOptions.push({ title: "TMDb Trending Movies Daily", id: "tmdb_trending_movie_daily" })
+                end if
+                if normalizeBoolSettingValue(getUserSettingValue("tmdb.trendingmovieweekly", false))
+                    filteredOptions.push({ title: "TMDb Trending Movies Weekly", id: "tmdb_trending_movie_weekly" })
+                end if
+                if normalizeBoolSettingValue(getUserSettingValue("tmdb.trendingtvdaily", false))
+                    filteredOptions.push({ title: "TMDb Trending TV Daily", id: "tmdb_trending_tv_daily" })
+                end if
+                if normalizeBoolSettingValue(getUserSettingValue("tmdb.trendingtvweekly", false))
+                    filteredOptions.push({ title: "TMDb Trending TV Weekly", id: "tmdb_trending_tv_weekly" })
+                end if
+                if normalizeBoolSettingValue(getUserSettingValue("tmdb.trendingallweekly", false))
+                    filteredOptions.push({ title: "TMDb Trending All Weekly", id: "tmdb_trending_all_weekly" })
+                end if
+
+                if normalizeBoolSettingValue(getUserSettingValue("seerr.row.trending_movies", false)) or normalizeBoolSettingValue(getUserSettingValue("seerr.row.trending_tv", false))
+                    filteredOptions.push({ title: "Seerr Trending", id: "seerr_trending" })
+                end if
+                if normalizeBoolSettingValue(getUserSettingValue("seerr.row.popular_movies", false))
+                    filteredOptions.push({ title: "Seerr Popular Movies", id: "seerr_popular_movies" })
+                end if
+                if normalizeBoolSettingValue(getUserSettingValue("seerr.row.popular_tv", false))
+                    filteredOptions.push({ title: "Seerr Popular TV Shows", id: "seerr_popular_series" })
+                end if
+                if normalizeBoolSettingValue(getUserSettingValue("seerr.row.upcoming_movies", false))
+                    filteredOptions.push({ title: "Seerr Upcoming Movies", id: "seerr_upcoming_movies" })
+                end if
+                if normalizeBoolSettingValue(getUserSettingValue("seerr.row.upcoming_tv", false))
+                    filteredOptions.push({ title: "Seerr Upcoming TV Shows", id: "seerr_upcoming_series" })
+                end if
+
+                if normalizeBoolSettingValue(getUserSettingValue("calendar.radarr.enabled", false))
+                    filteredOptions.push({ title: "Radarr Calendar", id: "calendar_radarr" })
+                end if
+                if normalizeBoolSettingValue(getUserSettingValue("calendar.sonarr.enabled", false))
+                    filteredOptions.push({ title: "Sonarr Calendar", id: "calendar_sonarr" })
+                end if
+                if normalizeBoolSettingValue(getUserSettingValue("calendar.merge", false))
+                    filteredOptions.push({ title: "Merged Calendar", id: "calendar_merged" })
+                end if
+
                 radioOptions = filteredOptions
             end if
 

--- a/components/settings/settings.bs
+++ b/components/settings/settings.bs
@@ -1809,90 +1809,42 @@ sub settingSelected()
                     filteredOptions.push(option)
                 end for
 
-                ' Dynamically append enabled custom dynamic rows
-                if normalizeBoolSettingValue(getUserSettingValue("imdb.top250movies", false))
-                    filteredOptions.push({ title: "IMDb Top 250 Movies", id: "imdb_top_250_movies" })
-                end if
-                if normalizeBoolSettingValue(getUserSettingValue("imdb.top250tvshows", false))
-                    filteredOptions.push({ title: "IMDb Top 250 TV Shows", id: "imdb_top_250_tv_shows" })
-                end if
-                if normalizeBoolSettingValue(getUserSettingValue("imdb.mostpopularmovies", false))
-                    filteredOptions.push({ title: "IMDb Most Popular Movies", id: "imdb_most_popular_movies" })
-                end if
-                if normalizeBoolSettingValue(getUserSettingValue("imdb.mostpopulartvshows", false))
-                    filteredOptions.push({ title: "IMDb Most Popular TV Shows", id: "imdb_most_popular_tv_shows" })
-                end if
-                if normalizeBoolSettingValue(getUserSettingValue("imdb.lowestratedmovies", false))
-                    filteredOptions.push({ title: "IMDb Lowest Rated Movies", id: "imdb_lowest_rated_movies" })
-                end if
-                if normalizeBoolSettingValue(getUserSettingValue("imdb.topenglishmovies", false))
-                    filteredOptions.push({ title: "IMDb Top Rated English Movies", id: "imdb_top_english_movies" })
-                end if
+                ' Each entry pairs the setting that enables a row with the option shown in the picker
+                externalRowOptions = [
+                    { settingName: "imdb.top250movies", title: "IMDb Top 250 Movies", id: "imdb_top_250_movies" },
+                    { settingName: "imdb.top250tvshows", title: "IMDb Top 250 TV Shows", id: "imdb_top_250_tv_shows" },
+                    { settingName: "imdb.mostpopularmovies", title: "IMDb Most Popular Movies", id: "imdb_most_popular_movies" },
+                    { settingName: "imdb.mostpopulartvshows", title: "IMDb Most Popular TV Shows", id: "imdb_most_popular_tv_shows" },
+                    { settingName: "imdb.lowestratedmovies", title: "IMDb Lowest Rated Movies", id: "imdb_lowest_rated_movies" },
+                    { settingName: "imdb.topenglishmovies", title: "IMDb Top Rated English Movies", id: "imdb_top_english_movies" },
+                    { settingName: "tmdb.popularmovies", title: "TMDb Popular Movies", id: "tmdb_popular_movies" },
+                    { settingName: "tmdb.topratedmovies", title: "TMDb Top Rated Movies", id: "tmdb_top_rated_movies" },
+                    { settingName: "tmdb.nowplayingmovies", title: "TMDb Now Playing Movies", id: "tmdb_now_playing_movies" },
+                    { settingName: "tmdb.upcomingmovies", title: "TMDb Upcoming Movies", id: "tmdb_upcoming_movies" },
+                    { settingName: "tmdb.populartv", title: "TMDb Popular TV Shows", id: "tmdb_popular_tv" },
+                    { settingName: "tmdb.topratedtv", title: "TMDb Top Rated TV Shows", id: "tmdb_top_rated_tv" },
+                    { settingName: "tmdb.airingtodaytv", title: "TMDb Airing Today TV Shows", id: "tmdb_airing_today_tv" },
+                    { settingName: "tmdb.ontheairtv", title: "TMDb On The Air TV Shows", id: "tmdb_on_the_air_tv" },
+                    { settingName: "tmdb.trendingmoviedaily", title: "TMDb Trending Movies Daily", id: "tmdb_trending_movie_daily" },
+                    { settingName: "tmdb.trendingmovieweekly", title: "TMDb Trending Movies Weekly", id: "tmdb_trending_movie_weekly" },
+                    { settingName: "tmdb.trendingtvdaily", title: "TMDb Trending TV Daily", id: "tmdb_trending_tv_daily" },
+                    { settingName: "tmdb.trendingtvweekly", title: "TMDb Trending TV Weekly", id: "tmdb_trending_tv_weekly" },
+                    { settingName: "tmdb.trendingallweekly", title: "TMDb Trending All Weekly", id: "tmdb_trending_all_weekly" },
+                    { settingName: "seerr.row.popular_movies", title: "Seerr Popular Movies", id: "seerr_popular_movies" },
+                    { settingName: "seerr.row.popular_tv", title: "Seerr Popular TV Shows", id: "seerr_popular_series" },
+                    { settingName: "seerr.row.upcoming_movies", title: "Seerr Upcoming Movies", id: "seerr_upcoming_movies" },
+                    { settingName: "seerr.row.upcoming_tv", title: "Seerr Upcoming TV Shows", id: "seerr_upcoming_series" }
+                ]
 
-                if normalizeBoolSettingValue(getUserSettingValue("tmdb.popularmovies", false))
-                    filteredOptions.push({ title: "TMDb Popular Movies", id: "tmdb_popular_movies" })
-                end if
-                if normalizeBoolSettingValue(getUserSettingValue("tmdb.topratedmovies", false))
-                    filteredOptions.push({ title: "TMDb Top Rated Movies", id: "tmdb_top_rated_movies" })
-                end if
-                if normalizeBoolSettingValue(getUserSettingValue("tmdb.nowplayingmovies", false))
-                    filteredOptions.push({ title: "TMDb Now Playing Movies", id: "tmdb_now_playing_movies" })
-                end if
-                if normalizeBoolSettingValue(getUserSettingValue("tmdb.upcomingmovies", false))
-                    filteredOptions.push({ title: "TMDb Upcoming Movies", id: "tmdb_upcoming_movies" })
-                end if
-                if normalizeBoolSettingValue(getUserSettingValue("tmdb.populartv", false))
-                    filteredOptions.push({ title: "TMDb Popular TV Shows", id: "tmdb_popular_tv" })
-                end if
-                if normalizeBoolSettingValue(getUserSettingValue("tmdb.topratedtv", false))
-                    filteredOptions.push({ title: "TMDb Top Rated TV Shows", id: "tmdb_top_rated_tv" })
-                end if
-                if normalizeBoolSettingValue(getUserSettingValue("tmdb.airingtodaytv", false))
-                    filteredOptions.push({ title: "TMDb Airing Today TV Shows", id: "tmdb_airing_today_tv" })
-                end if
-                if normalizeBoolSettingValue(getUserSettingValue("tmdb.ontheairtv", false))
-                    filteredOptions.push({ title: "TMDb On The Air TV Shows", id: "tmdb_on_the_air_tv" })
-                end if
-                if normalizeBoolSettingValue(getUserSettingValue("tmdb.trendingmoviedaily", false))
-                    filteredOptions.push({ title: "TMDb Trending Movies Daily", id: "tmdb_trending_movie_daily" })
-                end if
-                if normalizeBoolSettingValue(getUserSettingValue("tmdb.trendingmovieweekly", false))
-                    filteredOptions.push({ title: "TMDb Trending Movies Weekly", id: "tmdb_trending_movie_weekly" })
-                end if
-                if normalizeBoolSettingValue(getUserSettingValue("tmdb.trendingtvdaily", false))
-                    filteredOptions.push({ title: "TMDb Trending TV Daily", id: "tmdb_trending_tv_daily" })
-                end if
-                if normalizeBoolSettingValue(getUserSettingValue("tmdb.trendingtvweekly", false))
-                    filteredOptions.push({ title: "TMDb Trending TV Weekly", id: "tmdb_trending_tv_weekly" })
-                end if
-                if normalizeBoolSettingValue(getUserSettingValue("tmdb.trendingallweekly", false))
-                    filteredOptions.push({ title: "TMDb Trending All Weekly", id: "tmdb_trending_all_weekly" })
-                end if
+                for each externalRow in externalRowOptions
+                    if normalizeBoolSettingValue(getUserSettingValue(externalRow.settingName, false))
+                        filteredOptions.push({ title: externalRow.title, id: externalRow.id })
+                    end if
+                end for
 
+                ' Seerr serves movie and TV trending from one endpoint, so either flag offers the row
                 if normalizeBoolSettingValue(getUserSettingValue("seerr.row.trending_movies", false)) or normalizeBoolSettingValue(getUserSettingValue("seerr.row.trending_tv", false))
                     filteredOptions.push({ title: "Seerr Trending", id: "seerr_trending" })
-                end if
-                if normalizeBoolSettingValue(getUserSettingValue("seerr.row.popular_movies", false))
-                    filteredOptions.push({ title: "Seerr Popular Movies", id: "seerr_popular_movies" })
-                end if
-                if normalizeBoolSettingValue(getUserSettingValue("seerr.row.popular_tv", false))
-                    filteredOptions.push({ title: "Seerr Popular TV Shows", id: "seerr_popular_series" })
-                end if
-                if normalizeBoolSettingValue(getUserSettingValue("seerr.row.upcoming_movies", false))
-                    filteredOptions.push({ title: "Seerr Upcoming Movies", id: "seerr_upcoming_movies" })
-                end if
-                if normalizeBoolSettingValue(getUserSettingValue("seerr.row.upcoming_tv", false))
-                    filteredOptions.push({ title: "Seerr Upcoming TV Shows", id: "seerr_upcoming_series" })
-                end if
-
-                if normalizeBoolSettingValue(getUserSettingValue("calendar.radarr.enabled", false))
-                    filteredOptions.push({ title: "Radarr Calendar", id: "calendar_radarr" })
-                end if
-                if normalizeBoolSettingValue(getUserSettingValue("calendar.sonarr.enabled", false))
-                    filteredOptions.push({ title: "Sonarr Calendar", id: "calendar_sonarr" })
-                end if
-                if normalizeBoolSettingValue(getUserSettingValue("calendar.merge", false))
-                    filteredOptions.push({ title: "Merged Calendar", id: "calendar_merged" })
                 end if
 
                 radioOptions = filteredOptions

--- a/settings/settings.json
+++ b/settings/settings.json
@@ -1255,6 +1255,206 @@
             "children": []
           }
         ]
+      },
+      {
+        "title": "External Lists",
+        "description": "Configure IMDb, TMDB, and Seerr lists.",
+        "icon": "external_lists.png",
+        "children": [
+          {
+            "title": "IMDb Lists",
+            "description": "Configure IMDb Top 250, Popular, and other charts.",
+            "children": [
+              {
+                "title": "IMDb Top 250 Movies",
+                "description": "Show IMDb Top 250 Movies on the Home Screen",
+                "settingName": "imdb.top250movies",
+                "type": "bool",
+                "default": "false"
+              },
+              {
+                "title": "IMDb Top 250 TV Shows",
+                "description": "Show IMDb Top 250 TV Shows on the Home Screen",
+                "settingName": "imdb.top250tvshows",
+                "type": "bool",
+                "default": "false"
+              },
+              {
+                "title": "IMDb Most Popular Movies",
+                "description": "Show IMDb Most Popular Movies on the Home Screen",
+                "settingName": "imdb.mostpopularmovies",
+                "type": "bool",
+                "default": "false"
+              },
+              {
+                "title": "IMDb Most Popular TV Shows",
+                "description": "Show IMDb Most Popular TV Shows on the Home Screen",
+                "settingName": "imdb.mostpopulartvshows",
+                "type": "bool",
+                "default": "false"
+              },
+              {
+                "title": "IMDb Lowest Rated Movies",
+                "description": "Show IMDb Lowest Rated Movies on the Home Screen",
+                "settingName": "imdb.lowestratedmovies",
+                "type": "bool",
+                "default": "false"
+              },
+              {
+                "title": "IMDb Top English Movies",
+                "description": "Show IMDb Top English Movies on the Home Screen",
+                "settingName": "imdb.topenglishmovies",
+                "type": "bool",
+                "default": "false"
+              }
+            ]
+          },
+          {
+            "title": "TMDB Lists",
+            "description": "Configure TMDB Popular, Trending, and other charts.",
+            "children": [
+              {
+                "title": "TMDB Popular Movies",
+                "description": "Show TMDB Popular Movies on the Home Screen",
+                "settingName": "tmdb.popularmovies",
+                "type": "bool",
+                "default": "false"
+              },
+              {
+                "title": "TMDB Top Rated Movies",
+                "description": "Show TMDB Top Rated Movies on the Home Screen",
+                "settingName": "tmdb.topratedmovies",
+                "type": "bool",
+                "default": "false"
+              },
+              {
+                "title": "TMDB Now Playing Movies",
+                "description": "Show TMDB Now Playing Movies on the Home Screen",
+                "settingName": "tmdb.nowplayingmovies",
+                "type": "bool",
+                "default": "false"
+              },
+              {
+                "title": "TMDB Upcoming Movies",
+                "description": "Show TMDB Upcoming Movies on the Home Screen",
+                "settingName": "tmdb.upcomingmovies",
+                "type": "bool",
+                "default": "false"
+              },
+              {
+                "title": "TMDB Popular TV",
+                "description": "Show TMDB Popular TV on the Home Screen",
+                "settingName": "tmdb.populartv",
+                "type": "bool",
+                "default": "false"
+              },
+              {
+                "title": "TMDB Top Rated TV",
+                "description": "Show TMDB Top Rated TV on the Home Screen",
+                "settingName": "tmdb.topratedtv",
+                "type": "bool",
+                "default": "false"
+              },
+              {
+                "title": "TMDB Airing Today TV",
+                "description": "Show TMDB Airing Today TV on the Home Screen",
+                "settingName": "tmdb.airingtodaytv",
+                "type": "bool",
+                "default": "false"
+              },
+              {
+                "title": "TMDB On The Air TV",
+                "description": "Show TMDB On The Air TV on the Home Screen",
+                "settingName": "tmdb.ontheairtv",
+                "type": "bool",
+                "default": "false"
+              },
+              {
+                "title": "TMDB Trending Movie Daily",
+                "description": "Show TMDB Trending Movie Daily on the Home Screen",
+                "settingName": "tmdb.trendingmoviedaily",
+                "type": "bool",
+                "default": "false"
+              },
+              {
+                "title": "TMDB Trending Movie Weekly",
+                "description": "Show TMDB Trending Movie Weekly on the Home Screen",
+                "settingName": "tmdb.trendingmovieweekly",
+                "type": "bool",
+                "default": "false"
+              },
+              {
+                "title": "TMDB Trending TV Daily",
+                "description": "Show TMDB Trending TV Daily on the Home Screen",
+                "settingName": "tmdb.trendingtvdaily",
+                "type": "bool",
+                "default": "false"
+              },
+              {
+                "title": "TMDB Trending TV Weekly",
+                "description": "Show TMDB Trending TV Weekly on the Home Screen",
+                "settingName": "tmdb.trendingtvweekly",
+                "type": "bool",
+                "default": "false"
+              },
+              {
+                "title": "TMDB Trending All Weekly",
+                "description": "Show TMDB Trending All Weekly on the Home Screen",
+                "settingName": "tmdb.trendingallweekly",
+                "type": "bool",
+                "default": "false"
+              }
+            ]
+          },
+          {
+            "title": "Seerr Lists",
+            "description": "Configure Seerr Discovery Rows.",
+            "children": [
+              {
+                "title": "Trending Movies",
+                "description": "Show Seerr Trending Movies on the Home Screen",
+                "settingName": "seerr.row.trending_movies",
+                "type": "bool",
+                "default": "true"
+              },
+              {
+                "title": "Trending TV",
+                "description": "Show Seerr Trending TV on the Home Screen",
+                "settingName": "seerr.row.trending_tv",
+                "type": "bool",
+                "default": "true"
+              },
+              {
+                "title": "Popular Movies",
+                "description": "Show Seerr Popular Movies on the Home Screen",
+                "settingName": "seerr.row.popular_movies",
+                "type": "bool",
+                "default": "true"
+              },
+              {
+                "title": "Popular TV",
+                "description": "Show Seerr Popular TV on the Home Screen",
+                "settingName": "seerr.row.popular_tv",
+                "type": "bool",
+                "default": "true"
+              },
+              {
+                "title": "Upcoming Movies",
+                "description": "Show Seerr Upcoming Movies on the Home Screen",
+                "settingName": "seerr.row.upcoming_movies",
+                "type": "bool",
+                "default": "true"
+              },
+              {
+                "title": "Upcoming TV",
+                "description": "Show Seerr Upcoming TV on the Home Screen",
+                "settingName": "seerr.row.upcoming_tv",
+                "type": "bool",
+                "default": "true"
+              }
+            ]
+          }
+        ]
       }
     ]
   },

--- a/settings/settings.json
+++ b/settings/settings.json
@@ -1453,6 +1453,75 @@
                 "default": "true"
               }
             ]
+          },
+          {
+            "title": "Upcoming Calendars",
+            "description": "Configure upcoming release calendars from Radarr and Sonarr.",
+            "children": [
+              {
+                "title": "Enable Radarr Calendar",
+                "description": "Show upcoming movies from Radarr on the Home Screen",
+                "settingName": "calendar.radarr.enabled",
+                "type": "bool",
+                "default": "false"
+              },
+              {
+                "title": "Radarr Show Cinema Releases",
+                "description": "Show cinema releases in the Radarr calendar",
+                "settingName": "calendar.radarr.showCinema",
+                "type": "bool",
+                "default": "true"
+              },
+              {
+                "title": "Radarr Show Digital Releases",
+                "description": "Show digital/streaming releases in the Radarr calendar",
+                "settingName": "calendar.radarr.showDigital",
+                "type": "bool",
+                "default": "true"
+              },
+              {
+                "title": "Radarr Show Physical Releases",
+                "description": "Show physical media releases in the Radarr calendar",
+                "settingName": "calendar.radarr.showPhysical",
+                "type": "bool",
+                "default": "true"
+              },
+              {
+                "title": "Radarr Show Release Dates",
+                "description": "Show release date tags in the Radarr calendar items",
+                "settingName": "calendar.radarr.showDate",
+                "type": "bool",
+                "default": "true"
+              },
+              {
+                "title": "Enable Sonarr Calendar",
+                "description": "Show upcoming TV shows from Sonarr on the Home Screen",
+                "settingName": "calendar.sonarr.enabled",
+                "type": "bool",
+                "default": "false"
+              },
+              {
+                "title": "Sonarr Show Episode Info",
+                "description": "Show season and episode numbers in the Sonarr calendar",
+                "settingName": "calendar.sonarr.showEpisodeInfo",
+                "type": "bool",
+                "default": "true"
+              },
+              {
+                "title": "Sonarr Show Air Dates",
+                "description": "Show air dates in the Sonarr calendar items",
+                "settingName": "calendar.sonarr.showDate",
+                "type": "bool",
+                "default": "true"
+              },
+              {
+                "title": "Merge Radarr/Sonarr Calendars",
+                "description": "Merge Radarr and Sonarr calendars into a single row on the Home Screen",
+                "settingName": "calendar.merge",
+                "type": "bool",
+                "default": "false"
+              }
+            ]
           }
         ]
       }

--- a/settings/settings.json
+++ b/settings/settings.json
@@ -1259,7 +1259,7 @@
       {
         "title": "External Lists",
         "description": "Configure IMDb, TMDB, and Seerr lists.",
-        "icon": "external_lists.png",
+        "icon": "dynamiccontent.png",
         "children": [
           {
             "title": "IMDb Lists",

--- a/source/utils/settingsSync.bs
+++ b/source/utils/settingsSync.bs
@@ -84,7 +84,17 @@ namespace settingsSync
             { pluginKey: "tmdbTrendingMovieWeeklyEnabled", rokuKey: "tmdb.trendingmovieweekly", type: "bool" },
             { pluginKey: "tmdbTrendingTvDailyEnabled", rokuKey: "tmdb.trendingtvdaily", type: "bool" },
             { pluginKey: "tmdbTrendingTvWeeklyEnabled", rokuKey: "tmdb.trendingtvweekly", type: "bool" },
-            { pluginKey: "tmdbTrendingAllWeeklyEnabled", rokuKey: "tmdb.trendingallweekly", type: "bool" }
+            { pluginKey: "tmdbTrendingAllWeeklyEnabled", rokuKey: "tmdb.trendingallweekly", type: "bool" },
+
+            { pluginKey: "enableRadarrCalendar", rokuKey: "calendar.radarr.enabled", type: "bool" },
+            { pluginKey: "radarrCalendarShowCinema", rokuKey: "calendar.radarr.showCinema", type: "bool" },
+            { pluginKey: "radarrCalendarShowDigital", rokuKey: "calendar.radarr.showDigital", type: "bool" },
+            { pluginKey: "radarrCalendarShowPhysical", rokuKey: "calendar.radarr.showPhysical", type: "bool" },
+            { pluginKey: "radarrCalendarShowDate", rokuKey: "calendar.radarr.showDate", type: "bool" },
+            { pluginKey: "enableSonarrCalendar", rokuKey: "calendar.sonarr.enabled", type: "bool" },
+            { pluginKey: "sonarrCalendarShowEpisodeInfo", rokuKey: "calendar.sonarr.showEpisodeInfo", type: "bool" },
+            { pluginKey: "sonarrCalendarShowDate", rokuKey: "calendar.sonarr.showDate", type: "bool" },
+            { pluginKey: "mergeRadarrSonarrCalendars", rokuKey: "calendar.merge", type: "bool" }
         ]
     end function
 

--- a/source/utils/settingsSync.bs
+++ b/source/utils/settingsSync.bs
@@ -130,12 +130,12 @@ namespace settingsSync
 
         if isValid(profile.seerrRows)
             seerrRows = profile.seerrRows
-            tmpSettings["seerr.row.trending_movies"] = (seerrRows.trendingMovies = true or seerrRows.trendingMovies = "true") ? "true" : "false"
-            tmpSettings["seerr.row.trending_tv"] = (seerrRows.trendingTv = true or seerrRows.trendingTv = "true") ? "true" : "false"
-            tmpSettings["seerr.row.popular_movies"] = (seerrRows.popularMovies = true or seerrRows.popularMovies = "true") ? "true" : "false"
-            tmpSettings["seerr.row.popular_tv"] = (seerrRows.popularTv = true or seerrRows.popularTv = "true") ? "true" : "false"
-            tmpSettings["seerr.row.upcoming_movies"] = (seerrRows.upcomingMovies = true or seerrRows.upcomingMovies = "true") ? "true" : "false"
-            tmpSettings["seerr.row.upcoming_tv"] = (seerrRows.upcomingTv = true or seerrRows.upcomingTv = "true") ? "true" : "false"
+            tmpSettings["seerr.row.trending_movies"] = toBoolean(seerrRows.trendingMovies) ? "true" : "false"
+            tmpSettings["seerr.row.trending_tv"] = toBoolean(seerrRows.trendingTv) ? "true" : "false"
+            tmpSettings["seerr.row.popular_movies"] = toBoolean(seerrRows.popularMovies) ? "true" : "false"
+            tmpSettings["seerr.row.popular_tv"] = toBoolean(seerrRows.popularTv) ? "true" : "false"
+            tmpSettings["seerr.row.upcoming_movies"] = toBoolean(seerrRows.upcomingMovies) ? "true" : "false"
+            tmpSettings["seerr.row.upcoming_tv"] = toBoolean(seerrRows.upcomingTv) ? "true" : "false"
             
             for each key in ["seerr.row.trending_movies", "seerr.row.trending_tv", "seerr.row.popular_movies", "seerr.row.popular_tv", "seerr.row.upcoming_movies", "seerr.row.upcoming_tv"]
                 registry_write(key, tmpSettings[key], m.global.session.user.id)
@@ -241,7 +241,7 @@ namespace settingsSync
     function GetSeerrRowValue(key as string, defaultValue = true as boolean) as boolean
         userSettings = m.global.session.user.settings
         if isValid(userSettings) and isValid(userSettings[key])
-            return (userSettings[key] = "true" or userSettings[key] = true)
+            return toBoolean(userSettings[key])
         end if
         regVal = registry_read(key, m.global.session.user.id)
         if isValid(regVal)

--- a/source/utils/settingsSync.bs
+++ b/source/utils/settingsSync.bs
@@ -63,7 +63,28 @@ namespace settingsSync
             { pluginKey: "rewatchSortBy", rokuKey: "ui.home.rewatchSortBy", type: "direct" },
             { pluginKey: "rewatchIncludeMovies", rokuKey: "ui.home.rewatchIncludeMovies", type: "bool" },
             { pluginKey: "rewatchIncludeShows", rokuKey: "ui.home.rewatchIncludeShows", type: "bool" },
-            { pluginKey: "rewatchIncludeCollections", rokuKey: "ui.home.rewatchIncludeCollections", type: "bool" }
+            { pluginKey: "rewatchIncludeCollections", rokuKey: "ui.home.rewatchIncludeCollections", type: "bool" },
+
+            { pluginKey: "imdbTop250MoviesEnabled", rokuKey: "imdb.top250movies", type: "bool" },
+            { pluginKey: "imdbTop250TvShowsEnabled", rokuKey: "imdb.top250tvshows", type: "bool" },
+            { pluginKey: "imdbMostPopularMoviesEnabled", rokuKey: "imdb.mostpopularmovies", type: "bool" },
+            { pluginKey: "imdbMostPopularTvShowsEnabled", rokuKey: "imdb.mostpopulartvshows", type: "bool" },
+            { pluginKey: "imdbLowestRatedMoviesEnabled", rokuKey: "imdb.lowestratedmovies", type: "bool" },
+            { pluginKey: "imdbTopEnglishMoviesEnabled", rokuKey: "imdb.topenglishmovies", type: "bool" },
+
+            { pluginKey: "tmdbPopularMoviesEnabled", rokuKey: "tmdb.popularmovies", type: "bool" },
+            { pluginKey: "tmdbTopRatedMoviesEnabled", rokuKey: "tmdb.topratedmovies", type: "bool" },
+            { pluginKey: "tmdbNowPlayingMoviesEnabled", rokuKey: "tmdb.nowplayingmovies", type: "bool" },
+            { pluginKey: "tmdbUpcomingMoviesEnabled", rokuKey: "tmdb.upcomingmovies", type: "bool" },
+            { pluginKey: "tmdbPopularTvEnabled", rokuKey: "tmdb.populartv", type: "bool" },
+            { pluginKey: "tmdbTopRatedTvEnabled", rokuKey: "tmdb.topratedtv", type: "bool" },
+            { pluginKey: "tmdbAiringTodayTvEnabled", rokuKey: "tmdb.airingtodaytv", type: "bool" },
+            { pluginKey: "tmdbOnTheAirTvEnabled", rokuKey: "tmdb.ontheairtv", type: "bool" },
+            { pluginKey: "tmdbTrendingMovieDailyEnabled", rokuKey: "tmdb.trendingmoviedaily", type: "bool" },
+            { pluginKey: "tmdbTrendingMovieWeeklyEnabled", rokuKey: "tmdb.trendingmovieweekly", type: "bool" },
+            { pluginKey: "tmdbTrendingTvDailyEnabled", rokuKey: "tmdb.trendingtvdaily", type: "bool" },
+            { pluginKey: "tmdbTrendingTvWeeklyEnabled", rokuKey: "tmdb.trendingtvweekly", type: "bool" },
+            { pluginKey: "tmdbTrendingAllWeeklyEnabled", rokuKey: "tmdb.trendingallweekly", type: "bool" }
         ]
     end function
 
@@ -97,6 +118,20 @@ namespace settingsSync
             end if
         end for
 
+        if isValid(profile.seerrRows)
+            seerrRows = profile.seerrRows
+            tmpSettings["seerr.row.trending_movies"] = (seerrRows.trendingMovies = true or seerrRows.trendingMovies = "true") ? "true" : "false"
+            tmpSettings["seerr.row.trending_tv"] = (seerrRows.trendingTv = true or seerrRows.trendingTv = "true") ? "true" : "false"
+            tmpSettings["seerr.row.popular_movies"] = (seerrRows.popularMovies = true or seerrRows.popularMovies = "true") ? "true" : "false"
+            tmpSettings["seerr.row.popular_tv"] = (seerrRows.popularTv = true or seerrRows.popularTv = "true") ? "true" : "false"
+            tmpSettings["seerr.row.upcoming_movies"] = (seerrRows.upcomingMovies = true or seerrRows.upcomingMovies = "true") ? "true" : "false"
+            tmpSettings["seerr.row.upcoming_tv"] = (seerrRows.upcomingTv = true or seerrRows.upcomingTv = "true") ? "true" : "false"
+            
+            for each key in ["seerr.row.trending_movies", "seerr.row.trending_tv", "seerr.row.popular_movies", "seerr.row.popular_tv", "seerr.row.upcoming_movies", "seerr.row.upcoming_tv"]
+                registry_write(key, tmpSettings[key], m.global.session.user.id)
+            end for
+        end if
+
         shouldFetchResolvedRows = toBoolean(chainLookupReturn(tmpSettings, "homeRows.useServerConfig", false))
         if shouldFetchResolvedRows
             resolvedHomeRows = settingsSync.FetchResolvedHomeRows("tv")
@@ -121,7 +156,18 @@ namespace settingsSync
         if not settingsSync.IsSyncEnabled() then return
 
         mapping = settingsSync.FindMappingByRokuKey(rokuKey)
-        if not isValid(mapping) then return
+        if not isValid(mapping)
+            if Left(rokuKey, 10) = "seerr.row."
+                pushData = settingsSync.PreparePush(rokuKey, rokuValue)
+                if isValid(pushData)
+                    task = createObject("roSGNode", "PostTask")
+                    task.apiUrl = pushData.url
+                    task.stringData = pushData.body
+                    task.control = "RUN"
+                end if
+            end if
+            return
+        end if
 
         pluginValue = settingsSync.RokuToPlugin(rokuValue, mapping.type)
         if not isValid(pluginValue) then return
@@ -135,6 +181,34 @@ namespace settingsSync
     ' Prepare settings sync push data without making HTTP requests (render-thread safe).
     function PreparePush(rokuKey as string, rokuValue as dynamic) as dynamic
         if not settingsSync.IsSyncEnabled() then return invalid
+
+        if Left(rokuKey, 10) = "seerr.row."
+            seerrRows = {
+                trendingMovies: settingsSync.GetSeerrRowValue("seerr.row.trending_movies", true),
+                trendingTv: settingsSync.GetSeerrRowValue("seerr.row.trending_tv", true),
+                popularMovies: settingsSync.GetSeerrRowValue("seerr.row.popular_movies", true),
+                popularTv: settingsSync.GetSeerrRowValue("seerr.row.popular_tv", true),
+                upcomingMovies: settingsSync.GetSeerrRowValue("seerr.row.upcoming_movies", true),
+                upcomingTv: settingsSync.GetSeerrRowValue("seerr.row.upcoming_tv", true)
+            }
+            
+            localKey = rokuKey.mid(10)
+            targetBool = (rokuValue = "true" or rokuValue = true)
+            if localKey = "trending_movies" then seerrRows.trendingMovies = targetBool
+            if localKey = "trending_tv" then seerrRows.trendingTv = targetBool
+            if localKey = "popular_movies" then seerrRows.popularMovies = targetBool
+            if localKey = "popular_tv" then seerrRows.popularTv = targetBool
+            if localKey = "upcoming_movies" then seerrRows.upcomingMovies = targetBool
+            if localKey = "upcoming_tv" then seerrRows.upcomingTv = targetBool
+
+            return {
+                url: "/Moonfin/Settings/Profile/tv",
+                body: FormatJson({
+                    profile: { seerrRows: seerrRows },
+                    clientId: "roku"
+                })
+            }
+        end if
 
         mapping = settingsSync.FindMappingByRokuKey(rokuKey)
         if not isValid(mapping) then return invalid
@@ -152,6 +226,18 @@ namespace settingsSync
                 clientId: "roku"
             })
         }
+    end function
+
+    function GetSeerrRowValue(key as string, defaultValue = true as boolean) as boolean
+        userSettings = m.global.session.user.settings
+        if isValid(userSettings) and isValid(userSettings[key])
+            return (userSettings[key] = "true" or userSettings[key] = true)
+        end if
+        regVal = registry_read(key, m.global.session.user.id)
+        if isValid(regVal)
+            return (regVal = "true")
+        end if
+        return defaultValue
     end function
 
     function FindMappingByRokuKey(rokuKey as string) as object

--- a/source/utils/settingsSync.bs
+++ b/source/utils/settingsSync.bs
@@ -129,16 +129,16 @@ namespace settingsSync
         end for
 
         if isValid(profile.seerrRows)
-            seerrRows = profile.seerrRows
-            tmpSettings["seerr.row.trending_movies"] = toBoolean(seerrRows.trendingMovies) ? "true" : "false"
-            tmpSettings["seerr.row.trending_tv"] = toBoolean(seerrRows.trendingTv) ? "true" : "false"
-            tmpSettings["seerr.row.popular_movies"] = toBoolean(seerrRows.popularMovies) ? "true" : "false"
-            tmpSettings["seerr.row.popular_tv"] = toBoolean(seerrRows.popularTv) ? "true" : "false"
-            tmpSettings["seerr.row.upcoming_movies"] = toBoolean(seerrRows.upcomingMovies) ? "true" : "false"
-            tmpSettings["seerr.row.upcoming_tv"] = toBoolean(seerrRows.upcomingTv) ? "true" : "false"
-            
-            for each key in ["seerr.row.trending_movies", "seerr.row.trending_tv", "seerr.row.popular_movies", "seerr.row.popular_tv", "seerr.row.upcoming_movies", "seerr.row.upcoming_tv"]
-                registry_write(key, tmpSettings[key], m.global.session.user.id)
+            ' The server can omit individual flags, so leave those settings at their current value
+            for each rowMapping in settingsSync.GetSeerrRowMappings()
+                pluginValue = profile.seerrRows[rowMapping.pluginKey]
+                if not isValid(pluginValue) then continue for
+
+                rokuValue = settingsSync.PluginToRoku(pluginValue, "bool")
+                if not isValid(rokuValue) then continue for
+
+                tmpSettings[rowMapping.rokuKey] = rokuValue
+                registry_write(rowMapping.rokuKey, rokuValue, m.global.session.user.id)
             end for
         end if
 
@@ -193,23 +193,17 @@ namespace settingsSync
         if not settingsSync.IsSyncEnabled() then return invalid
 
         if Left(rokuKey, 10) = "seerr.row."
-            seerrRows = {
-                trendingMovies: settingsSync.GetSeerrRowValue("seerr.row.trending_movies", true),
-                trendingTv: settingsSync.GetSeerrRowValue("seerr.row.trending_tv", true),
-                popularMovies: settingsSync.GetSeerrRowValue("seerr.row.popular_movies", true),
-                popularTv: settingsSync.GetSeerrRowValue("seerr.row.popular_tv", true),
-                upcomingMovies: settingsSync.GetSeerrRowValue("seerr.row.upcoming_movies", true),
-                upcomingTv: settingsSync.GetSeerrRowValue("seerr.row.upcoming_tv", true)
-            }
-            
-            localKey = rokuKey.mid(10)
+            ' The server expects the whole seerrRows object, so send the other flags alongside this one
+            seerrRows = {}
             targetBool = (rokuValue = "true" or rokuValue = true)
-            if localKey = "trending_movies" then seerrRows.trendingMovies = targetBool
-            if localKey = "trending_tv" then seerrRows.trendingTv = targetBool
-            if localKey = "popular_movies" then seerrRows.popularMovies = targetBool
-            if localKey = "popular_tv" then seerrRows.popularTv = targetBool
-            if localKey = "upcoming_movies" then seerrRows.upcomingMovies = targetBool
-            if localKey = "upcoming_tv" then seerrRows.upcomingTv = targetBool
+
+            for each rowMapping in settingsSync.GetSeerrRowMappings()
+                if rowMapping.rokuKey = rokuKey
+                    seerrRows[rowMapping.pluginKey] = targetBool
+                else
+                    seerrRows[rowMapping.pluginKey] = settingsSync.GetSeerrRowValue(rowMapping.rokuKey, true)
+                end if
+            end for
 
             return {
                 url: "/Moonfin/Settings/Profile/tv",
@@ -238,15 +232,40 @@ namespace settingsSync
         }
     end function
 
+    ' Seerr row flags live in a nested seerrRows object on the server, so they can't use
+    ' the flat mapping table that GetMappings covers
+    function GetSeerrRowMappings() as object
+        return [
+            { rokuKey: "seerr.row.trending_movies", pluginKey: "trendingMovies" },
+            { rokuKey: "seerr.row.trending_tv", pluginKey: "trendingTv" },
+            { rokuKey: "seerr.row.popular_movies", pluginKey: "popularMovies" },
+            { rokuKey: "seerr.row.popular_tv", pluginKey: "popularTv" },
+            { rokuKey: "seerr.row.upcoming_movies", pluginKey: "upcomingMovies" },
+            { rokuKey: "seerr.row.upcoming_tv", pluginKey: "upcomingTv" }
+        ]
+    end function
+
     function GetSeerrRowValue(key as string, defaultValue = true as boolean) as boolean
         userSettings = m.global.session.user.settings
         if isValid(userSettings) and isValid(userSettings[key])
-            return toBoolean(userSettings[key])
+            return settingsSync.ToBooleanValue(userSettings[key], defaultValue)
         end if
         regVal = registry_read(key, m.global.session.user.id)
         if isValid(regVal)
-            return (regVal = "true")
+            return settingsSync.ToBooleanValue(regVal, defaultValue)
         end if
+        return defaultValue
+    end function
+
+    ' Coerces a stored setting into a real boolean. Settings arrive as either "true"/"false"
+    ' strings or actual booleans depending on where they were written
+    function ToBooleanValue(value as dynamic, defaultValue = false as boolean) as boolean
+        if not isValid(value) then return defaultValue
+
+        valueType = type(value)
+        if valueType = "Boolean" or valueType = "roBoolean" then return value
+        if valueType = "String" or valueType = "roString" then return LCase(value) = "true"
+
         return defaultValue
     end function
 


### PR DESCRIPTION
# Pull Request

## Summary
Add support for custom dynamic home screen rows to Roku. Ported TMDb charts, Seerr rows, and custom Letterboxd/MDBList lists resolved by the server plugin to the Roku client app. Add "External Lists" settings (IMDb, TMDB, Seerr lists, and Upcoming Calendars) with bi-directional server synchronization.

## Related Issues
Link related issues or tickets separated by commas.

- Closes #123
- Closes #132 
- Fixes # 
- Related to #

## Type of Change
- [ ] Bug fix
- [X] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

- Added support in **LoadItemsTask.xml** and **LoadItemsTask.bs** to dynamically fetch and process TMDb, Seerr, and custom plugin-dynamic rows.
- Implemented row creation and asynchronous SceneGraph rendering in **HomeRows.bs** for these custom server rows.
- Added an **External Lists** settings subpage menu in **settings.json** containing toggles for IMDb Lists, TMDB Lists, Seerr Lists, and Upcoming Calendars.
- Added bi-directional server-side synchronization for the new settings and nested `seerrRows` config in **settingsSync.bs**.
## Testing
Describe how this change was tested.

- [ ] Tested on physical Roku device
- [ ] Tested via sideload
- [ ] Manual testing completed
- [X] Not tested (explain why): To be tested by Jenn later today.

### Test Steps
1. Built the project via `npm run build` and sideloaded the output zip.
2. Navigated to Settings -> Moonfin Settings -> External Lists and verified that IMDb, TMDB, Seerr, and Upcoming Calendars submenus render successfully.
3. Toggled various lists and calendars, and verified that settings sync bi-directionally with the backend settings profile.
4. Verified that the custom rows load, render titles, and show item posters correctly on the Home screen.

## Screenshots (if applicable)
Include screenshots or recordings for UI changes.

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
