### PR TITLE
feat(ui): port modern details background opacity slider to Roku

### DIFF
--- a/components/details/ModernItemDetails.bs
+++ b/components/details/ModernItemDetails.bs
@@ -950,16 +950,16 @@ sub updateBackdropOpacity(itemData as object)
 
     ' Calculate overlays
     isPerson = (isValid(itemData) and itemData.type = "Person")
-    maxScrimOpacity = isPerson ? 0.15 : 0.28
+    maxScrimOpacity = isPerson ? 0.40 : 0.80
     
     backdropScrim.opacity = maxScrimOpacity * opacityFactor
 
     gradientScale = 0.3 + 0.7 * opacityFactor
     if isValid(backdropLeftScrim)
-        backdropLeftScrim.opacity = 1.0 * gradientScale
+        backdropLeftScrim.opacity = gradientScale
     end if
     if isValid(backdropBottomScrim)
-        backdropBottomScrim.opacity = 0.85 * gradientScale
+        backdropBottomScrim.opacity = gradientScale
     end if
 end sub
 

--- a/components/details/ModernItemDetails.bs
+++ b/components/details/ModernItemDetails.bs
@@ -923,6 +923,44 @@ sub setBackdropImage(itemData as object)
     if isValid(backdropUrl)
         backdropPoster.uri = backdropUrl
     end if
+
+    updateBackdropOpacity(itemData)
+end sub
+
+sub updateBackdropOpacity(itemData as object)
+    backdropScrim = m.top.findNode("backdropScrim")
+    backdropLeftScrim = m.top.findNode("backdropLeftScrim")
+    backdropBottomScrim = m.top.findNode("backdropBottomScrim")
+
+    if not isValid(backdropScrim) then return
+
+    ' Read opacity setting (default is 10)
+    blurAmount = 10
+    if isValid(m.global.session) and isValid(m.global.session.user) and isValid(m.global.session.user.settings)
+        blurSetting = m.global.session.user.settings["ui.backdrop.detailBlurAmount"]
+        if isValid(blurSetting)
+            blurVal = val(blurSetting)
+            if blurVal >= 0 and blurVal <= 25
+                blurAmount = blurVal
+            end if
+        end if
+    end if
+
+    opacityFactor = blurAmount / 25.0
+
+    ' Calculate overlays
+    isPerson = (isValid(itemData) and itemData.type = "Person")
+    maxScrimOpacity = isPerson ? 0.15 : 0.28
+    
+    backdropScrim.opacity = maxScrimOpacity * opacityFactor
+
+    gradientScale = 0.3 + 0.7 * opacityFactor
+    if isValid(backdropLeftScrim)
+        backdropLeftScrim.opacity = 1.0 * gradientScale
+    end if
+    if isValid(backdropBottomScrim)
+        backdropBottomScrim.opacity = 0.85 * gradientScale
+    end if
 end sub
 
 ' ============================================

--- a/components/details/ModernItemDetails.bs
+++ b/components/details/ModernItemDetails.bs
@@ -652,6 +652,9 @@ sub onShuffleEpisodeDataLoaded()
 end sub
 
 sub OnScreenShown(_isReturning = false as boolean)
+    ' Runs on first show and on return, so a change made in settings is picked up either way
+    updateBackdropOpacity()
+
     if _isReturning and isValid(m.top.lastFocus)
         m.top.lastFocus.setFocus(true)
         setLastFocus(m.top.lastFocus)
@@ -923,41 +926,27 @@ sub setBackdropImage(itemData as object)
     if isValid(backdropUrl)
         backdropPoster.uri = backdropUrl
     end if
-
-    updateBackdropOpacity(itemData)
 end sub
 
-sub updateBackdropOpacity(itemData as object)
+' The modern screen skips the server-side blur and instead reuses ui.backdrop.detailBlurAmount
+' to scale its backdrop scrim and edge gradients. The factors below match the Moonfin core
+' client so a given value renders the same backdrop on both.
+sub updateBackdropOpacity()
     backdropScrim = m.top.findNode("backdropScrim")
-    backdropLeftScrim = m.top.findNode("backdropLeftScrim")
-    backdropBottomScrim = m.top.findNode("backdropBottomScrim")
-
     if not isValid(backdropScrim) then return
 
-    ' Read opacity setting (default is 10)
-    blurAmount = 10
-    if isValid(m.global.session) and isValid(m.global.session.user) and isValid(m.global.session.user.settings)
-        blurSetting = m.global.session.user.settings["ui.backdrop.detailBlurAmount"]
-        if isValid(blurSetting)
-            blurVal = val(blurSetting)
-            if blurVal >= 0 and blurVal <= 25
-                blurAmount = blurVal
-            end if
-        end if
-    end if
+    opacityFactor = getBackdropBlurAmount() / 25.0
 
-    opacityFactor = blurAmount / 25.0
-
-    ' Calculate overlays
-    isPerson = (isValid(itemData) and itemData.type = "Person")
-    maxScrimOpacity = isPerson ? 0.40 : 0.80
-    
-    backdropScrim.opacity = maxScrimOpacity * opacityFactor
+    backdropScrim.opacity = 0.80 * opacityFactor
 
     gradientScale = 0.3 + 0.7 * opacityFactor
+
+    backdropLeftScrim = m.top.findNode("backdropLeftScrim")
     if isValid(backdropLeftScrim)
         backdropLeftScrim.opacity = gradientScale
     end if
+
+    backdropBottomScrim = m.top.findNode("backdropBottomScrim")
     if isValid(backdropBottomScrim)
         backdropBottomScrim.opacity = gradientScale
     end if

--- a/components/settings/settings.bs
+++ b/components/settings/settings.bs
@@ -1616,6 +1616,7 @@ sub LoadMenu(configSection, appendPath = true as boolean)
         settingsArray = []
 
         for each item in configSection.children
+            adjustDetailsBackdropBlurItem(item)
             settingsArray.push(item)
         end for
 
@@ -2126,4 +2127,35 @@ sub onDonationDialogClosed(_obj as object)
 
     ' Return focus to settings menu
     m.settingsMenu.setFocus(true)
+end sub
+
+sub adjustDetailsBackdropBlurItem(item as dynamic)
+    if not isValid(item) or not isStringEqual(item.settingName, "ui.backdrop.detailBlurAmount")
+        return
+    end if
+
+    detailStyle = LCase(dynamicToDisplayString(getUserSettingValue("ui.itemdetail.style", "modern")))
+    if detailStyle = "modern"
+        item.title = "Details Background Opacity"
+        item.description = "Control the opacity of the backdrop overlay and screen gradients on modern detail screens."
+        item.options = [
+            { title: "0%", id: "0" },
+            { title: "20%", id: "5" },
+            { title: "40%", id: "10" },
+            { title: "60%", id: "15" },
+            { title: "80%", id: "20" },
+            { title: "100%", id: "25" }
+        ]
+    else
+        item.title = "Detail Screen Backdrop Blur"
+        item.description = "Control the blur effect for movie, TV show, and episode detail screens. Higher values create a more frosted glass effect."
+        item.options = [
+            { title: "No Blur", id: "0" },
+            { title: "Light (5)", id: "5" },
+            { title: "Medium (10)", id: "10" },
+            { title: "Heavy (15)", id: "15" },
+            { title: "Very Heavy (20)", id: "20" },
+            { title: "Maximum (25)", id: "25" }
+        ]
+    end if
 end sub

--- a/components/settings/settings.bs
+++ b/components/settings/settings.bs
@@ -2129,33 +2129,37 @@ sub onDonationDialogClosed(_obj as object)
     m.settingsMenu.setFocus(true)
 end sub
 
+' Classic reads ui.backdrop.detailBlurAmount as a blur radius and modern reads it as backdrop
+' scrim strength, so the menu entry is retitled to suit whichever screen the user picked.
 sub adjustDetailsBackdropBlurItem(item as dynamic)
-    if not isValid(item) or not isStringEqual(item.settingName, "ui.backdrop.detailBlurAmount")
+    if not isValid(item) or not isStringEqual(chainLookupReturn(item, "settingName", ""), "ui.backdrop.detailBlurAmount")
         return
     end if
 
-    detailStyle = LCase(dynamicToDisplayString(getUserSettingValue("ui.itemdetail.style", "modern")))
-    if detailStyle = "modern"
-        item.title = "Details Background Opacity"
-        item.description = "Control the opacity of the backdrop overlay and screen gradients on modern detail screens."
-        item.options = [
-            { title: "0%", id: "0" },
-            { title: "20%", id: "5" },
-            { title: "40%", id: "10" },
-            { title: "60%", id: "15" },
-            { title: "80%", id: "20" },
-            { title: "100%", id: "25" }
-        ]
-    else
-        item.title = "Detail Screen Backdrop Blur"
-        item.description = "Control the blur effect for movie, TV show, and episode detail screens. Higher values create a more frosted glass effect."
-        item.options = [
-            { title: "No Blur", id: "0" },
-            { title: "Light (5)", id: "5" },
-            { title: "Medium (10)", id: "10" },
-            { title: "Heavy (15)", id: "15" },
-            { title: "Very Heavy (20)", id: "20" },
-            { title: "Maximum (25)", id: "25" }
-        ]
+    ' Remember what settings.json shipped so the classic wording can be restored
+    if not isValid(m.detailBlurItemDefaults)
+        m.detailBlurItemDefaults = {
+            title: item.title,
+            description: item.description,
+            options: item.options
+        }
     end if
+
+    if not isStringEqual(dynamicToDisplayString(getUserSettingValue("ui.itemdetail.style", "modern")), "modern")
+        item.title = m.detailBlurItemDefaults.title
+        item.description = m.detailBlurItemDefaults.description
+        item.options = m.detailBlurItemDefaults.options
+        return
+    end if
+
+    item.title = "Details Background Opacity"
+    item.description = "Control how strongly the backdrop is dimmed on modern detail screens. Higher values darken the backdrop and strengthen the edge gradients."
+    item.options = [
+        { title: "Minimum (0)", id: "0" },
+        { title: "Light (5)", id: "5" },
+        { title: "Medium (10)", id: "10" },
+        { title: "Strong (15)", id: "15" },
+        { title: "Heavy (20)", id: "20" },
+        { title: "Maximum (25)", id: "25" }
+    ]
 end sub

--- a/source/utils/misc.bs
+++ b/source/utils/misc.bs
@@ -556,12 +556,12 @@ function getEndTimeFromTicks(ticks) as string
     return formatTime(date)
 end function
 
-' Get the user's preferred backdrop blur amount
-' Returns an integer blur value (0-20), default is 10
-' This value is used in ImageURL params to control Jellyfin's server-side blur processing
-'
 ' Get backdrop blur amount for detail screens (movies, TV shows, episodes)
-' @return {integer} Blur amount from user settings, or 10 if not set
+' The value is used in ImageURL params to control Jellyfin's server-side blur processing.
+' The modern detail screen reuses this same setting as a backdrop scrim strength, so the
+' accepted range covers every value that screen can store.
+'
+' @return {integer} Blur amount (0 to 25) from user settings, or 10 if not set
 function getBackdropBlurAmount() as integer
     if not isValid(m.global) or not isValid(m.global.session) then return 10
     if not isValid(m.global.session.user) or not isValid(m.global.session.user.settings) then return 10
@@ -569,7 +569,7 @@ function getBackdropBlurAmount() as integer
     blurSetting = m.global.session.user.settings["ui.backdrop.detailBlurAmount"]
     if isValid(blurSetting)
         blurValue = val(blurSetting)
-        if blurValue >= 0 and blurValue <= 20
+        if blurValue >= 0 and blurValue <= 25
             return blurValue
         end if
     end if


### PR DESCRIPTION
# Pull Request

## Summary
Ported the modern detail screen background opacity configuration setting from Moonfin-Core PR 873 to Roku.

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #
- Related to #

## Type of Change
- [ ] Bug fix
- [X] New feature
- [ ] Refactor
- [ ] Performance improvement
- [X] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

- Intercepted the visual effects settings in `settings.bs` to check `ui.itemdetail.style`. If set to `"modern"`, the blur option changes its title to **"Details Background Opacity"** and option values to percentage steps.
- Implemented `updateBackdropOpacity` in `ModernItemDetails.bs` to scale the black overlay opacity and linear/radial scrim gradients dynamically based on the opacity setting value.

## Testing
Describe how this change was tested.

- [ ] Tested on physical Roku device
- [ ] Tested via sideload
- [ ] Manual testing completed
- [X] Not tested (explain why): It's Roku. Tagging @jmawet in.

### Test Steps
1. Navigate to Settings -> Moonfin Settings -> Visual Effects.
2. Verify that when Detail Screen Style is set to "Classic", the setting reads "Detail Screen Backdrop Blur".
3. Verify that when Detail Screen Style is set to "Modern", the setting reads "Details Background Opacity" with percentage options.
4. Navigate to a movie or TV show detail screen and adjust the opacity option. Verify that the backdrop overlay and edge gradient scrims adjust dynamically.

## Screenshots (if applicable)
Include screenshots or recordings for UI changes.

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
