### PR TITLE
feature-homerows - Port remaining internal home rows to Roku

### DIFF
--- a/components/home/HomeRows.bs
+++ b/components/home/HomeRows.bs
@@ -2917,6 +2917,7 @@ sub createCollectionsRow()
     if not sectionExists(sectionName)
         row = m.top.content.CreateChild("HomeRow")
         row.title = sectionName
+        row.id = "collections"
         row.imageWidth = getPosterSize(false)[0]
         row.cursorSize = getPosterSize(false)
     end if
@@ -2943,13 +2944,7 @@ sub updateCollectionsItems()
         item.imageWidth = row.imageWidth
         row.appendChild(item)
     end for
-    if sectionExists(sectionName)
-        m.top.content.replaceChild(row, getSectionIndex(sectionName))
-        setRowItemSize()
-        return
-    end if
-    m.top.content.insertChild(row, getSectionIndex(sectionName))
-    setRowItemSize()
+    addOrUpdateHomeRow(row, sectionName, "collections")
 end sub
 
 sub createGenresRow()
@@ -2957,6 +2952,7 @@ sub createGenresRow()
     if not sectionExists(sectionName)
         row = m.top.content.CreateChild("HomeRow")
         row.title = sectionName
+        row.id = "genres"
         row.imageWidth = getPosterSize(false)[0]
         row.cursorSize = getPosterSize(false)
     end if
@@ -2983,13 +2979,7 @@ sub updateGenresItems()
         item.imageWidth = row.imageWidth
         row.appendChild(item)
     end for
-    if sectionExists(sectionName)
-        m.top.content.replaceChild(row, getSectionIndex(sectionName))
-        setRowItemSize()
-        return
-    end if
-    m.top.content.insertChild(row, getSectionIndex(sectionName))
-    setRowItemSize()
+    addOrUpdateHomeRow(row, sectionName, "genres")
 end sub
 
 sub createPlaylistsRow()
@@ -2997,6 +2987,7 @@ sub createPlaylistsRow()
     if not sectionExists(sectionName)
         row = m.top.content.CreateChild("HomeRow")
         row.title = sectionName
+        row.id = "playlists"
         row.imageWidth = getPosterSize(false)[0]
         row.cursorSize = getPosterSize(false)
     end if
@@ -3023,13 +3014,7 @@ sub updatePlaylistsItems()
         item.imageWidth = row.imageWidth
         row.appendChild(item)
     end for
-    if sectionExists(sectionName)
-        m.top.content.replaceChild(row, getSectionIndex(sectionName))
-        setRowItemSize()
-        return
-    end if
-    m.top.content.insertChild(row, getSectionIndex(sectionName))
-    setRowItemSize()
+    addOrUpdateHomeRow(row, sectionName, "playlists")
 end sub
 
 sub createAudioRow()
@@ -3037,6 +3022,7 @@ sub createAudioRow()
     if not sectionExists(sectionName)
         row = m.top.content.CreateChild("HomeRow")
         row.title = sectionName
+        row.id = "audio"
         row.imageWidth = getPosterSize(false)[0]
         row.cursorSize = getPosterSize(false)
     end if
@@ -3063,11 +3049,5 @@ sub updateAudioItems()
         item.imageWidth = row.imageWidth
         row.appendChild(item)
     end for
-    if sectionExists(sectionName)
-        m.top.content.replaceChild(row, getSectionIndex(sectionName))
-        setRowItemSize()
-        return
-    end if
-    m.top.content.insertChild(row, getSectionIndex(sectionName))
-    setRowItemSize()
+    addOrUpdateHomeRow(row, sectionName, "audio")
 end sub

--- a/components/home/HomeRows.bs
+++ b/components/home/HomeRows.bs
@@ -1209,6 +1209,30 @@ function addHomeSection(sectionType as string) as boolean
         return true
     end if
 
+    ' Collections Items
+    if sectionType = "collections"
+        createCollectionsRow()
+        return true
+    end if
+
+    ' Genres Items
+    if sectionType = "genres"
+        createGenresRow()
+        return true
+    end if
+
+    ' Playlists Items
+    if sectionType = "playlists"
+        createPlaylistsRow()
+        return true
+    end if
+
+    ' Audio Items
+    if sectionType = "audio"
+        createAudioRow()
+        return true
+    end if
+
     ' Since You Watched recommendation rows
     if sectionType = "sinceyouwatched"
         createSinceYouWatchedRows()
@@ -2886,4 +2910,164 @@ sub updateCustomDynamicRowItems(event as object)
     end for
 
     addOrUpdateHomeRow(row, sectionName, rowId)
+end sub
+
+sub createCollectionsRow()
+    sectionName = tr("Collections")
+    if not sectionExists(sectionName)
+        row = m.top.content.CreateChild("HomeRow")
+        row.title = sectionName
+        row.imageWidth = getPosterSize(false)[0]
+        row.cursorSize = getPosterSize(false)
+    end if
+    task = getOrCreateTask("collections")
+    task.observeField("content", "updateCollectionsItems")
+    task.control = "RUN"
+end sub
+
+sub updateCollectionsItems()
+    m.processedRowCount++
+    itemData = getTaskContentAndCleanup("collections")
+    sectionName = tr("Collections")
+    if not isValidAndNotEmpty(itemData)
+        removeHomeSection(sectionName)
+        return
+    end if
+    row = CreateObject("roSGNode", "HomeRow")
+    row.title = sectionName
+    row.imageWidth = getPosterSize(false)[0]
+    row.cursorSize = getPosterSize(false)
+    row.usePoster = true
+    for each item in itemData
+        item.usePoster = row.usePoster
+        item.imageWidth = row.imageWidth
+        row.appendChild(item)
+    end for
+    if sectionExists(sectionName)
+        m.top.content.replaceChild(row, getSectionIndex(sectionName))
+        setRowItemSize()
+        return
+    end if
+    m.top.content.insertChild(row, getSectionIndex(sectionName))
+    setRowItemSize()
+end sub
+
+sub createGenresRow()
+    sectionName = tr("Genres")
+    if not sectionExists(sectionName)
+        row = m.top.content.CreateChild("HomeRow")
+        row.title = sectionName
+        row.imageWidth = getPosterSize(false)[0]
+        row.cursorSize = getPosterSize(false)
+    end if
+    task = getOrCreateTask("genres")
+    task.observeField("content", "updateGenresItems")
+    task.control = "RUN"
+end sub
+
+sub updateGenresItems()
+    m.processedRowCount++
+    itemData = getTaskContentAndCleanup("genres")
+    sectionName = tr("Genres")
+    if not isValidAndNotEmpty(itemData)
+        removeHomeSection(sectionName)
+        return
+    end if
+    row = CreateObject("roSGNode", "HomeRow")
+    row.title = sectionName
+    row.imageWidth = getPosterSize(false)[0]
+    row.cursorSize = getPosterSize(false)
+    row.usePoster = true
+    for each item in itemData
+        item.usePoster = row.usePoster
+        item.imageWidth = row.imageWidth
+        row.appendChild(item)
+    end for
+    if sectionExists(sectionName)
+        m.top.content.replaceChild(row, getSectionIndex(sectionName))
+        setRowItemSize()
+        return
+    end if
+    m.top.content.insertChild(row, getSectionIndex(sectionName))
+    setRowItemSize()
+end sub
+
+sub createPlaylistsRow()
+    sectionName = tr("Playlists")
+    if not sectionExists(sectionName)
+        row = m.top.content.CreateChild("HomeRow")
+        row.title = sectionName
+        row.imageWidth = getPosterSize(false)[0]
+        row.cursorSize = getPosterSize(false)
+    end if
+    task = getOrCreateTask("playlists")
+    task.observeField("content", "updatePlaylistsItems")
+    task.control = "RUN"
+end sub
+
+sub updatePlaylistsItems()
+    m.processedRowCount++
+    itemData = getTaskContentAndCleanup("playlists")
+    sectionName = tr("Playlists")
+    if not isValidAndNotEmpty(itemData)
+        removeHomeSection(sectionName)
+        return
+    end if
+    row = CreateObject("roSGNode", "HomeRow")
+    row.title = sectionName
+    row.imageWidth = getPosterSize(false)[0]
+    row.cursorSize = getPosterSize(false)
+    row.usePoster = true
+    for each item in itemData
+        item.usePoster = row.usePoster
+        item.imageWidth = row.imageWidth
+        row.appendChild(item)
+    end for
+    if sectionExists(sectionName)
+        m.top.content.replaceChild(row, getSectionIndex(sectionName))
+        setRowItemSize()
+        return
+    end if
+    m.top.content.insertChild(row, getSectionIndex(sectionName))
+    setRowItemSize()
+end sub
+
+sub createAudioRow()
+    sectionName = tr("Audio")
+    if not sectionExists(sectionName)
+        row = m.top.content.CreateChild("HomeRow")
+        row.title = sectionName
+        row.imageWidth = getPosterSize(false)[0]
+        row.cursorSize = getPosterSize(false)
+    end if
+    task = getOrCreateTask("audio")
+    task.observeField("content", "updateAudioItems")
+    task.control = "RUN"
+end sub
+
+sub updateAudioItems()
+    m.processedRowCount++
+    itemData = getTaskContentAndCleanup("audio")
+    sectionName = tr("Audio")
+    if not isValidAndNotEmpty(itemData)
+        removeHomeSection(sectionName)
+        return
+    end if
+    row = CreateObject("roSGNode", "HomeRow")
+    row.title = sectionName
+    row.imageWidth = getPosterSize(false)[0]
+    row.cursorSize = getPosterSize(false)
+    row.usePoster = false ' music albums are square/landscape ratio
+    for each item in itemData
+        item.usePoster = row.usePoster
+        item.imageWidth = row.imageWidth
+        row.appendChild(item)
+    end for
+    if sectionExists(sectionName)
+        m.top.content.replaceChild(row, getSectionIndex(sectionName))
+        setRowItemSize()
+        return
+    end if
+    m.top.content.insertChild(row, getSectionIndex(sectionName))
+    setRowItemSize()
 end sub

--- a/components/home/HomeRows.bs
+++ b/components/home/HomeRows.bs
@@ -1121,6 +1121,13 @@ end sub
 ' @param {string} sectionType - Type of section to add
 ' @return {boolean} indicating if the section was handled
 function addHomeSection(sectionType as string) as boolean
+    ' Favorites, collections, genres, playlists and audio are opt in, so skip them
+    ' unless their toggle is on. This keeps the row and the section picker in agreement.
+    if not internalRowEnabled(sectionType)
+        m.processedRowCount++
+        return false
+    end if
+
     ' Check if merge setting is enabled
     mergeSetting = get_user_setting("ui.home.mergeContinueWatchingNextUp")
     mergeContinueWatching = (mergeSetting = "true")
@@ -1209,27 +1216,9 @@ function addHomeSection(sectionType as string) as boolean
         return true
     end if
 
-    ' Collections Items
-    if sectionType = "collections"
-        createCollectionsRow()
-        return true
-    end if
-
-    ' Genres Items
-    if sectionType = "genres"
-        createGenresRow()
-        return true
-    end if
-
-    ' Playlists Items
-    if sectionType = "playlists"
-        createPlaylistsRow()
-        return true
-    end if
-
-    ' Audio Items
-    if sectionType = "audio"
-        createAudioRow()
+    internalTaskKey = internalRowTaskKey(sectionType)
+    if internalTaskKey <> ""
+        createInternalRow(internalTaskKey)
         return true
     end if
 
@@ -2912,142 +2901,95 @@ sub updateCustomDynamicRowItems(event as object)
     addOrUpdateHomeRow(row, sectionName, rowId)
 end sub
 
-sub createCollectionsRow()
-    sectionName = tr("Collections")
-    if not sectionExists(sectionName)
-        row = m.top.content.CreateChild("HomeRow")
-        row.title = sectionName
-        row.id = "collections"
-        row.imageWidth = getPosterSize(false)[0]
-        row.cursorSize = getPosterSize(false)
-    end if
-    task = getOrCreateTask("collections")
-    task.observeField("content", "updateCollectionsItems")
+' internalRowConfig: Describes the opt in home rows that share one row builder, keyed by the
+' task that loads them. Favorites is deliberately absent because it builds its own row to
+' cover the multi server case.
+'
+' @param {string} taskKey - Task key, as set on LoadItemsTask.itemsToLoad
+' @return {object} the row's section key, localized title and poster preference, or invalid
+function internalRowConfig(taskKey as string) as object
+    configs = {
+        collections: { sectionKey: "collections", title: tr("Collections"), usePoster: true },
+        genres: { sectionKey: "genres", title: tr("Genres"), usePoster: true },
+        audio: { sectionKey: "audio", title: tr("Audio"), usePoster: false },
+        ' The plain "playlists" task feeds the playlist picker, which needs a different node type
+        homeplaylists: { sectionKey: "playlists", title: tr("Playlists"), usePoster: true }
+    }
+
+    return configs[taskKey]
+end function
+
+' internalRowTaskKey: Maps a home section key to the task that loads it
+'
+' @param {string} sectionKey - Home section key, for example "collections"
+' @return {string} the task key, or an empty string for sections these rows don't cover
+function internalRowTaskKey(sectionKey as string) as string
+    keys = {
+        collections: "collections",
+        genres: "genres",
+        audio: "audio",
+        playlists: "homeplaylists"
+    }
+
+    return keys[sectionKey] ?? ""
+end function
+
+' internalRowEnabled: Reports whether an opt in home row should be built
+'
+' @param {string} sectionKey - Home section key
+' @return {boolean} true for rows that have no toggle, otherwise the state of that toggle
+function internalRowEnabled(sectionKey as string) as boolean
+    settingNames = {
+        favorites: "ui.home.displayFavoritesRows",
+        collections: "ui.home.displayCollectionsRows",
+        genres: "ui.home.displayGenresRows",
+        playlists: "ui.home.displayPlaylistsRows",
+        audio: "ui.home.displayAudioRows"
+    }
+
+    settingName = settingNames[sectionKey]
+    if not isValid(settingName) then return true
+
+    settings = chainLookupReturn(m.global, "session.user.settings", invalid)
+    if not isAssociativeArrayValue(settings) then return false
+
+    value = settings[settingName]
+    if not isValid(value) then return false
+    if type(value) = "String" or type(value) = "roString" then return LCase(value) = "true"
+
+    return value = true
+end function
+
+sub createInternalRow(taskKey as string)
+    task = getOrCreateTask(taskKey)
+    task.observeField("content", "updateInternalRowItems")
     task.control = "RUN"
 end sub
 
-sub updateCollectionsItems()
+sub updateInternalRowItems(event as object)
     m.processedRowCount++
-    itemData = getTaskContentAndCleanup("collections")
-    sectionName = tr("Collections")
+
+    taskKey = event.getRoSGNode().itemsToLoad
+    config = internalRowConfig(taskKey)
+    if not isValid(config) then return
+
+    itemData = getTaskContentAndCleanup(taskKey)
     if not isValidAndNotEmpty(itemData)
-        removeHomeSection(sectionName)
+        removeHomeSection(config.title)
         return
     end if
+
     row = CreateObject("roSGNode", "HomeRow")
-    row.title = sectionName
+    row.title = config.title
     row.imageWidth = getPosterSize(false)[0]
     row.cursorSize = getPosterSize(false)
-    row.usePoster = true
+    row.usePoster = config.usePoster
+
     for each item in itemData
         item.usePoster = row.usePoster
         item.imageWidth = row.imageWidth
         row.appendChild(item)
     end for
-    addOrUpdateHomeRow(row, sectionName, "collections")
-end sub
 
-sub createGenresRow()
-    sectionName = tr("Genres")
-    if not sectionExists(sectionName)
-        row = m.top.content.CreateChild("HomeRow")
-        row.title = sectionName
-        row.id = "genres"
-        row.imageWidth = getPosterSize(false)[0]
-        row.cursorSize = getPosterSize(false)
-    end if
-    task = getOrCreateTask("genres")
-    task.observeField("content", "updateGenresItems")
-    task.control = "RUN"
-end sub
-
-sub updateGenresItems()
-    m.processedRowCount++
-    itemData = getTaskContentAndCleanup("genres")
-    sectionName = tr("Genres")
-    if not isValidAndNotEmpty(itemData)
-        removeHomeSection(sectionName)
-        return
-    end if
-    row = CreateObject("roSGNode", "HomeRow")
-    row.title = sectionName
-    row.imageWidth = getPosterSize(false)[0]
-    row.cursorSize = getPosterSize(false)
-    row.usePoster = true
-    for each item in itemData
-        item.usePoster = row.usePoster
-        item.imageWidth = row.imageWidth
-        row.appendChild(item)
-    end for
-    addOrUpdateHomeRow(row, sectionName, "genres")
-end sub
-
-sub createPlaylistsRow()
-    sectionName = tr("Playlists")
-    if not sectionExists(sectionName)
-        row = m.top.content.CreateChild("HomeRow")
-        row.title = sectionName
-        row.id = "playlists"
-        row.imageWidth = getPosterSize(false)[0]
-        row.cursorSize = getPosterSize(false)
-    end if
-    task = getOrCreateTask("playlists")
-    task.observeField("content", "updatePlaylistsItems")
-    task.control = "RUN"
-end sub
-
-sub updatePlaylistsItems()
-    m.processedRowCount++
-    itemData = getTaskContentAndCleanup("playlists")
-    sectionName = tr("Playlists")
-    if not isValidAndNotEmpty(itemData)
-        removeHomeSection(sectionName)
-        return
-    end if
-    row = CreateObject("roSGNode", "HomeRow")
-    row.title = sectionName
-    row.imageWidth = getPosterSize(false)[0]
-    row.cursorSize = getPosterSize(false)
-    row.usePoster = true
-    for each item in itemData
-        item.usePoster = row.usePoster
-        item.imageWidth = row.imageWidth
-        row.appendChild(item)
-    end for
-    addOrUpdateHomeRow(row, sectionName, "playlists")
-end sub
-
-sub createAudioRow()
-    sectionName = tr("Audio")
-    if not sectionExists(sectionName)
-        row = m.top.content.CreateChild("HomeRow")
-        row.title = sectionName
-        row.id = "audio"
-        row.imageWidth = getPosterSize(false)[0]
-        row.cursorSize = getPosterSize(false)
-    end if
-    task = getOrCreateTask("audio")
-    task.observeField("content", "updateAudioItems")
-    task.control = "RUN"
-end sub
-
-sub updateAudioItems()
-    m.processedRowCount++
-    itemData = getTaskContentAndCleanup("audio")
-    sectionName = tr("Audio")
-    if not isValidAndNotEmpty(itemData)
-        removeHomeSection(sectionName)
-        return
-    end if
-    row = CreateObject("roSGNode", "HomeRow")
-    row.title = sectionName
-    row.imageWidth = getPosterSize(false)[0]
-    row.cursorSize = getPosterSize(false)
-    row.usePoster = false ' music albums are square/landscape ratio
-    for each item in itemData
-        item.usePoster = row.usePoster
-        item.imageWidth = row.imageWidth
-        row.appendChild(item)
-    end for
-    addOrUpdateHomeRow(row, sectionName, "audio")
+    addOrUpdateHomeRow(row, config.title, config.sectionKey)
 end sub

--- a/components/home/LoadItemsTask.bs
+++ b/components/home/LoadItemsTask.bs
@@ -1911,6 +1911,21 @@ sub loadItems()
         return
     end if
 
+    if isStringEqual(m.top.itemsToLoad, "collections")
+        m.top.content = loadCollections()
+        return
+    end if
+
+    if isStringEqual(m.top.itemsToLoad, "genres")
+        m.top.content = loadGenres()
+        return
+    end if
+
+    if isStringEqual(m.top.itemsToLoad, "audio")
+        m.top.content = loadAudio()
+        return
+    end if
+
     if isStringEqual(m.top.itemsToLoad, "isInMyList")
         m.top.content = loadIsInMyList()
         return
@@ -2290,5 +2305,93 @@ function loadCustomDynamicList(listName as string, additionalData as dynamic) as
         end if
     end if
 
+    return results
+end function
+
+function loadCollections() as object
+    results = []
+    data = api.items.Get({
+        userid: m.global.session.user.id,
+        includeItemTypes: "BoxSet",
+        recursive: true,
+        SortBy: "SortName",
+        Fields: "PrimaryImageAspectRatio,ProductionYear,UserData,BackdropImageTags,ImageTags",
+        EnableTotalRecordCount: false
+    })
+    if not isChainValid(data, "Items") then return results
+
+    for each item in data.Items
+        tmp = CreateObject("roSGNode", "HomeData")
+        tmp.type = "BoxSet"
+        tmp.title = item.name
+        tmp.id = item.id
+        params = {
+            Tags: item.PrimaryImageTag,
+            MaxWidth: 234,
+            MaxHeight: 330
+        }
+        tmp.posterURL = ImageUrl(item.Id, "Primary", params)
+        tmp.json = item
+        results.push(tmp)
+    end for
+    return results
+end function
+
+function loadGenres() as object
+    results = []
+    genres = api.genres.Get({
+        userId: m.global.session.user.id,
+        sortBy: "SortName",
+        sortOrder: "Ascending",
+        Fields: "PrimaryImageAspectRatio,ImageTags",
+        EnableTotalRecordCount: false
+    })
+    if not isChainValid(genres, "items") then return results
+
+    for each item in genres.items
+        tmp = CreateObject("roSGNode", "HomeData")
+        tmp.type = "Genre"
+        tmp.title = item.name
+        tmp.id = item.id
+        params = {
+            Tags: item.PrimaryImageTag,
+            MaxWidth: 234,
+            MaxHeight: 330
+        }
+        tmp.posterURL = ImageUrl(item.Id, "Primary", params)
+        tmp.json = item
+        results.push(tmp)
+    end for
+    return results
+end function
+
+function loadAudio() as object
+    results = []
+    data = api.items.Get({
+        userid: m.global.session.user.id,
+        includeItemTypes: "MusicAlbum",
+        recursive: true,
+        SortBy: "DateCreated",
+        SortOrder: "Descending",
+        Limit: 25,
+        Fields: "PrimaryImageAspectRatio,ProductionYear,UserData,BackdropImageTags,ImageTags",
+        EnableTotalRecordCount: false
+    })
+    if not isChainValid(data, "Items") then return results
+
+    for each item in data.Items
+        tmp = CreateObject("roSGNode", "HomeData")
+        tmp.type = "MusicAlbum"
+        tmp.title = item.name
+        tmp.id = item.id
+        params = {
+            Tags: item.PrimaryImageTag,
+            MaxWidth: 234,
+            MaxHeight: 330
+        }
+        tmp.posterURL = ImageUrl(item.Id, "Primary", params)
+        tmp.json = item
+        results.push(tmp)
+    end for
     return results
 end function

--- a/components/home/LoadItemsTask.bs
+++ b/components/home/LoadItemsTask.bs
@@ -1911,6 +1911,11 @@ sub loadItems()
         return
     end if
 
+    if isStringEqual(m.top.itemsToLoad, "homeplaylists")
+        m.top.content = loadHomePlaylists()
+        return
+    end if
+
     if isStringEqual(m.top.itemsToLoad, "collections")
         m.top.content = loadCollections()
         return
@@ -2308,6 +2313,29 @@ function loadCustomDynamicList(listName as string, additionalData as dynamic) as
     return results
 end function
 
+' internalRowNode: Builds a home card for one of the opt in internal rows
+'
+' @param {object} item - Item as returned by the server
+' @param {string} itemType - Value to store on the node's type field
+' @return {object} a HomeData node ready to append to a row
+function internalRowNode(item as object, itemType as string) as object
+    tmp = CreateObject("roSGNode", "HomeData")
+    tmp.type = itemType
+    tmp.title = item.name
+    tmp.id = item.id
+
+    params = { MaxWidth: 234, MaxHeight: 330 }
+    if hasImageTagPrimary(item)
+        params.Tag = item.ImageTags.Primary
+    end if
+    tmp.posterURL = ImageUrl(item.Id, "Primary", params)
+
+    ' HomeData refines the artwork for types it knows, such as MusicAlbum
+    tmp.json = item
+
+    return tmp
+end function
+
 function loadCollections() as object
     results = []
     data = api.items.Get({
@@ -2321,18 +2349,7 @@ function loadCollections() as object
     if not isChainValid(data, "Items") then return results
 
     for each item in data.Items
-        tmp = CreateObject("roSGNode", "HomeData")
-        tmp.type = "BoxSet"
-        tmp.title = item.name
-        tmp.id = item.id
-        params = {
-            Tags: item.PrimaryImageTag,
-            MaxWidth: 234,
-            MaxHeight: 330
-        }
-        tmp.posterURL = ImageUrl(item.Id, "Primary", params)
-        tmp.json = item
-        results.push(tmp)
+        results.push(internalRowNode(item, "BoxSet"))
     end for
     return results
 end function
@@ -2349,18 +2366,28 @@ function loadGenres() as object
     if not isChainValid(genres, "items") then return results
 
     for each item in genres.items
-        tmp = CreateObject("roSGNode", "HomeData")
-        tmp.type = "Genre"
-        tmp.title = item.name
-        tmp.id = item.id
-        params = {
-            Tags: item.PrimaryImageTag,
-            MaxWidth: 234,
-            MaxHeight: 330
-        }
-        tmp.posterURL = ImageUrl(item.Id, "Primary", params)
-        tmp.json = item
-        results.push(tmp)
+        results.push(internalRowNode(item, "Genre"))
+    end for
+    return results
+end function
+
+' The plain playlists task returns PlaylistData for the playlist picker, which carries no
+' artwork fields, so the home row needs its own loader
+function loadHomePlaylists() as object
+    results = []
+    data = api.items.Get({
+        userid: m.global.session.user.id,
+        includeItemTypes: "Playlist",
+        recursive: true,
+        SortBy: "SortName",
+        Fields: "PrimaryImageAspectRatio,ImageTags",
+        EnableTotalRecordCount: false
+    })
+    if not isChainValid(data, "Items") then return results
+
+    for each item in data.Items
+        if isStringEqual(item.name, "|My List|") then continue for
+        results.push(internalRowNode(item, "Playlist"))
     end for
     return results
 end function
@@ -2380,18 +2407,7 @@ function loadAudio() as object
     if not isChainValid(data, "Items") then return results
 
     for each item in data.Items
-        tmp = CreateObject("roSGNode", "HomeData")
-        tmp.type = "MusicAlbum"
-        tmp.title = item.name
-        tmp.id = item.id
-        params = {
-            Tags: item.PrimaryImageTag,
-            MaxWidth: 234,
-            MaxHeight: 330
-        }
-        tmp.posterURL = ImageUrl(item.Id, "Primary", params)
-        tmp.json = item
-        results.push(tmp)
+        results.push(internalRowNode(item, "MusicAlbum"))
     end for
     return results
 end function

--- a/components/settings/settings.bs
+++ b/components/settings/settings.bs
@@ -1842,12 +1842,21 @@ sub settingSelected()
 
             if Left(chainLookupReturn(selectedItem, "settingName", ""), 17) = "homeScreenSection"
                 filteredOptions = []
+                showFavorites = normalizeBoolSettingValue(getUserSettingValue("ui.home.displayFavoritesRows", false))
                 for each option in selectedItem.options
-                    filteredOptions.push(option)
+                    if option.id = "favorites"
+                        if showFavorites then filteredOptions.push(option)
+                    else
+                        filteredOptions.push(option)
+                    end if
                 end for
 
                 ' Each entry pairs the setting that enables a row with the option shown in the picker
-                externalRowOptions = [
+                optInRowOptions = [
+                    { settingName: "ui.home.displayCollectionsRows", title: "Collections", id: "collections" },
+                    { settingName: "ui.home.displayGenresRows", title: "Genres", id: "genres" },
+                    { settingName: "ui.home.displayPlaylistsRows", title: "Playlists", id: "playlists" },
+                    { settingName: "ui.home.displayAudioRows", title: "Audio", id: "audio" },
                     { settingName: "imdb.top250movies", title: "IMDb Top 250 Movies", id: "imdb_top_250_movies" },
                     { settingName: "imdb.top250tvshows", title: "IMDb Top 250 TV Shows", id: "imdb_top_250_tv_shows" },
                     { settingName: "imdb.mostpopularmovies", title: "IMDb Most Popular Movies", id: "imdb_most_popular_movies" },
@@ -1873,9 +1882,9 @@ sub settingSelected()
                     { settingName: "seerr.row.upcoming_tv", title: "Seerr Upcoming TV Shows", id: "seerr_upcoming_series" }
                 ]
 
-                for each externalRow in externalRowOptions
-                    if normalizeBoolSettingValue(getUserSettingValue(externalRow.settingName, false))
-                        filteredOptions.push({ title: externalRow.title, id: externalRow.id })
+                for each optInRow in optInRowOptions
+                    if normalizeBoolSettingValue(getUserSettingValue(optInRow.settingName, false))
+                        filteredOptions.push({ title: optInRow.title, id: optInRow.id })
                     end if
                 end for
 

--- a/settings/settings.json
+++ b/settings/settings.json
@@ -198,6 +198,47 @@
             ]
           },
           {
+            "title": "Home Row Toggles",
+            "description": "Enable or disable internal home rows.",
+            "children": [
+              {
+                "title": "Show Favorites Rows",
+                "description": "Show Favorites rows on the Home Screen",
+                "settingName": "ui.home.displayFavoritesRows",
+                "type": "bool",
+                "default": "false"
+              },
+              {
+                "title": "Show Collections Rows",
+                "description": "Show Collections rows on the Home Screen",
+                "settingName": "ui.home.displayCollectionsRows",
+                "type": "bool",
+                "default": "false"
+              },
+              {
+                "title": "Show Genres Rows",
+                "description": "Show Genres rows on the Home Screen",
+                "settingName": "ui.home.displayGenresRows",
+                "type": "bool",
+                "default": "false"
+              },
+              {
+                "title": "Show Playlists Rows",
+                "description": "Show Playlists rows on the Home Screen",
+                "settingName": "ui.home.displayPlaylistsRows",
+                "type": "bool",
+                "default": "false"
+              },
+              {
+                "title": "Show Audio Rows",
+                "description": "Show Audio rows on the Home Screen",
+                "settingName": "ui.home.displayAudioRows",
+                "type": "bool",
+                "default": "false"
+              }
+            ]
+          },
+          {
             "title": "Home Rows",
             "description": "Customize the home screen sections",
             "icon": "homescreen.png",

--- a/source/MainEventHandlers.bs
+++ b/source/MainEventHandlers.bs
@@ -875,6 +875,30 @@ sub onSelectedItemEvent(msg)
         else if isStringEqual(selectedItemType, "boxset")
             group = CreateVisualLibraryScene(selectedItem, ItemType.BOXSET)
             m.global.sceneManager.callFunc("pushScene", group)
+        else if isStringEqual(selectedItemType, "genre")
+            genreBrowseItem = createSGNode("ContentNode")
+            genreBrowseItem.addField("id", "string", false)
+            genreBrowseItem.addField("name", "string", false)
+            genreBrowseItem.addField("type", "string", false)
+            genreBrowseItem.addField("collectionType", "string", false)
+            genreBrowseItem.id = ""
+            genreBrowseItem.name = selectedItem.title
+            genreBrowseItem.type = "movies"
+            genreBrowseItem.collectionType = "movies"
+
+            group = createObject("roSGNode", "VisualLibraryScene")
+            group.mediaType = "Movie"
+            group.genreFilter = {
+                genreId: "",
+                genreName: selectedItem.title,
+                libraryId: "",
+                parentFolder: "",
+                itemType: "Movie,Series"
+            }
+            group.parentItem = genreBrowseItem
+            group.observeFieldScoped("selectedItem", m.port)
+            group.observeFieldScoped("quickPlayNode", m.port)
+            m.global.sceneManager.callFunc("pushScene", group)
         else if isStringEqual(selectedItemType, "folder") and isStringEqual(selectedItem.json.type, "genre")
             ' User clicked on a genre folder
             if isStringEqual(selectedItem.itemType, ItemType.MOVIE)

--- a/source/MainEventHandlers.bs
+++ b/source/MainEventHandlers.bs
@@ -767,7 +767,13 @@ sub onRefreshSeriesDetailsDataEvent()
 end sub
 
 sub onGenreItemSelectedEvent(msg)
-    genreData = msg.getData()
+    pushGenreBrowseScene(msg.getData())
+end sub
+
+' pushGenreBrowseScene: Opens the library grid filtered to a single genre
+'
+' @param {object} genreData - Carries genreId, genreName, libraryId, collectionType, mediaType and itemType
+sub pushGenreBrowseScene(genreData as object)
     if not isValid(genreData) then return
 
     genreBrowseItem = createSGNode("ContentNode")
@@ -876,29 +882,15 @@ sub onSelectedItemEvent(msg)
             group = CreateVisualLibraryScene(selectedItem, ItemType.BOXSET)
             m.global.sceneManager.callFunc("pushScene", group)
         else if isStringEqual(selectedItemType, "genre")
-            genreBrowseItem = createSGNode("ContentNode")
-            genreBrowseItem.addField("id", "string", false)
-            genreBrowseItem.addField("name", "string", false)
-            genreBrowseItem.addField("type", "string", false)
-            genreBrowseItem.addField("collectionType", "string", false)
-            genreBrowseItem.id = ""
-            genreBrowseItem.name = selectedItem.title
-            genreBrowseItem.type = "movies"
-            genreBrowseItem.collectionType = "movies"
-
-            group = createObject("roSGNode", "VisualLibraryScene")
-            group.mediaType = "Movie"
-            group.genreFilter = {
+            ' Genre cards on the home screen carry a name but no library, so filter by name
+            pushGenreBrowseScene({
                 genreId: "",
                 genreName: selectedItem.title,
                 libraryId: "",
-                parentFolder: "",
+                collectionType: "movies",
+                mediaType: "Movie",
                 itemType: "Movie,Series"
-            }
-            group.parentItem = genreBrowseItem
-            group.observeFieldScoped("selectedItem", m.port)
-            group.observeFieldScoped("quickPlayNode", m.port)
-            m.global.sceneManager.callFunc("pushScene", group)
+            })
         else if isStringEqual(selectedItemType, "folder") and isStringEqual(selectedItem.json.type, "genre")
             ' User clicked on a genre folder
             if isStringEqual(selectedItem.itemType, ItemType.MOVIE)

--- a/source/utils/settingsSync.bs
+++ b/source/utils/settingsSync.bs
@@ -66,6 +66,11 @@ namespace settingsSync
             { pluginKey: "rewatchIncludeMovies", rokuKey: "ui.home.rewatchIncludeMovies", type: "bool" },
             { pluginKey: "rewatchIncludeShows", rokuKey: "ui.home.rewatchIncludeShows", type: "bool" },
             { pluginKey: "rewatchIncludeCollections", rokuKey: "ui.home.rewatchIncludeCollections", type: "bool" },
+            { pluginKey: "displayFavoritesRows", rokuKey: "ui.home.displayFavoritesRows", type: "bool" },
+            { pluginKey: "displayCollectionsRows", rokuKey: "ui.home.displayCollectionsRows", type: "bool" },
+            { pluginKey: "displayGenresRows", rokuKey: "ui.home.displayGenresRows", type: "bool" },
+            { pluginKey: "displayPlaylistsRows", rokuKey: "ui.home.displayPlaylistsRows", type: "bool" },
+            { pluginKey: "displayAudioRows", rokuKey: "ui.home.displayAudioRows", type: "bool" },
 
             { pluginKey: "imdbTop250MoviesEnabled", rokuKey: "imdb.top250movies", type: "bool" },
             { pluginKey: "imdbTop250TvShowsEnabled", rokuKey: "imdb.top250tvshows", type: "bool" },


### PR DESCRIPTION
# Pull Request

## Summary
Ported the internal home screen rows configuration toggles (Favorites, Collections, Genres, Playlists, and Audio) from Moonfin-Core to Roku, allowing these rows to be toggled individually and mapped to Home Screen Section selections (1-8).

## Related Issues
Link related issues or tickets separated by commas.

- Closes #122 
- Closes #126
- Fixes #
- Related to #

## Type of Change
- [ ] Bug fix
- [X] New feature
- [ ] Refactor
- [ ] Performance improvement
- [X] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

- Added toggles in `settings.json` under "Home Screen" for "Show Favorites Rows", "Show Collections Rows", "Show Genres Rows", "Show Playlists Rows", and "Show Audio Rows".
- Mapped all five toggles in `settingsSync.bs` to sync local preferences with the Jellyfin server plugin Settings Sync.
- Intercepted home screen section option lists (Sections 1-8) in `settings.bs` to hide/show Favorites and dynamically append Collections, Genres, Playlists, and Audio options based on toggles.
- Implemented `loadCollections()`, `loadGenres()`, and `loadAudio()` inside `LoadItemsTask.bs` using API requests to fetch appropriate content nodes.
- Added row drawing and update handlers in `HomeRows.bs` for collections, genres, playlists, and audio.
- Added genre click navigation routing in `MainEventHandlers.bs` to push `VisualLibraryScene` filtered by the selected genre name.

## Testing
Describe how this change was tested.

- [ ] Tested on physical Roku device
- [ ] Tested via sideload
- [ ] Manual testing completed
- [X] Not tested (explain why): Paging @jmawet 

### Test Steps
1. Navigate to Settings -> Moonfin Settings -> Home Screen -> Home Row Toggles.
2. Toggle on "Show Collections Rows", "Show Genres Rows", "Show Playlists Rows", and "Show Audio Rows".
3. Verify that these options are now selectable in "Home Rows" section slots (Sections 1-8).
4. Assign "Genres" or "Collections" to a slot, return to the Home Screen, and verify that the row renders correctly and opens the appropriate item lists/views upon selection.

## Screenshots (if applicable)
Include screenshots or recordings for UI changes.

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
