### PR TITLE
fix quick connect authentication not moving to home scene

### DIFF
--- a/source/ShowScenes.bs
+++ b/source/ShowScenes.bs
@@ -540,6 +540,8 @@ function CreateSigninGroup(user = "")
     m.global.sceneManager.callFunc("pushScene", group)
     port = CreateObject("roMessagePort")
 
+    group.observeField("quickConnectAuthenticated", port)
+
     ' Add checkbox for saving credentials
     saveCredentials = group.findNode("saveCredentials")
 
@@ -591,8 +593,7 @@ function CreateSigninGroup(user = "")
                     m.global.sceneManager.callFunc("standardDialog", "Quick Connect Error", { data: ["<p>" + tr("There was an error detecting Quick Connect. Quick Connect is disabled on your server.") + "</p>"] })
                 else
                     group.quickConnectJson = json
-                    group.showQuickConnect = true 
-                    group.observeField("quickConnectAuthenticated", port)
+                    group.showQuickConnect = true
                 end if
             else if msg.getField() = "quickConnectAuthenticated"
                 authenticated = msg.getData()


### PR DESCRIPTION
# Pull Request

## Summary
This PR fixes an issue where the observation for `quickConnectAuthenticated` wasn't reached, therefore wouldn't immediately sign in after quick connect was authenticated. Before, you could only sign in & go to home after going back to user select and pressing the user again.

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
- Moved `group.observeField("quickConnectAuthenticated", port)` from inside the while loop to the top of the `CreateSignInGroup()` function.

## Testing
- [X] Tested on physical Roku device
- [X] Tested via sideload
- [X] Manual testing completed
- [ ] Not tested (explain why):

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
