### PR TITLE
fix media bar/home rows focus

### DIFF
--- a/components/home/Home.bs
+++ b/components/home/Home.bs
@@ -244,7 +244,9 @@ sub onMediaBarModeChanged()
     end if
 
     m.isMediaBarEnabled = true
-    applyMediaBarLayout(true)
+    if not m.homeRows.hasFocus()
+        applyMediaBarLayout(true)
+    end if
 
     if mode = "gallery"
         if isValid(m.backdrop) then m.backdrop.uri = ""

--- a/components/home/Home.bs
+++ b/components/home/Home.bs
@@ -321,9 +321,11 @@ sub onHomeRowsContentLoaded()
         end if
     end if
 
-    ' Only show/focus Media Bar if it's enabled
+    ' Only show/focus Media Bar if it's enabled and home rows doesn't have focus
     if m.isMediaBarEnabled
-        applyMediaBarLayout(true)
+        if not m.homeRows.hasFocus()
+            applyMediaBarLayout(true)
+        end if
     else
         applyMediaBarLayout(false)
     end if


### PR DESCRIPTION
# Pull Request

## Summary
This PR fixes an issue where navigating before the media bar loads causes it to be overlayed on homeRows. It also fixes an issue when changing from `Off` to any media bar mode causing the same bug.

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
- Guard `applyMediaBarLayout(true)` so it doesn't happen when `homeRows` already has focus.
- Also guard it in `mediaBarModeChanged()` so switching from off to another styles doesn't break the focus.

## Testing
- [X] Tested on physical Roku device
- [X] Tested via sideload
- [X] Manual testing completed
- [ ] Not tested (explain why):

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
