### PR TITLE
block hideModernFocusCard on homeRow edges

### DIFF
--- a/components/home/HomeRows.bs
+++ b/components/home/HomeRows.bs
@@ -2613,8 +2613,6 @@ function onKeyEvent(key as string, press as boolean) as boolean
             end if
         end if
 
-
-
     end if
 
     group = m.global.sceneManager.callFunc("getActiveScene")

--- a/components/home/HomeRows.bs
+++ b/components/home/HomeRows.bs
@@ -2600,19 +2600,18 @@ function onKeyEvent(key as string, press as boolean) as boolean
             end if
         end if
 
-        if isValid(m.top.keyPressedNotifier)
-            numRows = m.top.content.getChildren(-1, 0).count() - 1
-            currentRow = m.top.rowItemFocused[0]
-            numCols = m.top.content.getChild(currentRow).getChildCount() -1
+        ' Keep the focus card up when the press cannot move focus, so it only hides on a real move
+        rows = m.top.content.getChildren(-1, 0)
+        currentRow = m.top.rowItemFocused[0]
+        if currentRow >= 0 and currentRow < rows.count()
             currentCol = m.top.rowItemFocused[1]
-            bottom = (currentRow = numRows) and (key = KeyCode.Down)
-            right = (currentCol = numCols) and (key = KeyCode.Right)
-            left = (currentCol = 0) and (key = KeyCode.Left)
-            if not bottom and not right and not left
+            atBottom = (currentRow = rows.count() - 1) and (key = KeyCode.DOWN)
+            atRight = (currentCol = rows[currentRow].getChildCount() - 1) and (key = KeyCode.RIGHT)
+            atLeft = (currentCol = 0) and (key = KeyCode.LEFT)
+            if not atBottom and not atRight and not atLeft
                 m.top.keyPressedNotifier = not m.top.keyPressedNotifier
             end if
         end if
-
     end if
 
     group = m.global.sceneManager.callFunc("getActiveScene")

--- a/components/home/HomeRows.bs
+++ b/components/home/HomeRows.bs
@@ -2594,15 +2594,26 @@ function onKeyEvent(key as string, press as boolean) as boolean
             return true
         end if
 
-        if isValid(m.top.keyPressedNotifier)
-            m.top.keyPressedNotifier = not m.top.keyPressedNotifier
-        end if
-
         if key = KeyCode.UP
             if m.top.rowItemFocused[0] = 0
                 return false
             end if
         end if
+
+        if isValid(m.top.keyPressedNotifier)
+            numRows = m.top.content.getChildren(-1, 0).count() - 1
+            currentRow = m.top.rowItemFocused[0]
+            numCols = m.top.content.getChild(currentRow).getChildCount() -1
+            currentCol = m.top.rowItemFocused[1]
+            bottom = (currentRow = numRows) and (key = KeyCode.Down)
+            right = (currentCol = numCols) and (key = KeyCode.Right)
+            left = (currentCol = 0) and (key = KeyCode.Left)
+            if not bottom and not right and not left
+                m.top.keyPressedNotifier = not m.top.keyPressedNotifier
+            end if
+        end if
+
+
 
     end if
 


### PR DESCRIPTION
# Pull Request

## Summary
Previously if you click past the end of a home row, the key press triggers hideModernFocusCard() but since focus never changes it doesn't call showModernFocusCard() to bring it back. 

This blocks the keyPressedNotifier on the edges of homeRows (top/bottom/left/right) to avoid hiding the card in these situations. 

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #
- Related to #

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

- move the existing logic for pressing up on top row to be before keyPressNotifier code block
- check if current row/item is at the edge and key pressed would bring user off the edge
- only trigger keyPressedNotifier if none of the edge checks pass

## Testing
Describe how this change was tested.

- [X] Tested on physical Roku device
- [ ] Tested via sideload
- [ ] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. Navigate to bottom of home screen, keep pressing down and the focus card stays
2. Navigate to end of a row, keep pressing right and the focus card stays
3.

## Screenshots (if applicable)
Include screenshots or recordings for UI changes.

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
