### PR TITLE
fix missing path to sidebar from modern details tabs

### DIFF
--- a/components/details/DetailTabBar.bs
+++ b/components/details/DetailTabBar.bs
@@ -114,7 +114,7 @@ function onKeyEvent(key as string, press as boolean) as boolean
         focusTab(m.top.focusIndex + 1)
         return true
     else if key = "left"
-        if m.top.focusIndex <= 0 then return true
+        if m.top.focusIndex <= 0 then return FocusSidebar(m.top)
         focusTab(m.top.focusIndex - 1)
         return true
     else if key = "OK"


### PR DESCRIPTION
# Pull Request

## Summary
Noticed if focus was on modern details tab, you couldn't access sidebar, you had to go up to the action buttons

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #
- Related to #

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

- changed return true to return FocusSidebar(m.top) if pressing left on tab index <= 0
- 
- 

## Testing
Describe how this change was tested.

- [X] Tested on physical Roku device
- [ ] Tested via sideload
- [ ] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. Go to details page (modern)
2. Go down to tabs
3. Go to sidebar (it works now, yay)

## Screenshots (if applicable)
Include screenshots or recordings for UI changes.

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
