### PR TITLE
fix text onAccent theme color

### DIFF
--- a/source/utils/themeApply.bs
+++ b/source/utils/themeApply.bs
@@ -9,7 +9,8 @@ namespace themeApply
         return {
             "background": ["colorBackground"],
             "onBackground": ["colorText", "colorHomeRowHeaders", "colorHomeRowItemTitle"],
-            "accent": ["colorCursor", "colorHomeUsername", "colorHomeMyListIcon", "colorHomeRowItemProgress", "colorDialogSelectedText", "colorWhatsNewAuthor"],
+            "accent": ["colorCursor", "colorHomeUsername", "colorHomeMyListIcon", "colorHomeRowItemProgress", "colorWhatsNewAuthor"],
+            "onAccent": ["colorDialogSelectedText"],
             "surface": ["colorDialogBackground", "colorHomeRowItemBackground"],
             "onSurface": ["colorDialogText", "colorDialogBoldText"],
             "inputBorder": ["colorDialogBorderLine"],


### PR DESCRIPTION
# Pull Request

## Summary
The text on selected buttons was the same color as the button highlight, rendering it invisible. 

This was because the button highlight and the focused text were both pulling from "accent", when the text should be pulling from "onAccent"

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #
- Related to #

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

- 
- 
- 

## Testing
Describe how this change was tested.

- [X] Tested on physical Roku device
- [ ] Tested via sideload
- [ ] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. pull onAccent from theme and apply to colorDialogSelectedText
2. remove colorDialogSelectedText from accent
3.

## Screenshots (if applicable)

Before (invisible text, oh no): 
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/d334d6c2-4f7b-45a1-adeb-20dc0e42fbbd" />

After (visible text, yay): 
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/bdeae4c3-6252-49ec-b223-0c93b430825b" />


## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
