### PR TITLE
fix donation setting showing bool toggle

### DIFF
--- a/settings/settings.json
+++ b/settings/settings.json
@@ -1124,7 +1124,7 @@
         "title": "Support Moonfin",
         "description": "Help support continued development of Moonfin. Press OK to learn more or visit https://buymeacoffee.com/moonfin.",
         "settingName": "moonfin.showDonation",
-        "type": "bool",
+        "type": "",
         "default": "false"
       }
     ]


### PR DESCRIPTION
# Pull Request

## Summary
This PR simply removed the type from the `Support Moonfin` setting. It had bool before, which caused the new toggle icon to display when it wasn't even a boolean setting. The donation dialog continues to display like normal.

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
- Changed `moonfin.showDonation` type to empty

## Testing
- [X] Tested on physical Roku device
- [X] Tested via sideload
- [X] Manual testing completed
- [ ] Not tested (explain why):

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
