### PR TITLE
bugfix-rows - Fix dynamic Genre and Collection home rows

### DIFF
--- a/components/home/HomeRows.bs
+++ b/components/home/HomeRows.bs
@@ -750,7 +750,7 @@ function addServerHomeRow(row as object) as boolean
 
         lowerRowId = LCase(rowId)
         hasCustomPrefix = isValidAndNotEmpty(rowId) and (lowerRowId.startsWith("imdb_") or lowerRowId.startsWith("tmdb_") or lowerRowId.startsWith("seerr_") or lowerRowId.startsWith("plugindynamic:"))
-        hasCustomSource = (rowSource = "custom" or rowSource = "seerr" or rowSource = "tmdb" or rowSource = "letterboxd" or rowSource = "mdblist")
+        hasCustomSource = (rowSource = "custom" or rowSource = "seerr" or rowSource = "tmdb" or rowSource = "letterboxd" or rowSource = "mdblist" or rowSource = "genre" or rowSource = "collection")
         isCustomRow = hasCustomPrefix or hasCustomSource
 
         if isCustomRow
@@ -2888,13 +2888,13 @@ sub updateCustomDynamicRowItems(event as object)
 
     sectionName = ""
     for each serverRow in m.serverHomeRows
-        if serverRow.id = rowId
+        if isStringEqual(serverRow.id, rowId)
             sectionName = serverRow.title
             exit for
         end if
     end for
 
-    if not isValidAndNotEmpty(sectionName) or sectionName = rowId
+    if not isValidAndNotEmpty(sectionName) or isStringEqual(sectionName, rowId)
         mappedName = customDynamicRowTitle(rowId)
         sectionName = isValidAndNotEmpty(mappedName) ? mappedName : rowId
     end if
@@ -2957,6 +2957,8 @@ end function
 ' @param {string} sectionKey - Home section key
 ' @return {boolean} true for rows that have no toggle, otherwise the state of that toggle
 function internalRowEnabled(sectionKey as string) as boolean
+    if m.useServerConfig then return true
+
     settingNames = {
         favorites: "ui.home.displayFavoritesRows",
         collections: "ui.home.displayCollectionsRows",

--- a/components/home/LoadItemsTask.bs
+++ b/components/home/LoadItemsTask.bs
@@ -2231,6 +2231,18 @@ function loadCustomDynamicList(listName as string, additionalData as dynamic) as
             for each item in data.items
                 if not isValid(item) then continue for
 
+                jellyfinId = item.LookupCI("Id")
+                if not isValidAndNotEmpty(jellyfinId) then jellyfinId = item.LookupCI("id")
+
+                ' If this is a native Jellyfin item (e.g., from a dynamic genre or collection row), process via internalRowNode
+                if isValidAndNotEmpty(jellyfinId) and (isChainValid(item, "ImageTags") or isChainValid(item, "PrimaryImageTag") or isChainValid(item, "ServerId") or isChainValid(item, "CollectionType") or not isChainValid(item, "providerIds"))
+                    itemType = item.LookupCI("Type")
+                    if not isValidAndNotEmpty(itemType) then itemType = item.LookupCI("type")
+                    if not isValidAndNotEmpty(itemType) then itemType = "Movie"
+                    results.push(internalRowNode(item, itemType))
+                    continue for
+                end if
+
                 tmdbId = item.LookupCI("tmdbId")
                 if not isValidAndNotEmpty(tmdbId) then tmdbId = item.LookupCI("id")
 


### PR DESCRIPTION
# Pull Request

## Summary
Fix issue where server-synced individual Genre and Collection home rows assigned via Moonbase or other TV clients were failing to populate on the Roku home screen.

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #
- Related to #170 

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [X] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

- **LoadItemsTask.bs**: Added native Jellyfin item handling in `loadCustomDynamicList` so items returned from Moonbase custom row queries (such as dynamic genre or collection rows) build proper `HomeData` nodes with server artwork URLs instead of being discarded for lacking external TMDb/IMDb provider IDs.
- **HomeRows.bs**: Included `genre` and `collection` sources in `hasCustomSource` inside `addServerHomeRow` so dynamic section rows are correctly identified. Used case-insensitive string matching (`isStringEqual`) for row title lookups in `updateCustomDynamicRowItems`, and ensured `internalRowEnabled` bypasses local toggle gating when server configuration sync is active.

## Testing
Describe how this change was tested.

- [ ] Tested on physical Roku device
- [ ] Tested via sideload
- [ ] Manual testing completed
- [X] Not tested (explain why): Paging Jenn

### Test Steps
1. Assign an individual Genre row and Collection row in Moonbase home layout and sync to Roku user profile.
2. Launch Roku client and verify that both the Genre and Collection rows populate with cards and titles on the Home screen.

## Screenshots (if applicable)
Include screenshots or recordings for UI changes.

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
