### PR TITLE
fix modern card hiding when on sidebar

### DIFF
--- a/components/home/Home.bs
+++ b/components/home/Home.bs
@@ -927,7 +927,6 @@ function onKeyEvent(key as string, press as boolean) as boolean
 
         ' Otherwise go to overhang/sidebar if on first row
         if isValid(currentRowIndex) and currentRowIndex = 0
-            hideModernFocusCard()
             if FocusOverhang(m.top) then return true
             return FocusSidebar(m.top)
         end if
@@ -963,7 +962,6 @@ function onKeyEvent(key as string, press as boolean) as boolean
         scene = m.top.getScene()
         sidebar = scene.findNode("sidebar")
         if isValid(sidebar) and sidebar.visible
-            hideModernFocusCard()
             sidebar.setFocus(true)
             return true
         end if


### PR DESCRIPTION
# Pull Request

## Summary
This should be the last hiding focus card interaction lol

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #
- Related to #

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

- remove hideModernFocusCard() before navbar navigation 
- 
- 

## Testing
Describe how this change was tested.

- [X] Tested on physical Roku device
- [ ] Tested via sideload
- [ ] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1.
2.
3.

## Screenshots (if applicable)
Include screenshots or recordings for UI changes.
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/2fd428c3-c4c8-4895-ba95-dba64a7acb30" />


## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
