### PR TITLE
fix modern card appearance issues

### DIFF
--- a/components/home/Home.bs
+++ b/components/home/Home.bs
@@ -1304,6 +1304,11 @@ sub hideModernFocusCard()
     if isValid(m.mfGrow) then m.mfGrow.control = "stop"
     if isValid(m.modernFocusCard) then m.modernFocusCard.visible = false
     m.modernCardShown = false
+
+    if isValid(m.prevReflowRow)
+        resetRowReflow(m.prevReflowRow)
+        m.prevReflowRow = invalid
+    end if
 end sub
 
 ' Slides the items after the focused one to the right so the focused landscape

--- a/components/home/Home.bs
+++ b/components/home/Home.bs
@@ -82,6 +82,7 @@ sub init()
     m.modernCardShown = false
     m.modernShiftAmount = 284
     m.prevReflowRow = invalid
+    m.prevReflowCol = -1
 
     m.showMetadataRow = m.top.findNode("showMetadataRow")
     m.showReleaseYear = m.top.findNode("showReleaseYear")
@@ -314,6 +315,15 @@ end sub
 ' Check if Featured Media should be shown when content loads
 sub onHomeRowsContentLoaded()
     if not isValid(m.mediaBar) or not isValid(m.homeRows) then return
+
+    if m.modernHomeRows and isValid(m.homeRows.content)
+        focused = m.homeRows.rowItemFocused
+        if isValid(focused) and focused.count() = 2
+            if focused[0] >= 0 and focused[1] >= 0
+                applyModernReflow(focused[0], focused[1])
+            end if
+        end if
+    end if
 
     ' Check if Media Bar is enabled via toggle (no longer checking homesection0)
     if isValid(m.homeRows)
@@ -1318,6 +1328,12 @@ sub applyModernReflow(rowIndex as integer, focusedCol as integer)
     if not isValid(m.homeRows.content) then return
     if rowIndex < 0 or focusedCol < 0 then return
 
+    if isValid(m.prevReflowRow) and m.prevReflowRow = rowIndex
+        if m.prevReflowCol = focusedCol
+            return
+        end if
+    end if
+
     ' Reset the previously reflowed row if the focus moved to a different row
     if isValid(m.prevReflowRow) and m.prevReflowRow <> rowIndex
         resetRowReflow(m.prevReflowRow)
@@ -1338,6 +1354,7 @@ sub applyModernReflow(rowIndex as integer, focusedCol as integer)
     end for
 
     m.prevReflowRow = rowIndex
+    m.prevReflowCol = focusedCol
 end sub
 
 sub resetRowReflow(rowIndex as integer)


### PR DESCRIPTION
# Pull Request

## Summary
This PR fixes 2 issues with the modern home card. When the first row (Continue Watching) had a single item, and the media bar mode was Off or Banner, then the homeItem wouldn't appear when the row became unfocused (such as going to overhang/sidebar or to banner). It also fixes an issue in media bar Off mode where the home items would appear behind the modern focus card and the row wouldn't reflow initially until you navigation down->up.

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
- Reset row reflow when modern card is hidden so single item rows reflow back to a normal row.
- Fixed modern home row reflow on initial load in media bar Off mode, ensuring the focused item is hidden under the modern card instead of rendering behind until focus changes.

## Testing
- [X] Tested on physical Roku device
- [X] Tested via sideload
- [X] Manual testing completed
- [ ] Not tested (explain why):

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
