### PR TITLE
hide left media bar arrow when in sidebar nav mode

### DIFF
--- a/components/home/MediaBar.bs
+++ b/components/home/MediaBar.bs
@@ -138,10 +138,6 @@ sub applyCurrentStyle()
         m.logoShadow.visible = false
         m.titleText.visible = false
         m.infoBackground.visible = false
-        m.leftArrow.visible = false
-        m.leftArrowBg.visible = false
-        m.rightArrow.visible = false
-        m.rightArrowBg.visible = false
         m.dotsBackground.visible = false
         m.indicatorDots.visible = false
         m.overviewLabel.visible = false
@@ -185,12 +181,6 @@ sub applyCurrentStyle()
         m.genresLabel.font = "font:SmallestBoldSystemFont"
         m.ratingsRow.labelFont = "font:SmallBoldSystemFont"
         m.overviewLabel.visible = true
-        ' Left Arrow
-        m.leftArrow.visible = true
-        m.leftArrowBg.visible = true
-        ' Right Arrow
-        m.rightArrow.visible = true
-        m.rightArrowBg.visible = true
         ' Dots Background
         m.dotsBackground.visible = true
         ' Dots
@@ -230,12 +220,6 @@ sub applyCurrentStyle()
         m.genresLabel.font = "font:TinyBoldSystemFont"
         m.ratingsRow.labelFont = "font:TinyBoldSystemFont"
         m.overviewLabel.visible = false
-        ' Left Arrow
-        m.leftArrow.visible = true
-        m.leftArrowBg.visible = true
-        ' Right Arrow
-        m.rightArrow.visible = true
-        m.rightArrowBg.visible = true
         ' Dots Background
         m.dotsBackground.visible = false
         ' Dots
@@ -348,6 +332,28 @@ sub applyCurrentStyle()
 
     updateInfoBackgroundSize()
     updateDotsBackgroundSize()
+    updateArrowVisibility()
+end sub
+
+sub updateArrowVisibility()
+    scene = m.top.getScene()
+    sidebarActive = false
+    if isValid(scene)
+        sidebar = scene.findNode("sidebar")
+        sidebarActive = isValid(sidebar) and sidebar.visible
+    end if
+
+    showArrows = false
+    if isValid(m.mediaBarItems) and (m.mediaBarMode = "moonfin" or m.mediaBarMode = "makd")
+        showArrows = m.mediaBarItems.count() > 1
+    end if
+
+    m.rightArrow.visible = showArrows
+    if isValid(m.rightArrowBg) then m.rightArrowBg.visible = showArrows
+
+    showLeft = showArrows and not sidebarActive
+    m.leftArrow.visible = showLeft
+    if isValid(m.leftArrowBg) then m.leftArrowBg.visible = showLeft
 end sub
 
 ' Rebuild backdrop URLs for all items after mode change affects URL params
@@ -364,6 +370,7 @@ sub onFocusChanged(event as object)
     if hasFocus and m.mediaBarItems.count() > 0
         ' Immediately refresh display when focus is gained
         refreshDisplay()
+        updateArrowVisibility()
         ' Resume auto-advance timer
         if isValid(m.autoAdvanceTimer)
             m.autoAdvanceTimer.control = "start"
@@ -480,16 +487,7 @@ sub onMediaBarDataLoaded(event as object)
         else
             createIndicatorDots()
             if m.mediaBarItems.count() > 1
-                scene = m.top.getScene()
-                sidebarActive = false
-                if isValid(scene)
-                    sidebar = scene.findNode("sidebar")
-                    sidebarActive = isValid(sidebar) and sidebar.visible
-                end if
-                showArrows = (m.mediaBarMode <> "banner") and not sidebarActive
-                m.leftArrow.visible = showArrows
-                if isValid(m.leftArrowBg) then m.leftArrowBg.visible = showArrows
-                m.rightArrow.visible = showArrows
+                updateArrowVisibility()
                 startAutoAdvanceTimer()
             end if
             ' Display first item (single backdrop update)


### PR DESCRIPTION
# Pull Request

## Summary
This PR adds a new helper to show/hide arrows based on the navigation mode. Before, both arrows would show on modes that include arrows, even though left navigation is hijacked to go to the sidebar. This hides the left arrow on sidebar mode, so users don't mistakenly think they can go left through media bar items.

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [X] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
- Added `updateArrowVisibility()` which checks if the sidebar is in the scene, checks if media bar mode is moonfin or makd, then using these to determine if either left or right arrows should be shown.
- Removed redundant visibility changes in `applyCurrentStyle()`.
- Removed old sidebar checks in `onMediaBarDataLoaded()` and replaced with a call to the new function.

## Testing
- [X] Tested on physical Roku device
- [X] Tested via sideload
- [X] Manual testing completed
- [ ] Not tested (explain why):

## Screenshots
<img width="1920" height="1080" alt="screenshot-2026-08-03-18 39 05 253" src="https://github.com/user-attachments/assets/ac909d94-1289-41ef-9af2-86b64b741480" />


## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
