### PR TITLE
fix runtime display on shuffle dialog

### DIFF
--- a/components/shuffle/ShuffleDialog.bs
+++ b/components/shuffle/ShuffleDialog.bs
@@ -187,7 +187,9 @@ sub updateItemDetails(index as integer)
         m.officialRatingLabel.text = ""
     end if
 
-    if isValid(runtime) and runtime > 0
+    itemType = item.LookupCI("type")
+
+    if itemType = "Movie" and isValid(runtime) and runtime > 0
         totalMinutes = Int(runtime / 600000000)
         hours = Int(totalMinutes / 60)
         minutes = totalMinutes Mod 60

--- a/components/shuffle/ShuffleDialog.bs
+++ b/components/shuffle/ShuffleDialog.bs
@@ -188,12 +188,13 @@ sub updateItemDetails(index as integer)
     end if
 
     if isValid(runtime) and runtime > 0
-        hours = Int(runtime / 36000000000)
-        minutes = Int((runtime Mod 36000000000) / 600000000)
+        totalMinutes = Int(runtime / 600000000)
+        hours = Int(totalMinutes / 60)
+        minutes = totalMinutes Mod 60
         if hours > 0
             m.runtimeLabel.text = hours.ToStr() + "h " + minutes.ToStr() + "m"
         else
-            m.runtimeLabel.text = minutes.ToStr() + "m"
+            m.runtimeLabel.text = minutes.ToStr() + " min"
         end if
     else
         m.runtimeLabel.text = ""


### PR DESCRIPTION
# Pull Request

## Summary
This PR updates the runtime calculation on the shuffle dialog to match the media bar, fixing the issue of the minutes not displaying. This also hides the runtime when the item is not a Movie.

## Related Issues
- Closes #195

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [X] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
- Updates the calculation for hours and minutes to be displayed in the `runtimeLabel`.
- Guards the runtime calculation to check for item type, and set to empty string when not a Movie.

## Testing
- [X] Tested on physical Roku device
- [X] Tested via sideload
- [X] Manual testing completed
- [ ] Not tested (explain why):

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
