### PR TITLE
update extras row sizes, use cursor color on modern details

### DIFF
--- a/components/details/ModernItemDetails.bs
+++ b/components/details/ModernItemDetails.bs
@@ -591,6 +591,8 @@ sub showSectionGrid(index as integer)
     cardH = size[1]
     spacing = 30
 
+    m.tabGrid.focusBitmapBlendColor = chainLookupReturn(m.global.session, "user.settings.colorCursor", ColorPalette.HIGHLIGHT)
+
     cols = int(1728 / (cardW + spacing))
     if cols < 1 then cols = 1
 

--- a/components/extras/ExtrasItem.bs
+++ b/components/extras/ExtrasItem.bs
@@ -165,8 +165,8 @@ sub showContent()
                     m.rectFocusBorder.height = posterHeight
                 end if
 
-                ' Position text below poster (poster height + 23px spacing to match scaleGroup offset)
-                labelY = posterHeight + 31
+                ' Position text below poster
+                labelY = posterHeight + 5
 
                 ' Check if this is an episode (wide card with IndexNumber)
                 isEpisodeCard = posterWidth >= 400 and isChainValid(cont, "json.IndexNumber")
@@ -250,7 +250,7 @@ sub showContent()
         end if
 
         if isChainValid(cont, "json.officialrating")
-            if cont.json.officialrating <> ""
+            if cont.json.officialrating <> "" and isValidAndNotEmpty(cont.subTitle)
                 cont.subTitle += ` - ${cont.json.officialrating}`
             end if
         end if

--- a/components/extras/ExtrasRowList.bs
+++ b/components/extras/ExtrasRowList.bs
@@ -290,7 +290,7 @@ sub onExtrasLoaded()
                 row.appendChild(season)
             end if
         end for
-        addRowSize([200, 300])
+        addRowSize([200, 330])
     end if
 
     ' 2. Next Episode (for TV shows only)

--- a/components/extras/ExtrasRowList.bs
+++ b/components/extras/ExtrasRowList.bs
@@ -379,18 +379,9 @@ sub onExtrasLoaded()
             item.labelText = item.json.LookupCI("Name")
             item.shortDescriptionLine1 = item.json.LookupCI("Name")
 
-            ' Set year as subtitle
-            if isValid(item.json.LookupCI("ProductionYear"))
-                item.subTitle = stri(item.json.LookupCI("ProductionYear"))
-            else if isValid(item.json.LookupCI("PremiereDate"))
-                premierYear = CreateObject("roDateTime")
-                premierYear.FromISO8601String(item.json.LookupCI("PremiereDate"))
-                item.subTitle = stri(premierYear.GetYear())
-            end if
-
             row.appendChild(item)
         end for
-        addRowSize([180, 270])
+        addRowSize([180, 305])
     end if
 
     ' 5. Special Features

--- a/components/extras/LoadExtrasTask.bs
+++ b/components/extras/LoadExtrasTask.bs
@@ -598,15 +598,6 @@ function loadSimilar() as object
         tmp.labelText = item.Name
         tmp.type = item.Type
 
-        ' Set year as subtitle
-        if isValid(item.ProductionYear)
-            tmp.subTitle = stri(item.ProductionYear)
-        else if isValid(item.PremiereDate)
-            premierYear = CreateObject("roDateTime")
-            premierYear.FromISO8601String(item.PremiereDate)
-            tmp.subTitle = stri(premierYear.GetYear())
-        end if
-
         similar.push(tmp)
     end for
 


### PR DESCRIPTION
# Pull Request

## Summary
This PR updates row sizes of the extras grid so the labels properly display. It also removes the subtitle for similar items, as the core app only shows the title. It also fixes an issue where the users cursor color wasn't showing for the focus of extras items in modern details.

## Related Issues
- Closes #196
- Closes #197
 
## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [X] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
- Updated row size for seasons and similar so the spacing showed the labels.
- Lowered the distance between the poster and the item title label. 
- Set the `focusBitmapBlendColor` to be the users cursor color.

## Testing
- [X] Tested on physical Roku device
- [X] Tested via sideload
- [X] Manual testing completed
- [ ] Not tested (explain why):

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
