### PR TITLE
[Critical] fix inability to use password to sign in

### DIFF
--- a/components/config/SigninScene.bs
+++ b/components/config/SigninScene.bs
@@ -163,6 +163,7 @@ sub showQuickConnect()
     m.quickConnectTimer.control = "start"
 
     m.top.lastFocus = m.quickConnectBack
+    m.quickConnectBack.setFocus(true)
 end sub
 
 sub hideQuickConnect()


### PR DESCRIPTION
# Pull Request

## Summary
This critical PR simply sets focus to the back button when showing quick connect. Before, there was no focused item, therefore navigation in `signInScene` was broken and you couldn't enter a password.

This is only an issue when quick connect is detected. If quick connect is disabled, focus was normal and on password.

## Related Issues
- Closes #186

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
- Set focus to `quickConnectBack` in `showQuickConnect`.

## Testing
- [X] Tested on physical Roku device
- [X] Tested via sideload
- [X] Manual testing completed
- [ ] Not tested (explain why):

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
