### PR TITLE
Preroll crash

### DIFF
--- a/components/manager/QueueManager.bs
+++ b/components/manager/QueueManager.bs
@@ -21,7 +21,7 @@ sub init()
     m.queueTypes = []
     m.isPlaying = false
     ' Preroll videos only play if user has cinema mode setting enabled
-    m.isPrerollActive = m.global.session.user.settings["playback.cinemamode"]
+    m.isPrerollActive = toBoolean(m.global.session.user.settings["playback.cinemamode"])
     m.position = 0
     m.preferredAudioTrackIndex = -1
     m.preferredAudioTrackName = string.EMPTY
@@ -36,7 +36,7 @@ sub clear()
     m.isPlaying = false
     m.queue = []
     m.queueTypes = []
-    m.isPrerollActive = m.global.session.user.settings["playback.cinemamode"]
+    m.isPrerollActive = toBoolean(m.global.session.user.settings["playback.cinemamode"])
     setPosition(0)
     if not m.bypassNextPreferredAudioTrackIndexReset
         setPreferredAudioTrackIndex(-1)

--- a/source/utils/settingsSync.bs
+++ b/source/utils/settingsSync.bs
@@ -136,7 +136,7 @@ namespace settingsSync
             rokuValue = settingsSync.PluginToRoku(pluginValue, mapping.type)
             if not isValid(rokuValue) then continue for
 
-            tmpSettings[mapping.rokuKey] = rokuValue
+            tmpSettings[mapping.rokuKey] = toBoolean(rokuValue)
             if not chainLookupReturn(mapping, "skipRegistry", false)
                 registry_write(mapping.rokuKey, rokuValue, m.global.session.user.id)
             end if


### PR DESCRIPTION
# Pull Request

## Summary
Adds a safeguard in the queue manager to avoid crashes with wonky cinemamode settings sync

Adds a safeguard in settingsSync to ensure boolean values are written correctly to local settings

## Related Issues
Link related issues or tickets separated by commas.

- Closes #203 
- Fixes #
- Related to #

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

- add toBoolean in queueManager to prevent type mismatch
- add toBoolean in settingsSync to ensure bools written correctly moving forward
- 

## Testing
Describe how this change was tested.

- [X] Tested on physical Roku device
- [ ] Tested via sideload
- [ ] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. Playback no longer crashes
2.
3.

## Screenshots (if applicable)
Include screenshots or recordings for UI changes.

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
