### PR TITLE
fix home row padding settings

### DIFF
--- a/components/home/HomeRows.bs
+++ b/components/home/HomeRows.bs
@@ -148,14 +148,32 @@ sub updateSize()
     'Set width of Rows to cut off at edge of Safe Zone
     m.top.itemSize = [1703, itemHeight]
 
-    ' Padding arrives as a number value that needs to be scaled from flutter to roku
-    paddingKey = isModernHomeRows() ? "ui.home.modernRowsPadding" : "ui.home.classicRowsPadding"
-    padding = Val(m.global.session.user.settings[paddingKey])
-    if isModernHomeRows()
+    ' The stored pixel value doesn't map 1:1 to row spacing, so it gets scaled below
+    modernRows = isModernHomeRows()
+    if modernRows
+        paddingKey = "ui.home.modernRowsPadding"
+        minPadding = 360
+        maxPadding = 560
+        defaultPadding = 460
+    else
+        paddingKey = "ui.home.classicRowsPadding"
+        minPadding = 10
+        maxPadding = 130
+        defaultPadding = 30
+    end if
+
+    ' A stored value isn't guaranteed to be a number in range, and the formula turns anything
+    ' below the minimum into zero or negative spacing, so fall back instead
+    storedPadding = m.global.session.user.settings[paddingKey]
+    padding = Val(isValid(storedPadding) ? storedPadding.ToStr() : "")
+    if padding < minPadding or padding > maxPadding then padding = defaultPadding
+
+    if modernRows
         verticalSpacing = (padding - 200) * (padding / 360)
     else
         verticalSpacing = padding * 2
     end if
+
     m.top.itemSpacing = [0, verticalSpacing]
 
     ' spacing between items in a row. Modern keeps cards tight, the focused card

--- a/components/home/HomeRows.bs
+++ b/components/home/HomeRows.bs
@@ -148,29 +148,14 @@ sub updateSize()
     'Set width of Rows to cut off at edge of Safe Zone
     m.top.itemSize = [1703, itemHeight]
 
-    ' spacing between rows (modern reserves space for the focused card info block)
+    ' Padding arrives as a number value that needs to be scaled from flutter to roku
+    paddingKey = isModernHomeRows() ? "ui.home.modernRowsPadding" : "ui.home.classicRowsPadding"
+    padding = Val(m.global.session.user.settings[paddingKey])
     if isModernHomeRows()
-        paddingKey = "ui.home.modernRowsPadding"
-        compactSpacing = 360
-        spaciousSpacing = 560
-        defaultSpacing = 460
+        verticalSpacing = (padding - 200) * (padding / 360)
     else
-        paddingKey = "ui.home.classicRowsPadding"
-        compactSpacing = 10
-        spaciousSpacing = 90
-        defaultSpacing = 30
+        verticalSpacing = padding * 2
     end if
-
-    ' Padding arrives as either a pixel value or a named preset
-    padding = m.global.session.user.settings[paddingKey]
-    paddingStr = isValid(padding) ? padding.ToStr() : ""
-    verticalSpacing = Val(paddingStr)
-    if verticalSpacing <= 0
-        if isStringEqual(paddingStr, "compact") then verticalSpacing = compactSpacing
-        if isStringEqual(paddingStr, "spacious") then verticalSpacing = spaciousSpacing
-        if verticalSpacing <= 0 then verticalSpacing = defaultSpacing
-    end if
-
     m.top.itemSpacing = [0, verticalSpacing]
 
     ' spacing between items in a row. Modern keeps cards tight, the focused card

--- a/settings/settings.json
+++ b/settings/settings.json
@@ -335,48 +335,6 @@
                 "default": "false"
               },
               {
-                "title": "Classic Layout Home Rows Padding",
-                "description": "Adjust vertical padding between home screen rows in classic layout",
-                "settingName": "ui.home.classicRowsPadding",
-                "type": "radio",
-                "default": "30",
-                "options": [
-                  { "title": "10 px", "id": "10" },
-                  { "title": "20 px", "id": "20" },
-                  { "title": "30 px (Default)", "id": "30" },
-                  { "title": "40 px", "id": "40" },
-                  { "title": "50 px", "id": "50" },
-                  { "title": "60 px", "id": "60" },
-                  { "title": "70 px", "id": "70" },
-                  { "title": "80 px", "id": "80" },
-                  { "title": "90 px", "id": "90" },
-                  { "title": "100 px", "id": "100" },
-                  { "title": "110 px", "id": "110" },
-                  { "title": "120 px", "id": "120" },
-                  { "title": "130 px", "id": "130" }
-                ]
-              },
-              {
-                "title": "Modern Layout Home Rows Padding",
-                "description": "Adjust vertical padding between home screen rows in modern layout",
-                "settingName": "ui.home.modernRowsPadding",
-                "type": "radio",
-                "default": "460",
-                "options": [
-                  { "title": "360 px", "id": "360" },
-                  { "title": "380 px", "id": "380" },
-                  { "title": "400 px", "id": "400" },
-                  { "title": "420 px", "id": "420" },
-                  { "title": "440 px", "id": "440" },
-                  { "title": "460 px (Default)", "id": "460" },
-                  { "title": "480 px", "id": "480" },
-                  { "title": "500 px", "id": "500" },
-                  { "title": "520 px", "id": "520" },
-                  { "title": "540 px", "id": "540" },
-                  { "title": "560 px", "id": "560" }
-                ]
-              },
-              {
                 "title": "Recommendation Engine Source",
                 "description": "Select the recommendation engine source for home screen recommendations",
                 "settingName": "ui.home.recommendationSource",
@@ -884,6 +842,48 @@
               }
             ]
           },
+          {
+              "title": "Classic Layout Home Rows Padding",
+              "description": "Adjust vertical padding between home screen rows in classic layout",
+              "settingName": "ui.home.classicRowsPadding",
+              "type": "radio",
+              "default": "30",
+              "options": [
+                { "title": "10 px", "id": "10" },
+                { "title": "20 px", "id": "20" },
+                { "title": "30 px (Default)", "id": "30" },
+                { "title": "40 px", "id": "40" },
+                { "title": "50 px", "id": "50" },
+                { "title": "60 px", "id": "60" },
+                { "title": "70 px", "id": "70" },
+                { "title": "80 px", "id": "80" },
+                { "title": "90 px", "id": "90" },
+                { "title": "100 px", "id": "100" },
+                { "title": "110 px", "id": "110" },
+                { "title": "120 px", "id": "120" },
+                { "title": "130 px", "id": "130" }
+              ]
+            },
+            {
+              "title": "Modern Layout Home Rows Padding",
+              "description": "Adjust vertical padding between home screen rows in modern layout",
+              "settingName": "ui.home.modernRowsPadding",
+              "type": "radio",
+              "default": "460",
+              "options": [
+                { "title": "360 px", "id": "360" },
+                { "title": "380 px", "id": "380" },
+                { "title": "400 px", "id": "400" },
+                { "title": "420 px", "id": "420" },
+                { "title": "440 px", "id": "440" },
+                { "title": "460 px (Default)", "id": "460" },
+                { "title": "480 px", "id": "480" },
+                { "title": "500 px", "id": "500" },
+                { "title": "520 px", "id": "520" },
+                { "title": "540 px", "id": "540" },
+                { "title": "560 px", "id": "560" }
+              ]
+            },
           {
             "title": "Since You Watched Rows Settings",
             "description": "Customize the Since You Watched rows.",

--- a/settings/settings.json
+++ b/settings/settings.json
@@ -843,47 +843,47 @@
             ]
           },
           {
-              "title": "Classic Layout Home Rows Padding",
-              "description": "Adjust vertical padding between home screen rows in classic layout",
-              "settingName": "ui.home.classicRowsPadding",
-              "type": "radio",
-              "default": "30",
-              "options": [
-                { "title": "10 px", "id": "10" },
-                { "title": "20 px", "id": "20" },
-                { "title": "30 px (Default)", "id": "30" },
-                { "title": "40 px", "id": "40" },
-                { "title": "50 px", "id": "50" },
-                { "title": "60 px", "id": "60" },
-                { "title": "70 px", "id": "70" },
-                { "title": "80 px", "id": "80" },
-                { "title": "90 px", "id": "90" },
-                { "title": "100 px", "id": "100" },
-                { "title": "110 px", "id": "110" },
-                { "title": "120 px", "id": "120" },
-                { "title": "130 px", "id": "130" }
-              ]
-            },
-            {
-              "title": "Modern Layout Home Rows Padding",
-              "description": "Adjust vertical padding between home screen rows in modern layout",
-              "settingName": "ui.home.modernRowsPadding",
-              "type": "radio",
-              "default": "460",
-              "options": [
-                { "title": "360 px", "id": "360" },
-                { "title": "380 px", "id": "380" },
-                { "title": "400 px", "id": "400" },
-                { "title": "420 px", "id": "420" },
-                { "title": "440 px", "id": "440" },
-                { "title": "460 px (Default)", "id": "460" },
-                { "title": "480 px", "id": "480" },
-                { "title": "500 px", "id": "500" },
-                { "title": "520 px", "id": "520" },
-                { "title": "540 px", "id": "540" },
-                { "title": "560 px", "id": "560" }
-              ]
-            },
+            "title": "Classic Layout Home Rows Padding",
+            "description": "Adjust vertical padding between home screen rows in classic layout",
+            "settingName": "ui.home.classicRowsPadding",
+            "type": "radio",
+            "default": "30",
+            "options": [
+              { "title": "10 px", "id": "10" },
+              { "title": "20 px", "id": "20" },
+              { "title": "30 px (Default)", "id": "30" },
+              { "title": "40 px", "id": "40" },
+              { "title": "50 px", "id": "50" },
+              { "title": "60 px", "id": "60" },
+              { "title": "70 px", "id": "70" },
+              { "title": "80 px", "id": "80" },
+              { "title": "90 px", "id": "90" },
+              { "title": "100 px", "id": "100" },
+              { "title": "110 px", "id": "110" },
+              { "title": "120 px", "id": "120" },
+              { "title": "130 px", "id": "130" }
+            ]
+          },
+          {
+            "title": "Modern Layout Home Rows Padding",
+            "description": "Adjust vertical padding between home screen rows in modern layout",
+            "settingName": "ui.home.modernRowsPadding",
+            "type": "radio",
+            "default": "460",
+            "options": [
+              { "title": "360 px", "id": "360" },
+              { "title": "380 px", "id": "380" },
+              { "title": "400 px", "id": "400" },
+              { "title": "420 px", "id": "420" },
+              { "title": "440 px", "id": "440" },
+              { "title": "460 px (Default)", "id": "460" },
+              { "title": "480 px", "id": "480" },
+              { "title": "500 px", "id": "500" },
+              { "title": "520 px", "id": "520" },
+              { "title": "540 px", "id": "540" },
+              { "title": "560 px", "id": "560" }
+            ]
+          },
           {
             "title": "Since You Watched Rows Settings",
             "description": "Customize the Since You Watched rows.",


### PR DESCRIPTION
# Pull Request

## Summary
Fixes the home row padding settings to scale more consistently with core. 

Before this the modern row padding options were all way too high, and the classic row padding options scaled too small to where they barely made a difference

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #
- Related to #199

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

- move home row padding outside of home row toggles to match their location in core
- scale padding value from flutter default to something that works better visually on roku
- remove legacy paddingStr as the value will only ever be a number

## Testing
Describe how this change was tested.

- [X] Tested on physical Roku device
- [ ] Tested via sideload
- [ ] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1.
2.
3.

## Screenshots (if applicable)
Classic minimum (10):
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/17f19f80-18b8-432e-b971-70b897dd18d0" />

Classic default (30):
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/d7a45178-1917-4b03-b2dd-1759477583ba" />

Classic medium (80):
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/66284afc-fee9-4678-b435-f03dea854dc1" />

Classic maximum (130):
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/59b8163c-2943-4fa1-9093-03b025c695bb" />

Modern minimum (360):
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/76c8954a-0aad-4f57-9999-2837c433ad7e" />

Modern default (460):
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/15dedd79-f5f9-491b-b17c-38a2570c3f64" />

Modern maximum (560):
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/70b607c9-87b5-458e-b464-51fd69bba3c3" />


## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
