### PR TITLE
push user config settings to jellyfin after pulling from moonbase if …

### DIFF
--- a/source/utils/settingsSync.bs
+++ b/source/utils/settingsSync.bs
@@ -246,6 +246,11 @@ namespace settingsSync
             end if
             if configChanged
                 session.user.Update("Configuration", currentConfig)
+                ' Post the full configuration back so fields this client doesn't manage are preserved
+                m.settingSyncTask = createObject("roSGNode", "PostTask")
+                m.settingSyncTask.apiUrl = "/Users/Configuration"
+                m.settingSyncTask.stringData = FormatJson(currentConfig)
+                m.settingSyncTask.control = "RUN"
             end if
         end if
 


### PR DESCRIPTION
…needed

# Pull Request

## Summary
Default audio/subs settings were updating the local user config after pulling from moonbase, but needed to push those settings to jellyfin for them to take affect. 

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #
- Related to #199 

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

- if config changed, post to jf 
- uses same post method I created when I added these settings to roku
- 

## Testing
Describe how this change was tested.

- [X] Tested on physical Roku device
- [ ] Tested via sideload
- [ ] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1.
2.
3.

## Screenshots (if applicable)
Include screenshots or recordings for UI changes.

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
