### PR TITLE
fix custom osd progress bar time slots

### DIFF
--- a/components/video/OSD.bs
+++ b/components/video/OSD.bs
@@ -16,8 +16,10 @@ sub init()
     m.videoInfo = m.top.findNode("videoInfo")
     m.itemTitle = m.top.findNode("itemTitle")
     m.videoPlayPause = m.top.findNode("videoPlayPause")
-    m.videoRemainingTime = m.top.findNode("videoRemainingTime")
-    m.videoEndingTime = m.top.findNode("videoEndingTime")
+    m.belowLeft = m.top.findNode("belowLeft")
+    m.aboveRight = m.top.findNode("aboveRight")
+    m.belowRight = m.top.findNode("belowRight")
+    m.aboveLeft = m.top.findNode("aboveLeft")
     m.progressBar = m.top.findNode("progressBar")
     m.progressBarBackground = m.top.findNode("progressBarBackground")
     m.progressIndicator = m.top.findNode("progressIndicator")
@@ -34,7 +36,6 @@ sub init()
     m.top.observeField("hasFocus", "onFocusChanged")
     m.top.observeField("progressPercentage", "onProgressPercentageChanged")
     m.top.observeField("playbackState", "onPlaybackStateChanged")
-    m.top.observeField("videoEndingTime", "setVideoEndingTime")
 
     m.top.observeField("itemTitleText", "onItemTitleTextChanged")
     m.top.observeField("itemSubtitleText", "onItemSubtitleTextChanged")
@@ -90,44 +91,48 @@ function formatOSDTimeSlot(slotKey as string) as string
     if slotMode = "remaining" then return "-" + secondsToHuman(m.top.remainingPositionTime, true)
     if slotMode = "endsAt" then return "Ends at " + m.top.videoEndingTime
     if slotMode = "time" then return m.top.videoEndingTime
+    totalTime = m.top.positionTime + m.top.remainingPositionTime
+    if slotMode = "totalTime" then return secondsToHuman(totalTime, true)
     return ""
 end function
+
+sub updateOSDTime()
+    aboveRight = formatOSDTimeSlot("playback.timeAboveRight")
+    if aboveRight <> ""
+        m.aboveRight.text = aboveRight
+    end if
+    belowRight = formatOSDTimeSlot("playback.timeBelowRight")
+    if belowRight <> ""
+        m.belowRight.text = belowRight
+    end if
+    aboveLeft = formatOSDTimeSlot("playback.timeAboveLeft")
+    if aboveLeft <> ""
+        m.aboveLeft.text = aboveLeft
+    end if
+    belowLeft = formatOSDTimeSlot("playback.timeBelowLeft")
+    if aboveRight <> ""
+        m.belowLeft.text = belowLeft
+    end if
+end sub
 
 ' onProgressPercentageChanged: Handler for changes to m.top.progressPercentage param
 '
 sub onProgressPercentageChanged()
-    totalTime = m.top.positionTime + m.top.remainingPositionTime
     m.progressBar.width = m.progressBarBackground.width * m.top.progressPercentage
-
-    aboveLeft = formatOSDTimeSlot("playback.timeAboveLeft")
-    aboveRight = formatOSDTimeSlot("playback.timeAboveRight")
-    if aboveLeft <> "" or aboveRight <> ""
-        m.videoRemainingTime.text = (aboveLeft <> "" ? aboveLeft : "") + (aboveRight <> "" ? " / " + aboveRight : "")
-    else
-        m.videoRemainingTime.text = secondsToHuman(m.top.positionTime, true) + " / " + secondsToHuman(totalTime, true)
-    end if
+    updateOSDTime()
 
     ' Update circle indicator position (centered on progress, offset by circle radius)
     indicatorX = 103 + (m.progressBarBackground.width * m.top.progressPercentage) - 10
     m.progressIndicator.translation = [indicatorX, 812]
 end sub
 
-sub setVideoEndingTime()
-    belowRight = formatOSDTimeSlot("playback.timeBelowRight")
-    if belowRight <> ""
-        m.videoEndingTime.text = belowRight
-    else
-        m.videoEndingTime.text = "Ends at " + m.top.videoEndingTime
-    end if
-end sub
-
 sub updateSeekPreview(totalTime as float)
     newPosition = totalTime * m.seekPercentage
     m.progressBar.width = m.progressBarBackground.width * m.seekPercentage
+    updateOSDTime()
 
     indicatorX = 103 + (m.progressBarBackground.width * m.seekPercentage) - 10
     m.progressIndicator.translation = [indicatorX, 812]
-    m.videoRemainingTime.text = secondsToHuman(newPosition, true) + " / " + secondsToHuman(totalTime, true)
     m.top.action = "seek," + newPosition.ToStr()
 end sub
 

--- a/components/video/OSD.bs
+++ b/components/video/OSD.bs
@@ -20,6 +20,7 @@ sub init()
     m.aboveRight = m.top.findNode("aboveRight")
     m.belowRight = m.top.findNode("belowRight")
     m.aboveLeft = m.top.findNode("aboveLeft")
+    m.clock = m.top.findNode("clock")
     m.progressBar = m.top.findNode("progressBar")
     m.progressBarBackground = m.top.findNode("progressBarBackground")
     m.progressIndicator = m.top.findNode("progressIndicator")
@@ -36,6 +37,8 @@ sub init()
     m.top.observeField("hasFocus", "onFocusChanged")
     m.top.observeField("progressPercentage", "onProgressPercentageChanged")
     m.top.observeField("playbackState", "onPlaybackStateChanged")
+    ' Ends-at is recalculated on a clock timer, so it moves while paused when position doesn't
+    m.top.observeField("videoEndingTime", "updateOSDTime")
 
     m.top.observeField("itemTitleText", "onItemTitleTextChanged")
     m.top.observeField("itemSubtitleText", "onItemSubtitleTextChanged")
@@ -84,35 +87,34 @@ sub init()
     positionSecondaryControls()
 end sub
 
-function formatOSDTimeSlot(slotKey as string) as string
+' A previewPosition below zero means use the live playback position
+function formatOSDTimeSlot(slotKey as string, previewPosition as float) as string
     slotMode = m.global.session.user.settings[slotKey] ?? "none"
     if slotMode = "none" or slotMode = "" then return ""
-    if slotMode = "elapsed" then return secondsToHuman(m.top.positionTime, true)
-    if slotMode = "remaining" then return "-" + secondsToHuman(m.top.remainingPositionTime, true)
-    if slotMode = "endsAt" then return "Ends at " + m.top.videoEndingTime
-    if slotMode = "time" then return m.top.videoEndingTime
+
     totalTime = m.top.positionTime + m.top.remainingPositionTime
-    if slotMode = "totalTime" then return secondsToHuman(totalTime, true)
+    position = previewPosition >= 0 ? previewPosition : m.top.positionTime
+
+    if slotMode = "elapsed" then return secondsToHuman(position, true)
+    if slotMode = "endsAt" then return "Ends at " + m.top.videoEndingTime
+    if slotMode = "time" then return m.clock.callFunc("getFormattedTime", m.clock.callFunc("getCurrentTime"), true)
+    ' Both spellings are accepted because either can be the stored value
+    if slotMode = "timeRemaining" or slotMode = "remaining" then return "-" + secondsToHuman(totalTime - position, true)
+    if slotMode = "totalDuration" or slotMode = "totalTime" then return secondsToHuman(totalTime, true)
     return ""
 end function
 
+' Every slot is assigned so that switching one to None clears whatever it was holding
+sub renderOSDTimeSlots(previewPosition as float)
+    m.aboveLeft.text = formatOSDTimeSlot("playback.timeAboveLeft", previewPosition)
+    m.aboveRight.text = formatOSDTimeSlot("playback.timeAboveRight", previewPosition)
+    m.belowLeft.text = formatOSDTimeSlot("playback.timeBelowLeft", previewPosition)
+    m.belowRight.text = formatOSDTimeSlot("playback.timeBelowRight", previewPosition)
+end sub
+
+' Observer callbacks receive an event argument when they declare a parameter, so this stays bare
 sub updateOSDTime()
-    aboveRight = formatOSDTimeSlot("playback.timeAboveRight")
-    if aboveRight <> ""
-        m.aboveRight.text = aboveRight
-    end if
-    belowRight = formatOSDTimeSlot("playback.timeBelowRight")
-    if belowRight <> ""
-        m.belowRight.text = belowRight
-    end if
-    aboveLeft = formatOSDTimeSlot("playback.timeAboveLeft")
-    if aboveLeft <> ""
-        m.aboveLeft.text = aboveLeft
-    end if
-    belowLeft = formatOSDTimeSlot("playback.timeBelowLeft")
-    if aboveRight <> ""
-        m.belowLeft.text = belowLeft
-    end if
+    renderOSDTimeSlots(-1)
 end sub
 
 ' onProgressPercentageChanged: Handler for changes to m.top.progressPercentage param
@@ -129,7 +131,7 @@ end sub
 sub updateSeekPreview(totalTime as float)
     newPosition = totalTime * m.seekPercentage
     m.progressBar.width = m.progressBarBackground.width * m.seekPercentage
-    updateOSDTime()
+    renderOSDTimeSlots(newPosition)
 
     indicatorX = 103 + (m.progressBarBackground.width * m.seekPercentage) - 10
     m.progressIndicator.translation = [indicatorX, 812]

--- a/components/video/OSD.xml
+++ b/components/video/OSD.xml
@@ -30,8 +30,10 @@
     </Group>
     <Poster id="progressIndicator" uri="pkg:/images/icons/circle.png" width="20" height="20" translation="[103,812]" loadDisplayMode="scaleToFit" />
 
-    <Text id="videoEndingTime" font="font:SmallSystemFont" color="0xffffffFF" horizAlign="right" width="300" translation="[1517,780]" />
-    <Text id="videoRemainingTime" font="font:MediumSystemFont" color="0xffffffFF" horizAlign="left" width="300" translation="[103,855]" />
+    <Text id="aboveRight" font="font:SmallSystemFont" color="0xffffffFF" horizAlign="right" width="300" translation="[1517,780]" />
+    <Text id="belowLeft" font="font:MediumSystemFont" color="0xffffffFF" horizAlign="left" width="300" translation="[103,855]" />
+    <Text id="belowRight" font="font:MediumSystemFont" color="0xffffffFF" horizAlign="right" width="300" translation="[1517,855]" />
+    <Text id="aboveLeft" font="font:MediumSystemFont" color="0xffffffFF" horizAlign="left" width="300" translation="[103,780]" />
 
     <!-- Secondary controls (same row as transport, positioned dynamically) -->
     <LayoutGroup id="secondaryControls" itemSpacings="[20]" layoutDirection="horiz" horizAlignment="left" translation="[843,920]">

--- a/components/video/OSD.xml
+++ b/components/video/OSD.xml
@@ -30,7 +30,7 @@
     </Group>
     <Poster id="progressIndicator" uri="pkg:/images/icons/circle.png" width="20" height="20" translation="[103,812]" loadDisplayMode="scaleToFit" />
 
-    <Text id="aboveRight" font="font:SmallSystemFont" color="0xffffffFF" horizAlign="right" width="300" translation="[1517,780]" />
+    <Text id="aboveRight" font="font:MediumSystemFont" color="0xffffffFF" horizAlign="right" width="300" translation="[1517,780]" />
     <Text id="belowLeft" font="font:MediumSystemFont" color="0xffffffFF" horizAlign="left" width="300" translation="[103,855]" />
     <Text id="belowRight" font="font:MediumSystemFont" color="0xffffffFF" horizAlign="right" width="300" translation="[1517,855]" />
     <Text id="aboveLeft" font="font:MediumSystemFont" color="0xffffffFF" horizAlign="left" width="300" translation="[103,780]" />

--- a/settings/settings.json
+++ b/settings/settings.json
@@ -1984,9 +1984,9 @@
               { "title": "None", "id": "none" },
               { "title": "Current Time", "id": "time" },
               { "title": "Elapsed Time", "id": "elapsed" },
-              { "title": "Remaining Time", "id": "remaining" },
+              { "title": "Remaining Time", "id": "timeRemaining" },
               { "title": "Ends At Time", "id": "endsAt" },
-              { "title": "Total Duration", "id": "totalTime" }
+              { "title": "Total Duration", "id": "totalDuration" }
             ]
           },
           {
@@ -1999,9 +1999,9 @@
               { "title": "None", "id": "none" },
               { "title": "Current Time", "id": "time" },
               { "title": "Elapsed Time", "id": "elapsed" },
-              { "title": "Remaining Time", "id": "remaining" },
+              { "title": "Remaining Time", "id": "timeRemaining" },
               { "title": "Ends At Time", "id": "endsAt" },
-              { "title": "Total Duration", "id": "totalTime" }
+              { "title": "Total Duration", "id": "totalDuration" }
             ]
           },
           {
@@ -2014,24 +2014,24 @@
               { "title": "None", "id": "none" },
               { "title": "Current Time", "id": "time" },
               { "title": "Elapsed Time", "id": "elapsed" },
-              { "title": "Remaining Time", "id": "remaining" },
+              { "title": "Remaining Time", "id": "timeRemaining" },
               { "title": "Ends At Time", "id": "endsAt" },
-              { "title": "Total Duration", "id": "totalTime" }
+              { "title": "Total Duration", "id": "totalDuration" }
             ]
           },
           {
             "title": "Progress Bar Time Below Right",
-            "description": "Select information to display below the progress bar after the below left option",
+            "description": "Select information to display below the progress bar on the right side",
             "settingName": "playback.timeBelowRight",
             "type": "radio",
-            "default": "totalTime",
+            "default": "totalDuration",
             "options": [
               { "title": "None", "id": "none" },
               { "title": "Current Time", "id": "time" },
               { "title": "Elapsed Time", "id": "elapsed" },
-              { "title": "Remaining Time", "id": "remaining" },
+              { "title": "Remaining Time", "id": "timeRemaining" },
               { "title": "Ends At Time", "id": "endsAt" },
-              { "title": "Total Duration", "id": "totalTime" }
+              { "title": "Total Duration", "id": "totalDuration" }
             ]
           }
         ]

--- a/settings/settings.json
+++ b/settings/settings.json
@@ -1975,9 +1975,24 @@
             ]
           },
           {
-            "title": "Media Bar Playback Time Above Left",
+            "title": "Progress Bar Time Above Left",
             "description": "Select information to display above the progress bar on the left side",
             "settingName": "playback.timeAboveLeft",
+            "type": "radio",
+            "default": "none",
+            "options": [
+              { "title": "None", "id": "none" },
+              { "title": "Current Time", "id": "time" },
+              { "title": "Elapsed Time", "id": "elapsed" },
+              { "title": "Remaining Time", "id": "remaining" },
+              { "title": "Ends At Time", "id": "endsAt" },
+              { "title": "Total Duration", "id": "totalTime" }
+            ]
+          },
+          {
+            "title": "Progress Bar Time Below Left",
+            "description": "Select information to display below the progress bar on the left side",
+            "settingName": "playback.timeBelowLeft",
             "type": "radio",
             "default": "elapsed",
             "options": [
@@ -1985,69 +2000,14 @@
               { "title": "Current Time", "id": "time" },
               { "title": "Elapsed Time", "id": "elapsed" },
               { "title": "Remaining Time", "id": "remaining" },
-              { "title": "Ends At Time", "id": "endsAt" }
+              { "title": "Ends At Time", "id": "endsAt" },
+              { "title": "Total Duration", "id": "totalTime" }
             ]
           },
           {
-            "title": "Media Bar Playback Time Above Center",
-            "description": "Select information to display above the progress bar in the center",
-            "settingName": "playback.timeAboveCenter",
-            "type": "radio",
-            "default": "none",
-            "options": [
-              { "title": "None", "id": "none" },
-              { "title": "Current Time", "id": "time" },
-              { "title": "Elapsed Time", "id": "elapsed" },
-              { "title": "Remaining Time", "id": "remaining" },
-              { "title": "Ends At Time", "id": "endsAt" }
-            ]
-          },
-          {
-            "title": "Media Bar Playback Time Above Right",
+            "title": "Progress Bar Time Above Right",
             "description": "Select information to display above the progress bar on the right side",
             "settingName": "playback.timeAboveRight",
-            "type": "radio",
-            "default": "remaining",
-            "options": [
-              { "title": "None", "id": "none" },
-              { "title": "Current Time", "id": "time" },
-              { "title": "Elapsed Time", "id": "elapsed" },
-              { "title": "Remaining Time", "id": "remaining" },
-              { "title": "Ends At Time", "id": "endsAt" }
-            ]
-          },
-          {
-            "title": "Media Bar Playback Time Below Left",
-            "description": "Select information to display below the progress bar on the left side",
-            "settingName": "playback.timeBelowLeft",
-            "type": "radio",
-            "default": "none",
-            "options": [
-              { "title": "None", "id": "none" },
-              { "title": "Current Time", "id": "time" },
-              { "title": "Elapsed Time", "id": "elapsed" },
-              { "title": "Remaining Time", "id": "remaining" },
-              { "title": "Ends At Time", "id": "endsAt" }
-            ]
-          },
-          {
-            "title": "Media Bar Playback Time Below Center",
-            "description": "Select information to display below the progress bar in the center",
-            "settingName": "playback.timeBelowCenter",
-            "type": "radio",
-            "default": "none",
-            "options": [
-              { "title": "None", "id": "none" },
-              { "title": "Current Time", "id": "time" },
-              { "title": "Elapsed Time", "id": "elapsed" },
-              { "title": "Remaining Time", "id": "remaining" },
-              { "title": "Ends At Time", "id": "endsAt" }
-            ]
-          },
-          {
-            "title": "Media Bar Playback Time Below Right",
-            "description": "Select information to display below the progress bar on the right side",
-            "settingName": "playback.timeBelowRight",
             "type": "radio",
             "default": "endsAt",
             "options": [
@@ -2055,7 +2015,23 @@
               { "title": "Current Time", "id": "time" },
               { "title": "Elapsed Time", "id": "elapsed" },
               { "title": "Remaining Time", "id": "remaining" },
-              { "title": "Ends At Time", "id": "endsAt" }
+              { "title": "Ends At Time", "id": "endsAt" },
+              { "title": "Total Duration", "id": "totalTime" }
+            ]
+          },
+          {
+            "title": "Progress Bar Time Below Right",
+            "description": "Select information to display below the progress bar after the below left option",
+            "settingName": "playback.timeBelowRight",
+            "type": "radio",
+            "default": "totalTime",
+            "options": [
+              { "title": "None", "id": "none" },
+              { "title": "Current Time", "id": "time" },
+              { "title": "Elapsed Time", "id": "elapsed" },
+              { "title": "Remaining Time", "id": "remaining" },
+              { "title": "Ends At Time", "id": "endsAt" },
+              { "title": "Total Duration", "id": "totalTime" }
             ]
           }
         ]

--- a/source/utils/settingsSync.bs
+++ b/source/utils/settingsSync.bs
@@ -119,10 +119,8 @@ namespace settingsSync
             { pluginKey: "mergeRadarrSonarrCalendars", rokuKey: "calendar.merge", type: "bool" },
 
             { pluginKey: "playbackTimeAboveLeft", rokuKey: "playback.timeAboveLeft", type: "direct" },
-            { pluginKey: "playbackTimeAboveCenter", rokuKey: "playback.timeAboveCenter", type: "direct" },
             { pluginKey: "playbackTimeAboveRight", rokuKey: "playback.timeAboveRight", type: "direct" },
             { pluginKey: "playbackTimeBelowLeft", rokuKey: "playback.timeBelowLeft", type: "direct" },
-            { pluginKey: "playbackTimeBelowCenter", rokuKey: "playback.timeBelowCenter", type: "direct" },
             { pluginKey: "playbackTimeBelowRight", rokuKey: "playback.timeBelowRight", type: "direct" },
             { pluginKey: "musicPlaybackTimeDisplay", rokuKey: "playback.musicTimeDisplay", type: "direct" },
 


### PR DESCRIPTION
# Pull Request

## Summary
Make the osd progress bar time slot settings actually work correctly

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #
- Related to #199 

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

- removed existing videoEndTime and videoRemaining time text labels
- create new below/above/Left/Right text labels in their proper positions
- create updateOSDTime helper function to update all 4 text labels based on their settings
- anytime the existing text labels got updated, replace with a call to updateOSDTime

## Testing
Describe how this change was tested.

- [X] Tested on physical Roku device
- [ ] Tested via sideload
- [ ] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. Tested all 6 time label options in all 4 slots
2.
3.

## Screenshots (if applicable)
Default:
- Above left: none
- Below left: elapsed
- Above right: ends at
- Below right: total time
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/13cc789c-4910-450e-a8c9-26764f85b910" />


## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
