### PR TITLE
fix skip length unit conversion when syncing to/from moonbase

### DIFF
--- a/source/utils/settingsSync.bs
+++ b/source/utils/settingsSync.bs
@@ -58,8 +58,8 @@ namespace settingsSync
             { pluginKey: "autoplayNextEpisode", rokuKey: "playback.showNextUpAfterFinish", type: "bool" },
             { pluginKey: "resumeSubtractDuration", rokuKey: "playback.resumeRewind", type: "intToStr" },
             { pluginKey: "unpauseRewindDuration", rokuKey: "playback.unpauseRewind", type: "intToStr" },
-            { pluginKey: "skipBackLength", rokuKey: "playback.skipBackLength", type: "intToStr" },
-            { pluginKey: "skipForwardLength", rokuKey: "playback.skipForwardLength", type: "intToStr" },
+            { pluginKey: "skipBackLength", rokuKey: "playback.skipBackLength", type: "secondsToMs" },
+            { pluginKey: "skipForwardLength", rokuKey: "playback.skipForwardLength", type: "secondsToMs" },
             { pluginKey: "preferAudioDescription", rokuKey: "playback.preferAudioDescription", type: "bool" },
             { pluginKey: "preferSdhSubtitles", rokuKey: "playback.preferSdhSubtitles", type: "bool" },
             { pluginKey: "seerrBlockNsfw", rokuKey: "seerr.blockNsfw", type: "bool" },
@@ -167,13 +167,7 @@ namespace settingsSync
             pluginValue = profile[mapping.pluginKey]
             if not isValid(pluginValue) then continue for
 
-            if mapping.pluginKey = "skipForwardLength" or mapping.pluginKey = "skipBackLength"
-                newValue = pluginValue / 1000
-            else
-                newValue = pluginValue
-            end if
-
-            rokuValue = settingsSync.PluginToRoku(newValue, mapping.type)
+            rokuValue = settingsSync.PluginToRoku(pluginValue, mapping.type)
             if not isValid(rokuValue) then continue for
 
             tmpSettings[mapping.rokuKey] = toBoolean(rokuValue)
@@ -307,16 +301,10 @@ namespace settingsSync
     sub PushToServer(rokuKey as string, rokuValue as dynamic)
         if not settingsSync.IsSyncEnabled() then return
 
-        if rokuKey = "playback.skipForwardLength" or rokuKey = "playback.skipBackLength"
-            newValue = rokuValue * 1000
-        else
-            newValue = rokuValue
-        end if
-
         mapping = settingsSync.FindMappingByRokuKey(rokuKey)
         if not isValid(mapping)
             if Left(rokuKey, 10) = "seerr.row."
-                pushData = settingsSync.PreparePush(rokuKey, newValue)
+                pushData = settingsSync.PreparePush(rokuKey, rokuValue)
                 if isValid(pushData)
                     task = createObject("roSGNode", "PostTask")
                     task.apiUrl = pushData.url
@@ -327,7 +315,7 @@ namespace settingsSync
             return
         end if
 
-        pluginValue = settingsSync.RokuToPlugin(newValue, mapping.type)
+        pluginValue = settingsSync.RokuToPlugin(rokuValue, mapping.type)
         if not isValid(pluginValue) then return
 
         profileData = {}
@@ -443,6 +431,13 @@ namespace settingsSync
             return isTrue ? "false" : "true"
         else if conversionType = "intToStr"
             return pluginValue.toStr()
+        else if conversionType = "secondsToMs"
+            ' A reading under a second is already in seconds, since the smallest value stored
+            ' as milliseconds is 1000
+            raw = val(pluginValue.toStr())
+            if raw <= 0 then return invalid
+            if raw >= 1000 then raw = raw / 1000
+            return int(raw).toStr()
         else if conversionType = "jsonArray"
             if type(pluginValue) = "roArray" or type(pluginValue) = "Array"
                 return FormatJson(pluginValue)
@@ -501,6 +496,10 @@ namespace settingsSync
             return not (LCase(rokuStr) = "true")
         else if conversionType = "intToStr"
             return val(rokuStr)
+        else if conversionType = "secondsToMs"
+            seconds = int(val(rokuStr))
+            if seconds <= 0 then return invalid
+            return seconds * 1000
         else if conversionType = "jsonArray"
             parsed = ParseJson(rokuStr)
             if type(parsed) = "roArray" or type(parsed) = "Array"

--- a/source/utils/settingsSync.bs
+++ b/source/utils/settingsSync.bs
@@ -167,7 +167,13 @@ namespace settingsSync
             pluginValue = profile[mapping.pluginKey]
             if not isValid(pluginValue) then continue for
 
-            rokuValue = settingsSync.PluginToRoku(pluginValue, mapping.type)
+            if mapping.pluginKey = "skipForwardLength" or mapping.pluginKey = "skipBackLength"
+                newValue = pluginValue / 1000
+            else
+                newValue = pluginValue
+            end if
+
+            rokuValue = settingsSync.PluginToRoku(newValue, mapping.type)
             if not isValid(rokuValue) then continue for
 
             tmpSettings[mapping.rokuKey] = toBoolean(rokuValue)
@@ -301,10 +307,16 @@ namespace settingsSync
     sub PushToServer(rokuKey as string, rokuValue as dynamic)
         if not settingsSync.IsSyncEnabled() then return
 
+        if rokuKey = "playback.skipForwardLength" or rokuKey = "playback.skipBackLength"
+            newValue = rokuValue * 1000
+        else
+            newValue = rokuValue
+        end if
+
         mapping = settingsSync.FindMappingByRokuKey(rokuKey)
         if not isValid(mapping)
             if Left(rokuKey, 10) = "seerr.row."
-                pushData = settingsSync.PreparePush(rokuKey, rokuValue)
+                pushData = settingsSync.PreparePush(rokuKey, newValue)
                 if isValid(pushData)
                     task = createObject("roSGNode", "PostTask")
                     task.apiUrl = pushData.url
@@ -315,7 +327,7 @@ namespace settingsSync
             return
         end if
 
-        pluginValue = settingsSync.RokuToPlugin(rokuValue, mapping.type)
+        pluginValue = settingsSync.RokuToPlugin(newValue, mapping.type)
         if not isValid(pluginValue) then return
 
         profileData = {}


### PR DESCRIPTION
# Pull Request

## Summary
Moonbase stores skip length in ms, roku uses s

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #
- Related to #199

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

- divide skipForward/BackLength by 1000 when pulling from server
- multiply when pushing
- 

## Testing
Describe how this change was tested.

- [X] Tested on physical Roku device
- [ ] Tested via sideload
- [ ] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. Before it was pulling from moonbase as "30000", when it should be "30 sec"
2. Now it correctly converts and shows "30 sec"
3.

## Screenshots (if applicable)
Include screenshots or recordings for UI changes.

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
