### PR TITLE
map navbar color between moonbase and roku

### DIFF
--- a/settings/settings.json
+++ b/settings/settings.json
@@ -88,11 +88,11 @@
               },
               {
                 "title": "Moonfin Cyan",
-                "id": "0xFF00A4DC"
+                "id": "0x00A4DC"
               },
               {
                 "title": "Neon Pulse Magenta",
-                "id": "0xFFFF2E92"
+                "id": "0xFF2E92"
               }
             ]
           },
@@ -1214,6 +1214,14 @@
               {
                 "title": "Teal - Blue-green",
                 "id": "0x00695C"
+              },
+              {
+                "title": "Moonfin Cyan",
+                "id": "0x00A4DC"
+              },
+              {
+                "title": "Neon Pulse Magenta",
+                "id": "0xFF2E92"
               }
             ]
           },

--- a/settings/settings.json
+++ b/settings/settings.json
@@ -35,6 +35,10 @@
             "default": "0x475569",
             "options": [
               {
+                "title": "White - Pure white",
+                "id": "0xFFFFFF"
+              },
+              {
                 "title": "Black - Pure black",
                 "id": "0x000000"
               },
@@ -81,6 +85,14 @@
               {
                 "title": "Teal - Blue-green",
                 "id": "0x00695C"
+              },
+              {
+                "title": "Moonfin Cyan",
+                "id": "0xFF00A4DC"
+              },
+              {
+                "title": "Neon Pulse Magenta",
+                "id": "0xFFFF2E92"
               }
             ]
           },

--- a/source/utils/settingsSync.bs
+++ b/source/utils/settingsSync.bs
@@ -22,7 +22,7 @@ namespace settingsSync
             { pluginKey: "showLibrariesInToolbar", rokuKey: "navbar.show_libraries", type: "bool" },
             { pluginKey: "showShuffleButton", rokuKey: "navbar.show_shuffle", type: "bool" },
             { pluginKey: "navbarOpacity", rokuKey: "navbar.opacity", type: "opacityToPercent" },
-            { pluginKey: "navbarColor", rokuKey: "navbar.color", type: "colorHex" },
+            { pluginKey: "navbarColor", rokuKey: "navbar.color", type: "colorName" },
             { pluginKey: "homeImageUseSeriesImage", rokuKey: "ui.home.preferThumbnails", type: "boolInvert" },
             { pluginKey: "mergeContinueWatchingNextUp", rokuKey: "ui.home.mergeContinueWatchingNextUp", type: "bool" },
             { pluginKey: "enableMultiServerLibraries", rokuKey: "ui.home.enableMultiServer", type: "bool" },
@@ -143,6 +143,26 @@ namespace settingsSync
             { pluginKey: "preferDefaultAudioTrack", rokuKey: "playback.playDefaultAudioTrack", type: "bool" },
 
             { pluginKey: "customThemeId", rokuKey: "ui.theme.customThemeId", type: "direct" }
+        ]
+    end function
+
+    function ColorMapping() as object
+        return [
+            { pluginColor: "white", rokuColor: "0xFFFFFF" },
+            { pluginColor: "black", rokuColor: "0x000000" },
+            { pluginColor: "gray", rokuColor: "0x808080" },
+            { pluginColor: "darkBlue", rokuColor: "0x1A2332" },
+            { pluginColor: "purple", rokuColor: "0x4A148C" },
+            { pluginColor: "teal", rokuColor: "0x00695C" },
+            { pluginColor: "navy", rokuColor: "0x0D1B2A" },
+            { pluginColor: "charcoal", rokuColor: "0x36454F" },
+            { pluginColor: "brown", rokuColor: "0x3E2723" },
+            { pluginColor: "darkRed", rokuColor: "0x8B0000" },
+            { pluginColor: "darkGreen", rokuColor: "0x0B4F0F" },
+            { pluginColor: "slate", rokuColor: "0x475569" },
+            { pluginColor: "indigo", rokuColor: "0x1E3A8A" },
+            { pluginColor: "moonfinCyan", rokuColor: "0xFF00A4DC" },
+            { pluginColor: "neonPulseMagenta", rokuColor: "0xFFFF2E92" }
         ]
     end function
 
@@ -474,6 +494,15 @@ namespace settingsSync
             if valStr = "onlyforced" then return "OnlyForced"
             if valStr = "none" then return "None"
             return "Default"
+        else if conversionType = "colorName"
+            colorStr = pluginValue.toStr()
+            mappings = settingsSync.ColorMapping()
+            for each mapping in mappings
+                if mapping.pluginColor = colorStr
+                    return mapping.rokuColor
+                end if
+            end for
+            return colorStr
         end if
         return invalid
     end function
@@ -524,6 +553,14 @@ namespace settingsSync
             if valStr = "onlyforced" then return "onlyforced"
             if valStr = "none" then return "none"
             return "default"
+        else if conversionType = "colorName"
+            mappings = settingsSync.ColorMapping()
+            for each mapping in mappings
+                if mapping.rokuColor = rokuStr
+                    return mapping.pluginColor
+                end if
+            end for
+            return ""
         end if
         return invalid
     end function

--- a/source/utils/settingsSync.bs
+++ b/source/utils/settingsSync.bs
@@ -38,7 +38,7 @@ namespace settingsSync
             { pluginKey: "mediaBarItemCount", rokuKey: "ui.home.featuredMediaItems", type: "intToStr" },
             { pluginKey: "mediaBarIntervalMs", rokuKey: "ui.home.mediaBarIntervalMs", type: "intToStr" },
             { pluginKey: "mediaBarOpacity", rokuKey: "ui.overlayOpacity", type: "opacityToPercent" },
-            { pluginKey: "mediaBarOverlayColor", rokuKey: "ui.overlayColor", type: "colorHex" },
+            { pluginKey: "mediaBarOverlayColor", rokuKey: "ui.overlayColor", type: "colorName" },
             { pluginKey: "shuffleContentType", rokuKey: "shuffle_content_type", type: "shuffleType" },
             { pluginKey: "detailScreenStyle", rokuKey: "ui.itemdetail.style", type: "direct" },
             { pluginKey: "detailExpandedTabs", rokuKey: "ui.itemdetail.expandedTabs", type: "bool" },
@@ -161,9 +161,16 @@ namespace settingsSync
             { pluginColor: "darkGreen", rokuColor: "0x0B4F0F" },
             { pluginColor: "slate", rokuColor: "0x475569" },
             { pluginColor: "indigo", rokuColor: "0x1E3A8A" },
-            { pluginColor: "moonfinCyan", rokuColor: "0xFF00A4DC" },
-            { pluginColor: "neonPulseMagenta", rokuColor: "0xFFFF2E92" }
+            { pluginColor: "moonfinCyan", rokuColor: "0x00A4DC" },
+            { pluginColor: "neonPulseMagenta", rokuColor: "0xFF2E92" }
         ]
+    end function
+
+    ' A stored name can be camelCase or snake_case depending on what wrote it, so both sides
+    ' of a comparison get flattened before matching
+    function NormalizeColorName(name as dynamic) as string
+        if not isValid(name) then return ""
+        return LCase(name.toStr().Trim().Replace("_", ""))
     end function
 
     function IsSyncEnabled() as boolean
@@ -476,12 +483,6 @@ namespace settingsSync
             if rounded >= 1 then return "1.0"
             return rounded.toStr()
 
-        else if conversionType = "colorHex"
-            colorStr = pluginValue.toStr()
-            if colorStr.left(1) = "#"
-                colorStr = "0x" + colorStr.mid(1)
-            end if
-            return colorStr
         else if conversionType = "shuffleType"
             pluginStr = LCase(pluginValue.toStr())
             if pluginStr = "movies" then return "movies_only"
@@ -495,14 +496,14 @@ namespace settingsSync
             if valStr = "none" then return "None"
             return "Default"
         else if conversionType = "colorName"
-            colorStr = pluginValue.toStr()
-            mappings = settingsSync.ColorMapping()
-            for each mapping in mappings
-                if mapping.pluginColor = colorStr
+            colorStr = settingsSync.NormalizeColorName(pluginValue)
+            for each mapping in settingsSync.ColorMapping()
+                if settingsSync.NormalizeColorName(mapping.pluginColor) = colorStr
                     return mapping.rokuColor
                 end if
             end for
-            return colorStr
+            ' Returning invalid keeps the stored colour instead of overwriting it with a name
+            return invalid
         end if
         return invalid
     end function
@@ -534,14 +535,6 @@ namespace settingsSync
             rokuFloat = val(rokuStr)
             return int(rokuFloat * 100 + 0.5)
 
-        else if conversionType = "colorHex"
-            ' Roku writes colours as 0xRRGGBB, the server and the other clients read
-            ' #RRGGBB. Without turning it back the pushed value reaches them unusable.
-            colorStr = rokuStr
-            if LCase(colorStr.left(2)) = "0x"
-                colorStr = "#" + colorStr.mid(2)
-            end if
-            return colorStr
         else if conversionType = "shuffleType"
             if rokuStr = "movies_only" then return "movies"
             if rokuStr = "tv_only" then return "tv"
@@ -554,13 +547,14 @@ namespace settingsSync
             if valStr = "none" then return "none"
             return "default"
         else if conversionType = "colorName"
-            mappings = settingsSync.ColorMapping()
-            for each mapping in mappings
-                if mapping.rokuColor = rokuStr
+            colorStr = UCase(rokuStr.Trim())
+            for each mapping in settingsSync.ColorMapping()
+                if UCase(mapping.rokuColor) = colorStr
                     return mapping.pluginColor
                 end if
             end for
-            return ""
+            ' Returning invalid skips the push, since a nameless colour would clear the server value
+            return invalid
         end if
         return invalid
     end function


### PR DESCRIPTION
# Pull Request

## Summary
Moonbase stores navbarColor as the color name (eg "slate"), whereas Roku needs the hex code (eg "0x475569")

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #187 
- Related to #

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

- create ColorMapping to map the color names to codes
- change navbarColor setting sync conversion type to colorName
- for conversion type colorName, use ColorMapping as LUT
- add white/cyan/magenta color options

## Testing
Describe how this change was tested.

- [X] Tested on physical Roku device
- [ ] Tested via sideload
- [ ] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. Set navbarColor in moonbase
2. Push to user
3. Sidebar is no longer black on roku

## Screenshots (if applicable)
This was directly after opening the app (post moonbase push):
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/f4903a03-7840-4899-af70-6eeab457dbc7" />


## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
