### PR TITLE
remove mediabar focus steal when returning to home from home row item

### DIFF
--- a/components/home/Home.bs
+++ b/components/home/Home.bs
@@ -664,30 +664,13 @@ sub OnScreenShown(_isReturning = false as boolean)
     if isValid(scenePreviousFocus)
         ' Check if the saved focus was homeRows itself or a child of homeRows
         if scenePreviousFocus.isSameNode(m.homeRows) or isChildOf(scenePreviousFocus, m.homeRows)
-            mediaBarCheck = m.homeRows.callFunc("isFeaturedMediaEnabled")
-            if isValid(mediaBarCheck) and type(mediaBarCheck) = "roBoolean"
-                m.isMediaBarEnabled = mediaBarCheck
+            m.homeRows.setFocus(true)
+            focusRestored = true
+
+            if _isReturning
+                onItemFocusChanged()
             end if
-
-            if m.isMediaBarEnabled and isValid(m.mediaBar)
-                m.currentFocusedItemId = ""
-                m.currentFocusedItemServerUrl = invalid
-
-                m.mediaBar.setFocus(true)
-                focusRestored = true
-
-                applyMediaBarLayout(true)
-            else
-                m.homeRows.setFocus(true)
-                focusRestored = true
-
-                applyMediaBarLayout(false)
-
-                if _isReturning
-                    onItemFocusChanged()
-                end if
-            end if
-            ' Check if the saved focus was mediaBar itself or a child of mediaBar
+        ' Check if the saved focus was mediaBar itself or a child of mediaBar
         else if isValid(m.mediaBar) and (scenePreviousFocus.isSameNode(m.mediaBar) or isChildOf(scenePreviousFocus, m.mediaBar))
             m.currentFocusedItemId = ""
             m.currentFocusedItemServerUrl = invalid


### PR DESCRIPTION
# Pull Request

## Summary
When returning to home from another screen, there was additional code saying

if prevfocus = homerows
    if mediabar enabled
        focus media bar
    else 
        focus home rows

which makes no sense, why would you want focus to go to media bar if you came from home rows?

so I deleted that bit and it now returns to home rows correctly if you left the home screen from a home row item (still goes back to media bar if you left home screen from media bar)

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #183 
- Related to #

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

- delete mediabar focus trap if previous focus was home row
- 
- 

## Testing
Describe how this change was tested.

- [X] Tested on physical Roku device
- [ ] Tested via sideload
- [ ] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. Go to home row, click on item
2. Click back button, focus goes to the item you clicked in 1, no longer goes to media bar always
3.

## Screenshots (if applicable)
Include screenshots or recordings for UI changes.

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
