### PR TITLE
add overlay to dim seerr backdrop for legibility

### DIFF
--- a/components/seerr/SeerrDiscoveryScreen.xml
+++ b/components/seerr/SeerrDiscoveryScreen.xml
@@ -9,6 +9,7 @@
         <Poster id="backdrop" loadDisplayMode="scaleToZoom" width="1920" height="1080" opacity="0.0" />
 
         <Rectangle id="backdropTint" width="1920" height="1080" color="#F2000000" opacity="1.0" />
+        <Rectangle id="backdropScrim" width="1920" height="1080" color="#000000" opacity="0.28" />
 
         <!-- Top details section for focused item -->
         <LayoutGroup id="detailsSection" translation="[100, 180]" layoutDirection="vert" itemSpacings="[15]">


### PR DESCRIPTION
# Pull Request

## Summary
Add a slightly tinted overlay to the seerr discovery screen so white text is legible

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #90 
- Related to #

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [X] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

- add backdropscrim to seerrdiscovery.xml
- 
- 

## Testing
Describe how this change was tested.

- [X] Tested on physical Roku device
- [ ] Tested via sideload
- [ ] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1.
2.
3.

## Screenshots (if applicable)
Before:
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/5a6602de-05a7-4feb-94bb-f3578ab0fb89" />

After: 
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/195a2d0a-9dfe-4b48-9d97-b2afc1270b27" />


## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
