### PR TITLE
Rounded Corners Episode 2: A New Page

### DIFF
--- a/components/seerr/SeerrDiscoveryScreen.bs
+++ b/components/seerr/SeerrDiscoveryScreen.bs
@@ -61,7 +61,7 @@ sub init()
         m.normalItemSize ' 9: Your Requests
     ]
 
-    m.categoryRows.focusBitmapUri = "pkg:/images/hd_focus.9.png"
+    m.categoryRows.focusBitmapUri = "pkg:/images/posterFocus.9.png"
     m.categoryRows.focusBitmapBlendColor = ColorPalette.WHITE
     m.categoryRows.focusFootprintBitmapUri = string.EMPTY
     m.categoryRows.focusFootprintBlendColor = ColorPalette.TRANSPARENT

--- a/components/seerr/SeerrPoster.bs
+++ b/components/seerr/SeerrPoster.bs
@@ -3,6 +3,7 @@ import "pkg:/source/utils/misc.bs"
 
 sub init()
     m.poster = m.top.findNode("poster")
+    m.posterMask = m.top.findNode("posterMask")
     m.title = m.top.findNode("title")
     m.backdrop = m.top.findNode("backdrop")
     m.gradientOverlay = m.top.findNode("gradientOverlay")
@@ -84,6 +85,10 @@ sub itemContentChanged()
         m.overlayTitle.visible = false
         m.gradientOverlay.visible = false
     end if
+
+    ' Add poster mask for rounded corners
+    m.posterMask.maskUri = "pkg:/images/posterVertMask.png"
+    m.posterMask.maskSize  = [180, 270]
 
     ' Set poster image
     if isValid(itemData.hdPosterUrl)

--- a/components/seerr/SeerrPoster.bs
+++ b/components/seerr/SeerrPoster.bs
@@ -43,6 +43,9 @@ sub itemContentChanged()
         m.overlayTitle.width = width - 8
         m.overlayTitle.height = height
         m.overlayTitle.translation = [4, 0]
+
+        m.posterMask.maskUri = "pkg:/images/posterWideMask.png"
+        m.posterMask.maskSize = [width, height]
     else
         m.backdrop.width = m.normalWidth
         m.backdrop.height = m.normalHeight
@@ -53,6 +56,9 @@ sub itemContentChanged()
         m.gradientOverlay.translation = [0, 170]
         m.overlayTitle.width = m.normalWidth - 8
         m.overlayTitle.translation = [4, 185]
+
+        m.posterMask.maskUri = "pkg:/images/posterVertMask.png"
+        m.posterMask.maskSize = [m.normalWidth, m.normalHeight]
     end if
 
     ' Set title from either title or name field
@@ -85,10 +91,6 @@ sub itemContentChanged()
         m.overlayTitle.visible = false
         m.gradientOverlay.visible = false
     end if
-
-    ' Add poster mask for rounded corners
-    m.posterMask.maskUri = "pkg:/images/posterVertMask.png"
-    m.posterMask.maskSize  = [180, 270]
 
     ' Set poster image
     if isValid(itemData.hdPosterUrl)

--- a/components/seerr/SeerrPoster.xml
+++ b/components/seerr/SeerrPoster.xml
@@ -17,13 +17,15 @@
             visible="true" />
 
         <!-- Poster: 180x270 to match Home row MOVIE_POSTER size -->
-        <Poster id="poster"
-            width="180"
-            height="270"
-            translation="[0, 0]"
-            loadDisplayMode="scaleToZoom"
-            failedBitmapUri="pkg:/images/media_type_icons/movie.png"
-            loadingBitmapUri="pkg:/images/media_type_icons/movie.png" />
+        <MaskGroup id="posterMask">
+            <Poster id="poster"
+                width="180"
+                height="270"
+                translation="[0, 0]"
+                loadDisplayMode="scaleToZoom"
+                failedBitmapUri="pkg:/images/media_type_icons/movie.png"
+                loadingBitmapUri="pkg:/images/media_type_icons/movie.png" />
+        </MaskGroup>
 
         <!-- Gradient overlay at bottom for genre text readability (hidden by default) -->
         <Rectangle id="gradientOverlay"


### PR DESCRIPTION
# Pull Request

## Summary
Add rounded corners to posters on more pages

This PR currently covers:
- seerr discovery page

I'll keep updating more pages to this PR until it gets merged, then continue in a new pr (probably gonna call it "Rounded Corners Episode 3: Revenge of the Posters" lmao) and so on until all posters are covered

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #
- Related to #190 

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [X] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

- add new focus/mask with rounded corners
- copying what harley did in #116 on other pages basically
- 

## Testing
Describe how this change was tested.

- [X] Tested on physical Roku device
- [ ] Tested via sideload
- [ ] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1.
2.
3.

## Screenshots (if applicable)
Seerr discovery page:
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/bb6edbc0-02e7-4b3a-a418-cdd778d935ea" />


## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
