### PR TITLE
Adjust posters on Person Detail page

### DIFF
--- a/ExtrasItem.brs
+++ b/ExtrasItem.brs
@@ -1,0 +1,289 @@
+'import "pkg:/source/enums/ItemType.bs"
+'import "pkg:/source/enums/PersonType.bs"
+'import "pkg:/source/utils/misc.bs"
+'import "pkg:/source/utils/themeApply.bs"
+
+sub init()
+    m.extrasType = {
+        BEHINDTHESCENES: "Behind the Scenes"
+        CLIP: "Clip"
+        DELETEDSCENE: "Deleted Scene"
+        FEATURETTE: "Featurette"
+        INTERVIEW: "Interview"
+        SAMPLE: "Sample"
+        SCENE: "Scene"
+        SHORT: "Short"
+        THEMESONG: "ThemeSong"
+        THEMEVIDEO: "ThemeVideo"
+        TRAILER: "Trailer"
+        UNKNOWN: "Extra"
+    }
+    initPosterImg()
+    initName()
+    initRole()
+    ' Initialize nodes for both circular and rectangular posters
+    m.photoCircle = m.top.findNode("photoCircle")
+    m.posterImgRect = m.top.findNode("posterImgRect")
+    m.playedIndicator = m.top.findNode("playedIndicator")
+    m.scaleGroup = m.top.findNode("scaleGroup")
+    m.rectFocusBorder = m.top.findNode("rectFocusBorder")
+    m.epNumber = m.top.findNode("epNumber")
+    m.epDuration = m.top.findNode("epDuration")
+    m.name.height = 34
+    m.name.font.size = 25
+    m.name.horizAlign = "left"
+    m.name.vertAlign = "bottom"
+    m.role.font.size = 22
+    useFallbackFont = chainLookupReturn(m.global.session, "user.settings.useFallbackFont", false) and isValidAndNotEmpty(m.global.fallbackFont)
+    if useFallbackFont
+        m.name.font.uri = m.global.fallbackFont
+        m.role.font.uri = m.global.fallbackFont
+    end if
+    if isValid(m.epNumber)
+        m.epNumber.font.size = 25
+        m.epNumber.height = 34
+        m.epNumber.vertAlign = "bottom"
+        if useFallbackFont
+            m.epNumber.font.uri = m.global.fallbackFont
+        end if
+    end if
+    if isValid(m.epDuration)
+        m.epDuration.font.size = 25
+        m.epDuration.height = 34
+        m.epDuration.vertAlign = "bottom"
+        if useFallbackFont
+            m.epDuration.font.uri = m.global.fallbackFont
+        end if
+    end if
+    themeApply_ApplyToItem(m.top)
+end sub
+
+sub initPosterImg()
+    m.posterImg = m.top.findNode("posterImg")
+end sub
+
+sub initName()
+    m.name = m.top.findNode("pLabel")
+end sub
+
+sub initRole()
+    m.role = m.top.findNode("subTitle")
+end sub
+
+sub showContent()
+    ' validate nodes to prevent crash
+    if not isValid(m.posterImg) then
+        initPosterImg()
+    end if
+    if not isValid(m.name) then
+        initName()
+    end if
+    if not isValid(m.role) then
+        initRole()
+    end if
+    if isValid(m.top.itemContent)
+        cont = m.top.itemContent
+        m.name.text = cont.labelText
+        m.name.maxWidth = cont.imageWidth
+        ' Determine if this is a person (circular) or movie/show (rectangular)
+        isPerson = isStringEqual(cont.LookupCI("type"), "person")
+        if isPerson
+            ' Show circular poster for cast/crew
+            m.photoCircle.visible = true
+            m.posterImgRect.visible = false
+            m.posterImg.uri = cont.posterURL
+            ' MaskGroup handles circular cropping, no need for oversizing
+            imageSize = 250
+            m.posterImg.width = imageSize
+            m.posterImg.height = imageSize
+            ' Position text below circular image (adjusted for translation)
+            m.name.translation = [
+                0
+                281
+            ]
+            m.role.translation = [
+                0
+                321
+            ]
+            m.role.visible = true
+            if isValid(m.epNumber) then
+                m.epNumber.visible = false
+            end if
+            if isValid(m.epDuration) then
+                m.epDuration.visible = false
+            end if
+        else
+            ' Show rectangular poster for movies/shows/episodes
+            m.photoCircle.visible = false
+            m.posterImgRect.visible = true
+            m.posterImgRect.uri = cont.posterURL
+            ' Determine display mode based on content type
+            ' Use scaleToFit for movies, series, and seasons to show full poster
+            ' Use scaleToZoom for episodes to crop screenshot
+            isMovie = isValid(cont.Type) and (cont.Type = "Movie" or cont.Type = "Series" or cont.Type = "Season")
+            isNextEpisode = isValid(cont.json) and isValid(cont.json.NextEpisode) and cont.json.NextEpisode
+            if isMovie or isNextEpisode
+                m.posterImgRect.loadDisplayMode = "scaleToFit"
+            else
+                m.posterImgRect.loadDisplayMode = "scaleToZoom"
+            end if
+            if isValid(m.playedIndicator)
+                showWatchedCheckmark = true
+                if isChainValid(cont, "json.passedData.libraryID")
+                    showWatchedCheckmark = chainLookupReturn(m.global.session, ("user.settings." + bslib_toString(cont.json.passedData.libraryID) + "-showWatchedCheckmark"), true)
+                end if
+                m.playedIndicator.data = {
+                    showWatchedCheckmark: showWatchedCheckmark
+                    played: chainLookupReturn(cont, "json.UserData.Played", false)
+                    unplayedCount: chainLookupReturn(cont, "json.UserData.UnplayedItemCount", 0)
+                }
+            end if
+            ' Dynamically set poster size based on imageWidth
+            if isValid(cont.imageWidth)
+                posterWidth = cont.imageWidth
+                ' Calculate height based on aspect ratio
+                ' For wide episodes (16:9): 450x253
+                ' For portrait (2:3): 234x351
+                if posterWidth >= 400
+                    ' Wide format (16:9 ratio)
+                    posterHeight = int(posterWidth * 0.5625)
+                else
+                    ' Portrait format (2:3 ratio)
+                    posterHeight = int(posterWidth * 1.5)
+                end if
+                m.posterImgRect.width = posterWidth
+                m.posterImgRect.height = posterHeight
+                ' Update focus border size to match poster
+                if isValid(m.rectFocusBorder)
+                    m.rectFocusBorder.width = posterWidth
+                    m.rectFocusBorder.height = posterHeight
+                end if
+                ' Position text below poster (poster height + 23px spacing to match scaleGroup offset)
+                labelY = posterHeight + 31
+                ' Check if this is an episode (wide card with IndexNumber)
+                isEpisodeCard = posterWidth >= 400 and isChainValid(cont, "json.IndexNumber")
+                if isEpisodeCard
+                    ' Episode layout: "E1" grey | "Episode Name" white | "45 min" grey right-aligned
+                    epIdx = cont.json.LookupCI("IndexNumber")
+                    epPrefix = ("E" + bslib_toString(epIdx))
+                    if isValid(m.epNumber)
+                        m.epNumber.text = epPrefix
+                        m.epNumber.translation = [
+                            0
+                            labelY
+                        ]
+                        m.epNumber.visible = true
+                    end if
+                    ' Offset the episode name after the "E##" prefix
+                    ' Approximate width: ~18px per character for font size 25
+                    prefixWidth = epPrefix.len() * 18 + 8
+                    m.name.translation = [
+                        prefixWidth
+                        labelY
+                    ]
+                    m.name.maxWidth = posterWidth - prefixWidth - 80
+                    ' Duration on the right
+                    if isValid(m.epDuration)
+                        runTicks = cont.json.LookupCI("RunTimeTicks")
+                        if isValid(runTicks) and type(runTicks) = "LongInteger"
+                            minutes = int(runTicks / 600000000)
+                            m.epDuration.text = (bslib_toString(minutes) + " min")
+                        else
+                            m.epDuration.text = ""
+                        end if
+                        m.epDuration.width = posterWidth
+                        m.epDuration.translation = [
+                            0
+                            labelY
+                        ]
+                        m.epDuration.visible = true
+                    end if
+                    ' Hide subtitle row for episodes (duration is inline now)
+                    m.role.visible = false
+                else
+                    ' Non-episode: standard layout
+                    m.name.translation = [
+                        0
+                        labelY
+                    ]
+                    m.role.translation = [
+                        0
+                        posterHeight + 71
+                    ]
+                    m.role.visible = true
+                    if isValid(m.epNumber) then
+                        m.epNumber.visible = false
+                    end if
+                    if isValid(m.epDuration) then
+                        m.epDuration.visible = false
+                    end if
+                end if
+                ' Adjust played indicator position
+                m.playedIndicator.translation = [
+                    posterWidth - 50
+                    10
+                ]
+            else
+                ' Default to portrait poster size
+                m.posterImgRect.width = 234
+                m.posterImgRect.height = 351
+                ' Update focus border size to match default poster
+                if isValid(m.rectFocusBorder)
+                    m.rectFocusBorder.width = 234
+                    m.rectFocusBorder.height = 351
+                end if
+                m.name.translation = [
+                    0
+                    382
+                ]
+                m.role.translation = [
+                    0
+                    422
+                ]
+                m.role.visible = true
+                m.playedIndicator.translation = [
+                    130
+                    10
+                ]
+                if isValid(m.epNumber) then
+                    m.epNumber.visible = false
+                end if
+                if isValid(m.epDuration) then
+                    m.epDuration.visible = false
+                end if
+            end if
+            ' Handle music videos differently
+            if isStringEqual(cont.LookupCI("type"), "musicvideo")
+                m.name.maxWidth = 400
+                m.role.maxWidth = 400
+            end if
+        end if
+        if isChainValid(cont, "json.ExtraType")
+            if cont.json.ExtraType <> ""
+                cont.subTitle = m.extrasType[UCase(cont.json.ExtraType)]
+            end if
+        end if
+        m.role.Text = cont.subTitle.trim()
+    else
+        m.role.text = tr("Unknown")
+        m.posterImg.uri = "pkg:/images/baseline_person_white_48dp.png"
+    end if
+end sub
+
+sub focusChanged()
+    ' Enable text scrolling on focus
+    if m.top.itemHasFocus then
+        m.name.repeatCount = - 1
+    else
+        m.name.repeatCount = 0
+    end if
+    ' Focus border is handled natively by the RowList's focusBitmapUri
+    ' (smooth animated transition like home rows)
+    if isValid(m.global) and isValid(m.global.device) and m.global.device.isAudioGuideEnabled = true
+        txt2Speech = CreateObject("roTextToSpeech")
+        txt2Speech.Flush()
+        txt2Speech.Say(m.name.text)
+        txt2Speech.Say(m.role.text)
+    end if
+end sub
+'//# sourceMappingURL=./ExtrasItem.brs.map

--- a/ExtrasRowList.brs
+++ b/ExtrasRowList.brs
@@ -1,0 +1,544 @@
+'import "pkg:/source/api/Image.bs"
+'import "pkg:/source/enums/ColorPalette.bs"
+'import "pkg:/source/enums/ItemType.bs"
+'import "pkg:/source/enums/PersonType.bs"
+'import "pkg:/source/enums/TaskControl.bs"
+'import "pkg:/source/enums/VideoType.bs"
+'import "pkg:/source/utils/misc.bs"
+
+sub init()
+    m.top.visible = true
+    m.top.focusBitmapBlendColor = chainLookupReturn(m.global.session, "user.settings.colorCursor", "#ffffff")
+    updateSize()
+    m.top.observeField("rowItemSelected", "onRowItemSelected")
+    m.top.observeField("rowItemFocused", "onRowItemFocused")
+    ' Create single unified task for all extras data
+    m.LoadExtrasTask = CreateObject("roSGNode", "LoadExtrasTask")
+    m.LoadExtrasTask.observeField("content", "onExtrasLoaded")
+end sub
+
+sub updateSize()
+    itemHeight = 425
+    m.top.itemSize = [
+        1710
+        itemHeight
+    ]
+    m.top.rowItemSpacing = [
+        36
+        36
+    ]
+    ' Initialize rowItemSize as empty array - will be populated by addRowSize calls
+    m.top.rowItemSize = []
+end sub
+
+sub onParentIdChanged()
+    ' Note: loadParts is called explicitly from MovieDetails/ShowScenes with full data
+    ' including multi-server metadata. Don't auto-load here as it would use incomplete data.
+    ' Just ensure content node exists.
+    if not isValid(m.top.content)
+        m.top.content = CreateObject("roSGNode", "ContentNode")
+    end if
+end sub
+
+sub onShowIDChanged()
+    ' This is called when showID is set, but we handle loading in loadParts instead
+    ' Just validate that content exists
+    if not isValid(m.top.content)
+        m.top.content = CreateObject("roSGNode", "ContentNode")
+    end if
+end sub
+
+sub onSeasonOfEpisodesLoaded()
+    data = m.LoadEpisodesTask.content
+    m.LoadEpisodesTask.unobserveField("content")
+    if not isValidAndNotEmpty(data) then
+        return
+    end if
+    if not m.top.hasItems then
+        m.top.hasItems = true
+    end if
+    ' Find current episode position
+    shiftAmount = 0
+    if isValidAndNotEmpty(m.top.episodeID)
+        for each episode in data
+            if isStringEqual(m.top.episodeID, episode.json.LookupCI("id")) then
+                exit for
+            end if
+            shiftAmount++
+        end for
+    end if
+    ' Shift episodes array so the current episode is first, then following episodes
+    if shiftAmount > 0
+        for i = 0 to shiftAmount - 1
+            itemToMove = data.Shift()
+            data.push(itemToMove)
+        end for
+    end if
+    ' Remove the current episode (first item) so we only show "next" episodes
+    if data.count() > 0
+        data.shift()
+    end if
+    ' Only create row if there are episodes to show
+    if data.count() > 0
+        row = m.top.content.createChild("ContentNode")
+        row.Title = "Next Episode"
+        for each episode in data
+            ' Use wide episode poster (screenshot)
+            episode.Id = episode.json.LookupCI("Id")
+            episode.Type = episode.json.LookupCI("Type")
+            ' Add custom fields
+            episode.addField("labelText", "string", false)
+            episode.addField("imageWidth", "integer", false)
+            ' Set label as "S#:E#" format
+            if isValid(episode.json.ParentIndexNumber) and isValid(episode.json.IndexNumber)
+                episode.labelText = ("S" + bslib_toString(episode.json.ParentIndexNumber) + ":E" + bslib_toString(episode.json.IndexNumber))
+            else
+                episode.labelText = ""
+            end if
+            ' Set subtitle as episode name
+            episode.subTitle = episode.json.LookupCI("Name")
+            ' Use portrait image width to match other poster rows
+            episode.imageWidth = 234
+            row.appendChild(episode)
+        end for
+        ' Portrait poster size to match movies/shows: 234 width, 351 height
+        addRowSize([
+            234
+            351
+        ])
+    end if
+end sub
+
+sub loadParts(data as object)
+    m.top.content = CreateObject("roSGNode", "ContentNode")
+    m.top.parentId = data.id
+    ' Determine if this is a TV show (but not an Episode)
+    isTVShow = false
+    isEpisodeMode = false
+    if isValid(data.Type)
+        if data.Type = "Series"
+            isTVShow = true
+            m.top.showID = data.id
+        else if data.Type = "Episode"
+            ' Episodes should not show seasons, but should show same-season episodes
+            isTVShow = false
+            isEpisodeMode = true
+        else if isValid(m.top.showID) and m.top.showID <> ""
+            ' Season or other TV content
+            isTVShow = true
+        end if
+    else if isValid(m.top.showID) and m.top.showID <> ""
+        isTVShow = true
+    end if
+    ' Launch unified task to load all data in parallel
+    m.LoadExtrasTask.itemId = data.id
+    m.LoadExtrasTask.isTVShow = isTVShow
+    m.LoadExtrasTask.isEpisode = isEpisodeMode
+    ' Pass episode-specific data for same-season episode loading
+    if isEpisodeMode
+        m.LoadExtrasTask.showID = m.top.showID
+        m.LoadExtrasTask.seasonID = m.top.seasonID
+    end if
+    ' Pass multi-server info if available
+    if isValid(data._serverUrl) and isValidAndNotEmpty(data._serverUrl)
+        m.LoadExtrasTask.serverUrl = data._serverUrl
+        m.LoadExtrasTask.serverUserId = data._userId
+        m.LoadExtrasTask.serverAuthToken = data._authToken
+    else
+    end if
+    m.LoadExtrasTask.control = "RUN"
+end sub
+
+' Process all loaded data at once
+sub onExtrasLoaded()
+    extrasData = m.LoadExtrasTask.content
+    m.LoadExtrasTask.unobserveField("content")
+    if not isValid(extrasData)
+        return
+    end if
+    ' Extract data from content nodes
+    seasonsNode = invalid
+    nextupNode = invalid
+    episodesNode = invalid
+    peopleNode = invalid
+    similarNode = invalid
+    specialsNode = invalid
+    for i = 0 to extrasData.getChildCount() - 1
+        child = extrasData.getChild(i)
+        if isValid(child) and isValid(child.title)
+            if child.title = "seasons" then
+                seasonsNode = child
+            end if
+            if child.title = "nextup" then
+                nextupNode = child
+            end if
+            if child.title = "episodes" then
+                episodesNode = child
+            end if
+            if child.title = "people" then
+                peopleNode = child
+            end if
+            if child.title = "similar" then
+                similarNode = child
+            end if
+            if child.title = "specials" then
+                specialsNode = child
+            end if
+        end if
+    end for
+    ' Add rows in the desired order: Season Episodes → Seasons → Next Episode → Cast & Crew → More Like This
+    ' 0. Same-season episodes (for episode detail views)
+    if isValid(episodesNode) and episodesNode.getChildCount() > 0
+        ' Filter out the current episode and build the row
+        allEpisodes = episodesNode.getChildren(-1, 0)
+        currentEpId = m.top.episodeID
+        filteredEpisodes = []
+        ' Find current episode position and reorder: current+1 onward first, then wrap
+        currentIndex = -1
+        for i = 0 to allEpisodes.count() - 1
+            ep = allEpisodes[i]
+            if isValid(ep) and isValid(ep.json)
+                epId = ep.json.LookupCI("Id")
+                if isValidAndNotEmpty(currentEpId) and isStringEqual(currentEpId, epId)
+                    currentIndex = i
+                    exit for
+                end if
+            end if
+        end for
+        ' Add episodes after current first, then episodes before current
+        if currentIndex >= 0
+            for i = currentIndex + 1 to allEpisodes.count() - 1
+                filteredEpisodes.push(allEpisodes[i])
+            end for
+            for i = 0 to currentIndex - 1
+                filteredEpisodes.push(allEpisodes[i])
+            end for
+        else
+            ' Current not found, show all
+            for each ep in allEpisodes
+                filteredEpisodes.push(ep)
+            end for
+        end if
+        if filteredEpisodes.count() > 0
+            if not m.top.hasItems then
+                m.top.hasItems = true
+            end if
+            ' Determine season number for row title
+            seasonNum = invalid
+            firstEp = filteredEpisodes[0]
+            if isValid(firstEp) and isValid(firstEp.json)
+                seasonNum = firstEp.json.LookupCI("ParentIndexNumber")
+            end if
+            if isValid(seasonNum)
+                row = m.top.content.createChild("ContentNode")
+                row.Title = (bslib_toString(tr("Season")) + " " + bslib_toString(seasonNum) + " " + bslib_toString(tr("Episodes")))
+            else
+                row = m.top.content.createChild("ContentNode")
+                row.Title = tr("Episodes")
+            end if
+            for each episode in filteredEpisodes
+                if not isValid(episode) or not isValid(episode.json) then
+                    continue for
+                end if
+                episode.Id = episode.json.LookupCI("Id")
+                episode.Type = episode.json.LookupCI("Type")
+                ' Set label to just the episode name
+                epName = episode.json.LookupCI("Name")
+                if isValid(epName)
+                    episode.labelText = epName
+                else
+                    episode.labelText = ""
+                end if
+                ' Duration is read from json in ExtrasItem renderer
+                episode.subTitle = ""
+                ' Set landscape card width for ExtrasItem rendering
+                episode.imageWidth = 400
+                row.appendChild(episode)
+            end for
+            ' Landscape card size for episode thumbnails (16:9)
+            addRowSize([
+                400
+                280
+            ])
+        end if
+    end if
+    ' 1. Seasons (for TV shows only)
+    if isValid(seasonsNode) and seasonsNode.getChildCount() > 0
+        if not m.top.hasItems then
+            m.top.hasItems = true
+        end if
+        row = m.top.content.createChild("ContentNode")
+        row.Title = tr("Seasons")
+        ' Get all children at once using getChildren(-1, 0) which returns all children
+        allSeasons = seasonsNode.getChildren(-1, 0)
+        for each season in allSeasons
+            if isValid(season) and isValid(season.json)
+                season.Id = season.json.LookupCI("Id")
+                season.Type = season.json.LookupCI("Type")
+                if isValid(season.json.IndexNumber)
+                    season.labelText = (bslib_toString(tr("Season")) + " " + bslib_toString(season.json.IndexNumber))
+                else
+                    season.labelText = season.json.LookupCI("Name")
+                end if
+                if isValid(season.json.ChildCount)
+                    season.subTitle = (bslib_toString(season.json.ChildCount) + " " + bslib_toString(tr("episodes")))
+                end if
+                row.appendChild(season)
+            end if
+        end for
+        addRowSize([
+            200
+            300
+        ])
+    end if
+    ' 2. Next Episode (for TV shows only)
+    if isValid(nextupNode) and nextupNode.getChildCount() > 0
+        if not m.top.hasItems then
+            m.top.hasItems = true
+        end if
+        row = m.top.content.createChild("ContentNode")
+        row.Title = tr("Next Episode")
+        ' Get all episodes at once
+        allEpisodes = nextupNode.getChildren(-1, 0)
+        for each episode in allEpisodes
+            if not isValid(episode) or not isValid(episode.json)
+                continue for
+            end if
+            episode.Id = episode.json.LookupCI("Id")
+            episode.Type = episode.json.LookupCI("Type")
+            ' Set label as "S#:E# - Episode Name"
+            labelParts = []
+            if isValid(episode.json.ParentIndexNumber) and isValid(episode.json.IndexNumber)
+                labelParts.push(("S" + bslib_toString(episode.json.ParentIndexNumber) + ":E" + bslib_toString(episode.json.IndexNumber)))
+            end if
+            if isValid(episode.json.Name)
+                labelParts.push(episode.json.Name)
+            end if
+            episode.labelText = labelParts.join(" - ")
+            ' Set subtitle as series name
+            if isValid(episode.json.SeriesName)
+                episode.subTitle = episode.json.SeriesName
+            else
+                episode.subTitle = ""
+            end if
+            row.appendChild(episode)
+        end for
+        addRowSize([
+            502
+            283
+        ])
+    end if
+    ' 3. Cast
+    if isValid(peopleNode) and peopleNode.getChildCount() > 0
+        if not m.top.hasItems then
+            m.top.hasItems = true
+        end if
+        row = m.top.content.createChild("ContentNode")
+        row.Title = tr("Cast")
+        ' Get all people at once
+        allPeople = peopleNode.getChildren(-1, 0)
+        for each person in allPeople
+            if not isValid(person) or not isValid(person.json) then
+                continue for
+            end if
+            personType = person.json.LookupCI("type")
+            personRole = person.json.LookupCI("Role")
+            personName = person.json.LookupCI("Name")
+            ' Set the actor/crew member's name as the main label
+            if isValid(personName)
+                person.labelText = personName
+            end if
+            ' Format subtitle: "as [Role]" for actors with roles, otherwise just the person type
+            if LCase(personType) = "actor" and isValid(personRole) and personRole.ToStr().Trim() <> ""
+                person.subTitle = "as " + personRole
+            else
+                person.subTitle = personType
+            end if
+            person.Type = "Person"
+            row.appendChild(person)
+        end for
+        addRowSize([
+            250
+            330
+        ])
+    end if
+    ' 4. More Like This
+    if isValid(similarNode) and similarNode.getChildCount() > 0
+        if not m.top.hasItems then
+            m.top.hasItems = true
+        end if
+        row = m.top.content.createChild("ContentNode")
+        row.Title = tr("More Like This")
+        ' Get all similar items at once
+        allSimilar = similarNode.getChildren(-1, 0)
+        for each item in allSimilar
+            if not isValid(item) or not isValid(item.json) then
+                continue for
+            end if
+            item.Id = item.json.LookupCI("Id")
+            item.Type = item.json.LookupCI("Type")
+            item.labelText = item.json.LookupCI("Name")
+            item.shortDescriptionLine1 = item.json.LookupCI("Name")
+            ' Set year as subtitle
+            if isValid(item.json.LookupCI("ProductionYear"))
+                item.subTitle = stri(item.json.LookupCI("ProductionYear"))
+            else if isValid(item.json.LookupCI("PremiereDate"))
+                premierYear = CreateObject("roDateTime")
+                premierYear.FromISO8601String(item.json.LookupCI("PremiereDate"))
+                item.subTitle = stri(premierYear.GetYear())
+            end if
+            row.appendChild(item)
+        end for
+        addRowSize([
+            180
+            270
+        ])
+    end if
+    ' 5. Special Features
+    if isValid(specialsNode) and specialsNode.getChildCount() > 0
+        if not m.top.hasItems then
+            m.top.hasItems = true
+        end if
+        row = m.top.content.createChild("ContentNode")
+        row.Title = tr("Special Features")
+        ' Get all specials at once
+        allSpecials = specialsNode.getChildren(-1, 0)
+        for each special in allSpecials
+            if not isValid(special) or not isValid(special.json) then
+                continue for
+            end if
+            special.Id = special.json.LookupCI("Id")
+            special.Type = special.json.LookupCI("Type")
+            row.appendChild(special)
+        end for
+        addRowSize([
+            180
+            270
+        ])
+    end if
+end sub
+
+' Update content with pre-loaded data from task
+sub updateContent(loadedContent as object)
+    if not isValid(loadedContent) or loadedContent.getChildCount() = 0 then
+        return
+    end if
+    m.top.content = CreateObject("roSGNode", "ContentNode")
+    m.top.hasItems = true
+    ' Separate movies and shows
+    movies = []
+    shows = []
+    for i = 0 to loadedContent.getChildCount() - 1
+        item = loadedContent.getChild(i)
+        if item.subtype() = "MovieData"
+            movies.push(item)
+        else if item.subtype() = "SeriesData"
+            shows.push(item)
+        end if
+    end for
+    ' Add Movies row if there are any
+    if movies.count() > 0
+        row = buildRow("Movies", movies, 180)
+        addRowSize([
+            180
+            270
+        ])
+        m.top.content.appendChild(row)
+    end if
+    ' Add TV Shows row if there are any
+    if shows.count() > 0
+        row = buildRow("TV Shows", shows, 180)
+        addRowSize([
+            180
+            270
+        ])
+        m.top.content.appendChild(row)
+    end if
+end sub
+
+sub onSeriesLoaded()
+    data = m.LoadSeriesTask.content
+    m.LoadSeriesTask.unobserveField("content")
+    if isValidAndNotEmpty(data)
+        if not m.top.hasItems then
+            m.top.hasItems = true
+        end if
+        row = buildRow("Series", data)
+        addRowSize([
+            230
+            405
+        ])
+        m.top.content.appendChild(row)
+    end if
+    m.top.visible = true
+end sub
+
+function buildRow(rowTitle as string, items, imgWdth = 0)
+    row = CreateObject("roSGNode", "ContentNode")
+    row.Title = tr(rowTitle)
+    for each mov in items
+        ' Add custom fields
+        mov.addField("labelText", "string", false)
+        mov.addField("imageWidth", "integer", false)
+        if LCase(mov.json.type) = "episode"
+            if isAllValid([
+                mov.json.SeriesName
+                mov.json.ParentIndexNumber
+                mov.json.IndexNumber
+                mov.json.Name
+            ])
+                mov.labelText = mov.json.SeriesName
+                endingEpisode = ""
+                if isValid(mov.json.LookupCI("indexNumberEnd"))
+                    endingEpisode = ("-" + bslib_toString(mov.json.LookupCI("indexNumberEnd")))
+                end if
+                mov.subTitle = ("S" + bslib_toString(mov.json.ParentIndexNumber) + ":E" + bslib_toString(mov.json.IndexNumber) + bslib_toString(endingEpisode) + " - " + bslib_toString(mov.json.Name))
+            else
+                mov.labelText = mov.json.Name
+                mov.subTitle = mov.json.ProductionYear
+            end if
+        else
+            mov.labelText = mov.json.Name
+            mov.subTitle = mov.json.ProductionYear
+            if isValid(mov.json.EndDate)
+                mov.subTitle += (" - " + bslib_toString(LEFT(mov.json.EndDate, 4)))
+            end if
+        end if
+        mov.Id = mov.json.Id
+        mov.Type = mov.json.Type
+        if imgWdth > 0
+            mov.imageWidth = imgWdth
+        end if
+        row.appendChild(mov)
+    end for
+    return row
+end function
+
+sub addRowSize(newRow)
+    sizeArray = m.top.rowItemSize
+    newSizeArray = []
+    for each size in sizeArray
+        newSizeArray.push(size)
+    end for
+    newSizeArray.push(newRow)
+    m.top.rowItemSize = newSizeArray
+end sub
+
+sub onRowItemSelected()
+    selectedItem = m.top.content.getChild(m.top.rowItemSelected[0]).getChild(m.top.rowItemSelected[1])
+    if isValid(selectedItem)
+        if isValid(selectedItem.json)
+            if isChainValid(selectedItem, "json._serverUrl")
+            else
+            end if
+        end if
+    end if
+    m.top.selectedItem = selectedItem
+    m.top.selectedItem = invalid
+end sub
+
+sub onRowItemFocused()
+    focusedItem = m.top.content.getChild(m.top.rowItemFocused[0]).getChild(m.top.rowItemFocused[1])
+    m.top.focusedItem = focusedItem
+end sub
+'//# sourceMappingURL=./ExtrasRowList.brs.map

--- a/LoadExtrasTask.brs
+++ b/LoadExtrasTask.brs
@@ -1,0 +1,587 @@
+'import "pkg:/source/api/baserequest.bs"
+'import "pkg:/source/api/Image.bs"
+'import "pkg:/source/api/Items.bs"
+'import "pkg:/source/api/sdk.bs"
+'import "pkg:/source/enums/ItemType.bs"
+'import "pkg:/source/utils/deviceCapabilities.bs"
+'import "pkg:/source/utils/misc.bs"
+
+' Fast parallel loading task for TV show details
+' Loads seasons, next up, people, and similar items simultaneously
+sub init()
+    m.top.functionName = "loadAllExtras"
+end sub
+
+' Helper function to check if we should use multi-server API calls
+function isMultiServer() as boolean
+    return isValidAndNotEmpty(m.top.serverUrl) and isValidAndNotEmpty(m.top.serverUserId) and isValidAndNotEmpty(m.top.serverAuthToken)
+end function
+
+' Helper function to get server data object
+function getServerData() as object
+    return {
+        serverUrl: m.top.serverUrl
+        userId: m.top.serverUserId
+        authToken: m.top.serverAuthToken
+    }
+end function
+
+' Helper function to make API request using appropriate server
+function apiItemsGet(params as object) as object
+    if isMultiServer()
+        serverData = getServerData()
+        url = Substitute("Users/{0}/Items", serverData.userId)
+        req = APIRequestForServer(serverData.serverUrl, serverData.userId, serverData.authToken, url, params)
+        if not isValid(req) then
+            return invalid
+        end if
+        return getJson(req)
+    else
+        return api_items_Get(params)
+    end if
+end function
+
+' Helper function to get similar items using appropriate server
+function apiItemsGetSimilar(itemId as string, params as object) as object
+    if isMultiServer()
+        serverData = getServerData()
+        url = Substitute("Items/{0}/Similar", itemId)
+        req = APIRequestForServer(serverData.serverUrl, serverData.userId, serverData.authToken, url, params)
+        if not isValid(req) then
+            return invalid
+        end if
+        return getJson(req)
+    else
+        return api_items_GetSimilar(itemId, params)
+    end if
+end function
+
+' Helper function to get user ID for API calls
+function getUserId() as string
+    if isMultiServer()
+        return m.top.serverUserId
+    else
+        return m.global.session.user.id
+    end if
+end function
+
+' Main function that loads all extras data in parallel
+sub loadAllExtras()
+    if isMultiServer()
+    end if
+    ' Create ContentNode to hold all results
+    resultsNode = CreateObject("roSGNode", "ContentNode")
+    if not isValid(m.top.itemId) or m.top.itemId = ""
+        m.top.content = resultsNode
+        return
+    end if
+    ' Check if this is person mode
+    if isValid(m.top.isPersonMode) and m.top.isPersonMode = true
+        ' Load person videos (movies and TV shows)
+        personVideosData = loadPersonVideos()
+        for each item in personVideosData
+            resultsNode.appendChild(item)
+        end for
+        m.top.content = resultsNode
+        return
+    end if
+    ' Check what type of content we're loading
+    isTVShow = isValid(m.top.isTVShow) and m.top.isTVShow = true
+    isEpisodeMode = isValid(m.top.isEpisode) and m.top.isEpisode = true
+    ' Create child nodes for each data type
+    seasonsNode = resultsNode.createChild("ContentNode")
+    seasonsNode.title = "seasons"
+    nextupNode = resultsNode.createChild("ContentNode")
+    nextupNode.title = "nextup"
+    episodesNode = resultsNode.createChild("ContentNode")
+    episodesNode.title = "episodes"
+    peopleNode = resultsNode.createChild("ContentNode")
+    peopleNode.title = "people"
+    similarNode = resultsNode.createChild("ContentNode")
+    similarNode.title = "similar"
+    specialsNode = resultsNode.createChild("ContentNode")
+    specialsNode.title = "specials"
+    ' Launch all API calls - BrightScript will execute them as fast as possible
+    if isTVShow
+        seasonData = loadSeasons()
+        for each item in seasonData
+            seasonsNode.appendChild(item)
+        end for
+        nextupData = loadNextUp()
+        for each item in nextupData
+            nextupNode.appendChild(item)
+        end for
+    end if
+    ' Load same-season episodes for episode detail views
+    if isEpisodeMode and isValidAndNotEmpty(m.top.showID) and isValidAndNotEmpty(m.top.seasonID)
+        episodeData = loadSeasonEpisodes()
+        for each item in episodeData
+            episodesNode.appendChild(item)
+        end for
+    end if
+    peopleData = loadPeople()
+    for each item in peopleData
+        peopleNode.appendChild(item)
+    end for
+    similarData = loadSimilar()
+    for each item in similarData
+        similarNode.appendChild(item)
+    end for
+    specialsData = loadSpecials()
+    for each item in specialsData
+        specialsNode.appendChild(item)
+    end for
+    m.top.content = resultsNode
+end sub
+
+function loadSeasons() as object
+    seasons = []
+    ' Normalize server URL once if multi-server
+    normalizedServerUrl = ""
+    if isMultiServer()
+        normalizedServerUrl = m.top.serverUrl
+        if normalizedServerUrl.right(1) = "/"
+            normalizedServerUrl = normalizedServerUrl.left(normalizedServerUrl.len() - 1)
+        end if
+    end if
+    params = {
+        userId: getUserId()
+        ParentId: m.top.itemId
+        Fields: "Overview,PrimaryImageAspectRatio,ChildCount,MediaSources"
+        enableTotalRecordCount: true
+    }
+    data = apiItemsGet(params)
+    if not isChainValid(data, "Items") then
+        return seasons
+    end if
+    for each item in data.Items
+        tmp = createSGNode("HomeData")
+        ' Add server metadata to item for multi-server navigation
+        if isMultiServer()
+            item._serverUrl = m.top.serverUrl
+            item._userId = m.top.serverUserId
+            item._authToken = m.top.serverAuthToken
+        end if
+        tmp.json = item
+        ' Set image dimensions for portrait posters
+        tmp.imageWidth = 200
+        imgParams = {
+            "maxHeight": 400
+            "maxWidth": 200
+        }
+        if hasImageTagPrimary(item)
+            imgParams.Tag = item.ImageTags.Primary
+        end if
+        ' Build image URL using correct server for multi-server items
+        if isMultiServer()
+            tmp.posterURL = normalizedServerUrl + "/Items/" + item.Id + "/Images/Primary?maxWidth=200&maxHeight=400&quality=90"
+            if hasImageTagPrimary(item)
+                tmp.posterURL = tmp.posterURL + "&tag=" + item.ImageTags.Primary
+            end if
+        else
+            tmp.posterURL = ImageURL(item.Id, "Primary", imgParams)
+        end if
+        seasons.push(tmp)
+    end for
+    return seasons
+end function
+
+' Load all episodes from the same season (for episode detail views)
+function loadSeasonEpisodes() as object
+    episodes = []
+    normalizedServerUrl = ""
+    if isMultiServer()
+        normalizedServerUrl = m.top.serverUrl
+        if normalizedServerUrl.right(1) = "/"
+            normalizedServerUrl = normalizedServerUrl.left(normalizedServerUrl.len() - 1)
+        end if
+    end if
+    params = {
+        userId: getUserId()
+        seasonId: m.top.seasonID
+        Fields: "Overview,PrimaryImageAspectRatio,MediaSources,MediaStreams"
+        enableTotalRecordCount: false
+    }
+    data = invalid
+    if isMultiServer()
+        serverData = getServerData()
+        url = Substitute("Shows/{0}/Episodes", m.top.showID)
+        req = APIRequestForServer(serverData.serverUrl, serverData.userId, serverData.authToken, url, params)
+        if isValid(req) then
+            data = getJson(req)
+        end if
+    else
+        data = api_shows_GetEpisodes(m.top.showID, params)
+    end if
+    if not isChainValid(data, "Items") then
+        return episodes
+    end if
+    for each item in data.Items
+        tmp = createSGNode("HomeData")
+        if isMultiServer()
+            item._serverUrl = m.top.serverUrl
+            item._userId = m.top.serverUserId
+            item._authToken = m.top.serverAuthToken
+        end if
+        tmp.json = item
+        ' Use landscape thumbnail for episode cards
+        imgParams = {
+            "maxWidth": 480
+            "maxHeight": 270
+        }
+        if isValid(item.ImageTags) and isValid(item.ImageTags.Thumb)
+            imgParams.Tag = item.ImageTags.Thumb
+            if isMultiServer()
+                tmp.posterURL = normalizedServerUrl + "/Items/" + item.Id + "/Images/Thumb?maxWidth=480&maxHeight=270&quality=90&tag=" + item.ImageTags.Thumb
+            else
+                tmp.posterURL = ImageURL(item.Id, "Thumb", imgParams)
+            end if
+        else if hasImageTagPrimary(item)
+            imgParams.Tag = item.ImageTags.Primary
+            if isMultiServer()
+                tmp.posterURL = normalizedServerUrl + "/Items/" + item.Id + "/Images/Primary?maxWidth=480&maxHeight=270&quality=90&tag=" + item.ImageTags.Primary
+            else
+                tmp.posterURL = ImageURL(item.Id, "Primary", imgParams)
+            end if
+        end if
+        episodes.push(tmp)
+    end for
+    return episodes
+end function
+
+' Load movies and TV shows for a person
+function loadPersonVideos() as object
+    videos = []
+    ' Normalize server URL once if multi-server
+    normalizedServerUrl = ""
+    if isMultiServer()
+        normalizedServerUrl = m.top.serverUrl
+        if normalizedServerUrl.right(1) = "/"
+            normalizedServerUrl = normalizedServerUrl.left(normalizedServerUrl.len() - 1)
+        end if
+    end if
+    params = {
+        "userid": getUserId()
+        "PersonIds": m.top.itemId
+        "Recursive": true
+        "SortBy": "PremiereDate"
+        "SortOrder": "Ascending"
+        "IncludeItemTypes": "Movie,Series"
+        "ImageTypeLimit": 1
+        "EnableImageTypes": "Primary,Backdrop,Thumb"
+        "Limit": 100
+    }
+    data = apiItemsGet(params)
+    if not isChainValid(data, "Items") then
+        return videos
+    end if
+    for each item in data.Items
+        tmp = invalid
+        if item.Type = "Movie"
+            tmp = CreateObject("roSGNode", "MovieData")
+        else if item.Type = "Series"
+            tmp = CreateObject("roSGNode", "SeriesData")
+        end if
+        if tmp <> invalid
+            ' Add server metadata to item JSON for multi-server navigation
+            if isMultiServer()
+                item._serverUrl = m.top.serverUrl
+                item._userId = m.top.serverUserId
+                item._authToken = m.top.serverAuthToken
+            end if
+            tmp.json = item
+            ' Add custom fields
+            tmp.addField("imageWidth", "integer", false)
+            tmp.addField("labelText", "string", false)
+            tmp.imageWidth = 234
+            ' Set poster URL - use correct server for multi-server items
+            imgParams = {
+                "maxHeight": 351
+                "maxWidth": 234
+            }
+            if hasImageTagPrimary(item)
+                imgParams.Tag = item.ImageTags.Primary
+            end if
+            if isMultiServer()
+                tmp.posterURL = normalizedServerUrl + "/Items/" + item.Id + "/Images/Primary?maxWidth=234&maxHeight=351&quality=90"
+                if hasImageTagPrimary(item)
+                    tmp.posterURL = tmp.posterURL + "&tag=" + item.ImageTags.Primary
+                end if
+            else
+                tmp.posterURL = ImageURL(item.Id, "Primary", imgParams)
+            end if
+            ' Set label text
+            tmp.labelText = item.Name
+            ' Set subtitle with year or date range
+            if item.Type = "Series"
+                if isValid(item.PremiereDate)
+                    premiereDate = CreateObject("roDateTime")
+                    premiereDate.FromISO8601String(item.PremiereDate)
+                    premieredText = premiereDate.AsDateString("short-month-no-weekday")
+                    tmp.subTitle = premieredText
+                    if isValid(item.EndDate) and item.Status = "Ended"
+                        endedDate = CreateObject("roDateTime")
+                        endedDate.FromISO8601String(item.EndDate)
+                        endedText = endedDate.AsDateString("short-month-no-weekday")
+                        tmp.subTitle = premieredText + " - " + endedText
+                    end if
+                end if
+            else if isValid(item.ProductionYear)
+                tmp.subTitle = item.ProductionYear.ToStr()
+            end if
+            videos.push(tmp)
+        end if
+    end for
+    return videos
+end function
+
+function loadNextUp() as object
+    episodes = []
+    ' First, get the next up episode using GetNextUp API
+    nextUpParams = {
+        SeriesId: m.top.itemId
+        UserId: getUserId()
+        EnableRewatching: false
+        limit: 1
+        Fields: "PrimaryImageAspectRatio,Overview"
+        EnableTotalRecordCount: false
+    }
+    ' Note: GetNextUp doesn't have a multi-server version yet, skip for now if multi-server
+    if isMultiServer()
+        return episodes
+    end if
+    nextUpData = api_shows_GetNextUp(nextUpParams)
+    if not isChainValid(nextUpData, "Items") or nextUpData.Items.count() = 0
+        return episodes
+    end if
+    firstEpisode = nextUpData.Items[0]
+    ' If we have a season ID and episode index, get all episodes from that season starting from this episode
+    if isValid(firstEpisode.SeasonId) and isValid(firstEpisode.IndexNumber)
+        ' Get episodes from the season starting at this episode's index
+        seasonParams = {
+            ParentId: firstEpisode.SeasonId
+            UserId: getUserId()
+            StartIndex: firstEpisode.IndexNumber - 1 ' Convert to 0-based index
+            limit: 10
+            SortBy: "IndexNumber"
+            SortOrder: "Ascending"
+            Filters: "IsNotFolder"
+            Fields: "PrimaryImageAspectRatio,Overview"
+            EnableTotalRecordCount: false
+        }
+        seasonData = apiItemsGet(seasonParams)
+        if isChainValid(seasonData, "Items")
+            for each item in seasonData.Items
+                tmp = createSGNode("HomeData")
+                tmp.json = item
+                ' Set wide thumbnail for episodes
+                tmp.imageWidth = 502
+                imgParams = {
+                    "maxHeight": 283
+                    "maxWidth": 502
+                }
+                if hasImageTagPrimary(item)
+                    imgParams.Tag = item.ImageTags.Primary
+                end if
+                tmp.posterURL = ImageURL(item.Id, "Primary", imgParams)
+                episodes.push(tmp)
+            end for
+        end if
+    else
+        ' Fallback: just use the single next up episode
+        tmp = createSGNode("HomeData")
+        tmp.json = firstEpisode
+        tmp.imageWidth = 502
+        imgParams = {
+            "maxHeight": 283
+            "maxWidth": 502
+        }
+        if hasImageTagPrimary(firstEpisode)
+            imgParams.Tag = firstEpisode.ImageTags.Primary
+        end if
+        tmp.posterURL = ImageURL(firstEpisode.Id, "Primary", imgParams)
+        episodes.push(tmp)
+    end if
+    return episodes
+end function
+
+function loadPeople() as object
+    people = []
+    ' Normalize server URL once if multi-server
+    normalizedServerUrl = ""
+    if isMultiServer()
+        normalizedServerUrl = m.top.serverUrl
+        if normalizedServerUrl.right(1) = "/"
+            normalizedServerUrl = normalizedServerUrl.left(normalizedServerUrl.len() - 1)
+        end if
+    end if
+    ' First get the item details to access the People array
+    ' Use multi-server API if needed
+    itemDetails = invalid
+    if isMultiServer()
+        serverData = getServerData()
+        url = Substitute("Items/{0}", m.top.itemId)
+        req = APIRequestForServer(serverData.serverUrl, serverData.userId, serverData.authToken, url, {
+            "fields": "People"
+            "userId": serverData.userId
+        })
+        if isValid(req)
+            itemDetails = getJson(req)
+        end if
+    else
+        itemDetails = api_items_GetByID(m.top.itemId, {
+            userId: m.global.session.user.id
+            fields: "People"
+        })
+    end if
+    if not isChainValid(itemDetails, "People")
+        return people
+    end if
+    orderedPeople = []
+    trailingPeople = []
+    for each person in itemDetails.People
+        personType = LCase(person.Type)
+        if personType <> "director" and personType <> "writer"
+            orderedPeople.push(person)
+        else
+            trailingPeople.push(person)
+        end if
+    end for
+    orderedPeople.append(trailingPeople)
+    for each person in orderedPeople
+        tmp = createSGNode("HomeData")
+        ' Add server metadata to person item for multi-server navigation
+        if isMultiServer()
+            person._serverUrl = m.top.serverUrl
+            person._userId = m.top.serverUserId
+            person._authToken = m.top.serverAuthToken
+        end if
+        tmp.json = person
+        ' Set person image dimensions
+        tmp.imageWidth = 250
+        imgParams = {
+            "maxHeight": 331
+            "maxWidth": 250
+        }
+        ' Add image tag if available for cache busting
+        if isValid(person.PrimaryImageTag) and person.PrimaryImageTag <> ""
+            imgParams.Tag = person.PrimaryImageTag
+        end if
+        ' Build image URL using correct server for multi-server items
+        if isMultiServer()
+            tmp.posterURL = normalizedServerUrl + "/Items/" + person.Id + "/Images/Primary?maxWidth=250&maxHeight=331&quality=90"
+            if isValid(person.PrimaryImageTag) and person.PrimaryImageTag <> ""
+                tmp.posterURL = tmp.posterURL + "&tag=" + person.PrimaryImageTag
+            end if
+        else
+            tmp.posterURL = ImageURL(person.Id, "Primary", imgParams)
+        end if
+        ' Set display fields
+        tmp.labelText = person.Name
+        tmp.type = "Person"
+        ' Format subtitle: "as [Role]" for actors with roles, otherwise just the person type
+        personType = person.Type
+        personRole = person.Role
+        if LCase(personType) = "actor" and isValid(personRole) and personRole.ToStr().Trim() <> ""
+            tmp.subTitle = "as " + personRole
+        else
+            tmp.subTitle = personType
+        end if
+        people.push(tmp)
+    end for
+    return people
+end function
+
+function loadSimilar() as object
+    similar = []
+    ' Normalize server URL once if multi-server
+    normalizedServerUrl = ""
+    if isMultiServer()
+        normalizedServerUrl = m.top.serverUrl
+        if normalizedServerUrl.right(1) = "/"
+            normalizedServerUrl = normalizedServerUrl.left(normalizedServerUrl.len() - 1)
+        end if
+    end if
+    params = {
+        userId: getUserId()
+        limit: 25
+        Fields: "PrimaryImageAspectRatio,MediaSources"
+    }
+    data = apiItemsGetSimilar(m.top.itemId, params)
+    if not isChainValid(data, "Items") then
+        return similar
+    end if
+    for each item in data.Items
+        tmp = createSGNode("HomeData")
+        ' Add server metadata to item JSON for multi-server navigation
+        if isMultiServer()
+            item._serverUrl = m.top.serverUrl
+            item._userId = m.top.serverUserId
+            item._authToken = m.top.serverAuthToken
+        end if
+        tmp.json = item
+        ' Use standard poster dimensions
+        tmp.imageWidth = 180
+        imgParams = {
+            "maxHeight": 270
+            "maxWidth": 180
+        }
+        if hasImageTagPrimary(item)
+            imgParams.Tag = item.ImageTags.Primary
+        end if
+        ' Build image URL using correct server for multi-server items
+        if isMultiServer()
+            tmp.posterURL = normalizedServerUrl + "/Items/" + item.Id + "/Images/Primary?maxWidth=180&maxHeight=270&quality=90"
+            if hasImageTagPrimary(item)
+                tmp.posterURL = tmp.posterURL + "&tag=" + item.ImageTags.Primary
+            end if
+        else
+            tmp.posterURL = ImageURL(item.Id, "Primary", imgParams)
+        end if
+        ' Set display fields
+        tmp.labelText = item.Name
+        tmp.type = item.Type
+        ' Set year as subtitle
+        if isValid(item.ProductionYear)
+            tmp.subTitle = stri(item.ProductionYear)
+        else if isValid(item.PremiereDate)
+            premierYear = CreateObject("roDateTime")
+            premierYear.FromISO8601String(item.PremiereDate)
+            tmp.subTitle = stri(premierYear.GetYear())
+        end if
+        similar.push(tmp)
+    end for
+    return similar
+end function
+
+function loadSpecials() as object
+    specials = []
+    ' Skip specials for multi-server items (requires server-specific API)
+    if isMultiServer() then
+        return specials
+    end if
+    params = {
+        userId: getUserId()
+        SpecialFeatureTypes: "Trailer,AdditionalPart,BehindTheScenes,DeletedScene,Clip,Interview,Scene"
+    }
+    data = api_items_GetSpecialFeatures(m.top.itemId, params)
+    if not isValidAndNotEmpty(data) then
+        return specials
+    end if
+    for each item in data
+        tmp = createSGNode("HomeData")
+        tmp.json = item
+        tmp.imageWidth = 180
+        imgParams = {
+            "maxHeight": 270
+            "maxWidth": 180
+        }
+        if hasImageTagPrimary(item)
+            imgParams.Tag = item.ImageTags.Primary
+        end if
+        tmp.posterURL = ImageURL(item.Id, "Primary", imgParams)
+        specials.push(tmp)
+    end for
+    return specials
+end function
+'//# sourceMappingURL=./LoadExtrasTask.brs.map

--- a/PersonDetails.brs
+++ b/PersonDetails.brs
@@ -1,0 +1,373 @@
+'import "pkg:/source/api/baserequest.bs"
+'import "pkg:/source/api/Image.bs"
+'import "pkg:/source/api/sdk.bs"
+'import "pkg:/source/enums/ColorPalette.bs"
+'import "pkg:/source/enums/KeyCode.bs"
+'import "pkg:/source/utils/config.bs"
+'import "pkg:/source/utils/misc.bs"
+'import "pkg:/source/utils/multiserver.bs"
+
+sub init()
+    m.name = m.top.findNode("name")
+    m.birthInfo = m.top.findNode("birthInfo")
+    m.dscr = m.top.findNode("description")
+    m.personImage = m.top.findNode("personImage")
+    m.playedIndicator = m.top.findNode("playedIndicator")
+    m.filmographyLabel = m.top.findNode("filmographyLabel")
+    m.favoriteButtonGroup = m.top.findNode("favoriteButtonGroup")
+    m.favoriteIcon = m.top.findNode("favoriteIcon")
+    m.favoriteButtonBg = m.top.findNode("favoriteButtonBg")
+    m.favoriteText = m.top.findNode("favoriteText")
+    if isValid(m.favoriteButtonGroup)
+        m.favoriteButtonGroup.observeField("focusedChild", "onFavoriteButtonFocusChanged")
+    end if
+    m.backdrop = m.top.findNode("backdrop")
+    m.backdropPrev = m.top.findNode("backdropPrev")
+    m.backdropFadeIn = m.top.findNode("backdropFadeIn")
+    m.backdropPrevFadeOut = m.top.findNode("backdropPrevFadeOut")
+    m.backdropFadeInInterp = m.top.findNode("backdropFadeInInterp")
+    m.backdropPrevFadeOutInterp = m.top.findNode("backdropPrevFadeOutInterp")
+    m.backdropCrossfading = false
+    if isValid(m.backdrop)
+        m.backdrop.observeField("loadStatus", "onBackdropLoadStatusChange")
+    end if
+    m.favoriteTask = createObject("roSGNode", "FavoriteItemsTask")
+    m.extrasGrid = m.top.findNode("extrasGrid")
+    if isValid(m.extrasGrid)
+        m.extrasGrid.observeField("focusedItem", "onFilmographyItemFocused")
+    end if
+    m.extrasGrid.setFocus(true)
+    m.top.optionsAvailable = false
+    m.filmographyItemCount = 0
+end sub
+
+sub onFavoriteButtonFocusChanged()
+    updateFavoriteFocusVisual()
+end sub
+
+sub updateFavoriteFocusVisual()
+    if not isValid(m.favoriteButtonBg) or not isValid(m.favoriteButtonGroup) then
+        return
+    end if
+    isFocused = m.favoriteButtonGroup.hasFocus() or m.favoriteButtonGroup.isInFocusChain()
+    fave = false
+    if isValid(m.top.itemContent) and isChainValid(m.top.itemContent, "json")
+        fave = chainLookupReturn(m.top.itemContent.json, "UserData.IsFavorite", false)
+    end if
+    if isFocused
+        m.favoriteButtonBg.blendColor = "#ffffff"
+        m.favoriteButtonBg.opacity = 1.0
+        if isValid(m.favoriteIcon)
+            if fave then
+                m.favoriteIcon.blendColor = "#CC3333"
+            else
+                m.favoriteIcon.blendColor = "#000000"
+            end if
+        end if
+        if isValid(m.favoriteText) then
+            m.favoriteText.color = "#ffffff"
+        end if
+    else
+        m.favoriteButtonBg.blendColor = "#444444"
+        m.favoriteButtonBg.opacity = 0.6
+        if isValid(m.favoriteIcon)
+            if fave then
+                m.favoriteIcon.blendColor = "#CC3333"
+            else
+                m.favoriteIcon.blendColor = "#FFFFFF"
+            end if
+        end if
+        if isValid(m.favoriteText) then
+            m.favoriteText.color = "#CCCCCC"
+        end if
+    end if
+    if isValid(m.favoriteText)
+        if fave then
+            m.favoriteText.text = tr("Favorited")
+        else
+            m.favoriteText.text = tr("Favorite")
+        end if
+    end if
+end sub
+
+sub loadPerson()
+    item = m.top.itemContent
+    itemData = item.json
+    m.top.Id = itemData.id
+    if isValid(m.name) and isValid(itemData.Name)
+        m.name.text = itemData.Name
+    end if
+    if isValid(m.birthInfo) and isValidAndNotEmpty(itemData.PremiereDate)
+        birthDate = CreateObject("roDateTime")
+        birthDate.FromISO8601String(itemData.PremiereDate)
+        birthString = tr("Born") + ": " + birthDate.AsDateString("long-date-no-weekday")
+        if isValidAndNotEmpty(itemData.EndDate)
+            deathDate = CreateObject("roDateTime")
+            deathDate.FromISO8601String(itemData.EndDate)
+            birthString += " — " + tr("Died") + ": " + deathDate.AsDateString("long-date-no-weekday")
+        end if
+        m.birthInfo.text = birthString
+    end if
+    if isValid(m.dscr)
+        if isValidAndNotEmpty(itemData.Overview)
+            m.dscr.text = itemData.Overview
+        else
+            m.dscr.text = tr("Biographical information for this person is not currently available.")
+        end if
+    end if
+    if isValid(m.personImage)
+        if isValidAndNotEmpty(item.posterURL)
+            m.personImage.uri = item.posterURL
+        else
+            m.personImage.uri = "pkg:/images/baseline_person_white_48dp.png"
+        end if
+    end if
+    if isValidAndNotEmpty(item.backdropUrl)
+        setBackdrop(item.backdropUrl)
+    end if
+    if isValid(m.extrasGrid)
+        loadPersonVideos()
+    end if
+    updateFavoriteFocusVisual()
+    updateFilmographyLabel(0)
+    m.playedIndicator.data = {
+        favorite: chainLookupReturn(itemData, "UserData.IsFavorite", false)
+    }
+end sub
+
+sub OnScreenShown(_isReturning = false as boolean)
+    if isValid(m.top.lastFocus)
+        m.top.lastFocus.setFocus(true)
+        setLastFocus(m.top.lastFocus)
+    else
+        if isValid(m.favoriteButtonGroup)
+            timer = CreateObject("roSGNode", "Timer")
+            timer.duration = 0.05
+            timer.repeat = false
+            timer.observeField("fire", "focusFavoriteButton")
+            timer.control = "start"
+            m.focusTimer = timer
+        end if
+    end if
+end sub
+
+sub focusFavoriteButton()
+    if isValid(m.favoriteButtonGroup)
+        m.favoriteButtonGroup.setFocus(true)
+        setLastFocus(m.favoriteButtonGroup)
+        m.top.lastFocus = m.favoriteButtonGroup
+    end if
+    updateFavoriteFocusVisual()
+end sub
+
+' ===== Backdrop Management =====
+sub setBackdrop(url as string)
+    if not isValid(m.backdrop) or not isValidAndNotEmpty(url) then
+        return
+    end if
+    ' Don't reload the same image
+    if m.backdrop.uri = url then
+        return
+    end if
+    ' Stop any running animations
+    if isValid(m.backdropFadeIn) then
+        m.backdropFadeIn.control = "stop"
+    end if
+    if isValid(m.backdropPrevFadeOut) then
+        m.backdropPrevFadeOut.control = "stop"
+    end if
+    ' Copy current backdrop to prev layer
+    if isValid(m.backdropPrev) and m.backdrop.uri <> ""
+        m.backdropPrev.uri = m.backdrop.uri
+        m.backdropPrev.opacity = m.backdrop.opacity
+    end if
+    ' Set new backdrop, hidden until loaded
+    m.backdrop.opacity = 0.0
+    m.backdrop.uri = url
+    m.backdropCrossfading = true
+end sub
+
+sub onBackdropLoadStatusChange()
+    if not isValid(m.backdrop) then
+        return
+    end if
+    if m.backdrop.loadStatus <> "ready" then
+        return
+    end if
+    if not isValidAndNotEmpty(m.backdrop.uri) then
+        return
+    end if
+    if m.backdropCrossfading
+        targetOpacity = 0.4
+        if isValid(m.backdropFadeInInterp)
+            m.backdropFadeInInterp.keyValue = [
+                0.0
+                targetOpacity
+            ]
+        end if
+        if isValid(m.backdropPrevFadeOutInterp)
+            m.backdropPrevFadeOutInterp.keyValue = [
+                targetOpacity
+                0.0
+            ]
+        end if
+        if isValid(m.backdropFadeIn)
+            m.backdropFadeIn.control = "start"
+        end if
+        if isValid(m.backdropPrevFadeOut)
+            m.backdropPrevFadeOut.control = "start"
+        end if
+        m.backdropCrossfading = false
+    else
+        if isValid(m.backdropPrev)
+            m.backdropPrev.uri = m.backdrop.uri
+        end if
+    end if
+end sub
+
+sub onFilmographyItemFocused()
+    if not isValid(m.extrasGrid) then
+        return
+    end if
+    focusedItem = m.extrasGrid.focusedItem
+    if not isValid(focusedItem) then
+        return
+    end if
+    ' Update backdrop from focused filmography item
+    if isValidAndNotEmpty(focusedItem.backdropUrl)
+        setBackdrop(focusedItem.backdropUrl)
+    end if
+end sub
+
+' ===== Key Handling =====
+function onKeyEvent(key as string, press as boolean) as boolean
+    if not press then
+        return false
+    end if
+    if key = "OK"
+        if m.favoriteButtonGroup.hasFocus()
+            toggleFavorite()
+            return true
+        end if
+        return false
+    end if
+    if key = "back"
+        m.global.sceneManager.callfunc("popScene")
+        return true
+    end if
+    if key = "down"
+        if m.favoriteButtonGroup.hasFocus()
+            if isValid(m.extrasGrid) and m.extrasGrid.hasItems
+                m.extrasGrid.setFocus(true)
+                setLastFocus(m.extrasGrid)
+                m.top.lastFocus = m.extrasGrid
+                return true
+            end if
+        end if
+    else if key = "left"
+        if m.favoriteButtonGroup.hasFocus()
+            return FocusSidebar(m.top)
+        end if
+    else if key = "up"
+        if m.favoriteButtonGroup.hasFocus()
+            return FocusOverhang(m.top)
+        else if isValid(m.extrasGrid) and m.extrasGrid.isInFocusChain()
+            focusedRow = m.extrasGrid.rowItemFocused
+            if isValid(focusedRow) and focusedRow.count() > 0 and focusedRow[0] = 0
+                m.favoriteButtonGroup.setFocus(true)
+                setLastFocus(m.favoriteButtonGroup)
+                m.top.lastFocus = m.favoriteButtonGroup
+                return true
+            end if
+        end if
+    end if
+    return false
+end function
+
+' ===== Data Loading =====
+sub loadPersonVideos()
+    loadTask = CreateObject("roSGNode", "LoadExtrasTask")
+    loadTask.itemId = m.top.Id
+    loadTask.isPersonMode = true
+    ' Pass multi-server metadata if present
+    item = m.top.itemContent
+    if isValid(item) and isChainValid(item, "json")
+        itemData = item.json
+        if isValidAndNotEmpty(itemData._serverUrl)
+            loadTask.serverUrl = itemData._serverUrl
+        end if
+        if isValidAndNotEmpty(itemData._userId)
+            loadTask.serverUserId = itemData._userId
+        end if
+        if isValidAndNotEmpty(itemData._authToken)
+            loadTask.serverAuthToken = itemData._authToken
+        end if
+    end if
+    loadTask.observeField("content", "onPersonVideosLoaded")
+    loadTask.control = "RUN"
+end sub
+
+sub onPersonVideosLoaded(event as object)
+    content = event.getData()
+    if isValid(content) and isValid(m.extrasGrid)
+        m.filmographyItemCount = content.getChildCount()
+        updateFilmographyLabel(m.filmographyItemCount)
+        ' Grab the first backdrop URL before updateContent reparents the nodes
+        initialBackdropUrl = ""
+        if not isValidAndNotEmpty(m.backdrop.uri)
+            for i = 0 to content.getChildCount() - 1
+                item = content.getChild(i)
+                if isValid(item) and isValidAndNotEmpty(item.backdropUrl)
+                    initialBackdropUrl = item.backdropUrl
+                    exit for
+                end if
+            end for
+        end if
+        m.extrasGrid.callFunc("updateContent", content)
+        ' Set initial backdrop
+        if isValidAndNotEmpty(initialBackdropUrl)
+            setBackdrop(initialBackdropUrl)
+        end if
+    end if
+end sub
+
+sub updateFilmographyLabel(count as integer)
+    if isValid(m.filmographyLabel)
+        if count > 0
+            m.filmographyLabel.text = tr("Filmography") + (" (" + bslib_toString(count) + ")")
+        else
+            m.filmographyLabel.text = tr("Filmography")
+        end if
+    end if
+end sub
+
+' ===== Favorite =====
+sub toggleFavorite()
+    if not isValid(m.top.itemContent) then
+        return
+    end if
+    itemData = m.top.itemContent.json
+    if not isValid(itemData) or not isValid(itemData.id) then
+        return
+    end if
+    newStatus = not chainLookupReturn(itemData, "UserData.IsFavorite", false)
+    m.favoriteTask.itemId = itemData.id
+    if newStatus then
+        m.favoriteTask.favTask = "favorite"
+    else
+        m.favoriteTask.favTask = "unfavorite"
+    end if
+    m.favoriteTask.control = "RUN"
+    if not isChainValid(itemData, "UserData")
+        itemData.UserData = {
+            "IsFavorite": newStatus
+        }
+    else
+        itemData.UserData.IsFavorite = newStatus
+    end if
+    updateFavoriteFocusVisual()
+    m.playedIndicator.data = {
+        favorite: newStatus
+    }
+end sub
+'//# sourceMappingURL=./PersonDetails.brs.map

--- a/PersonDetails.xml
+++ b/PersonDetails.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<component name="PersonDetails" extends="JFScreen">
+    <interface>
+        <field id="itemContent" type="node" onChange="loadPerson" />
+        <field id="image" type="node" />
+        <field id="selectedItem" type="node" alias="extrasGrid.selectedItem" alwaysNotify="true" />
+    </interface>
+    <script type="text/brightscript" uri="pkg:/components/PersonDetails.brs" />
+    <script type="text/brightscript" uri="pkg:/source/utils/multiserver.brs" />
+    <script type="text/brightscript" uri="pkg:/source/api/Image.brs" />
+    <script type="text/brightscript" uri="pkg:/source/enums/ImageType.brs" />
+    <script type="text/brightscript" uri="pkg:/source/api/sdk.brs" />
+    <script type="text/brightscript" uri="pkg:/source/enums/KeyCode.brs" />
+    <script type="text/brightscript" uri="pkg:/source/enums/ColorPalette.brs" />
+    <children>
+        <Poster id="backdropPrev" loadDisplayMode="scaleToFill" width="1920" height="1080" opacity="0.0" />
+        <Poster id="backdrop" loadDisplayMode="scaleToFill" width="1920" height="1080" opacity="0.0" />
+        <Rectangle id="backdropTint" width="1920" height="1080" color="#F2000000" opacity="1.0" />
+        <Group id="infoSection" translation="[96, 140]">
+            <Poster id="personImage" width="234" height="351" loadDisplayMode="scaleToFit" />
+            <PlayedCheckmark id="playedIndicator" translation="[192, 0]" favoriteOffset="[-192, 0]" />
+            <Text id="name" translation="[270, 5]" font="font:LargeBoldSystemFont" color="#FFFFFF" />
+            <Text id="birthInfo" translation="[270, 55]" font="font:SmallSystemFont" color="#AAAAAA" />
+            <Text id="description" translation="[270, 90]" font="font:SmallSystemFont" width="1500" height="260" wrap="true" color="#DDDDDD" />
+        </Group>
+        <Group id="favoriteButtonGroup" focusable="true" translation="[96, 505]">
+        <Poster id="favoriteButtonBg" uri="pkg:/images/hd_focus_filled.9.png" loadDisplayMode="scaleToFit" width="80" height="75" blendColor="#444444" opacity="0.6" />
+        <Poster id="favoriteIcon" uri="pkg:/images/icons/heart.png" width="48" height="48" translation="[16, 10]" />
+        </Group>
+        <Text id="filmographyLabel" translation="[96, 600]" font="font:MediumBoldSystemFont" color="#FFFFFF" />
+        <ExtrasRowList id="extrasGrid" translation="[96, 650]" rowFocusAnimationStyle="floatingFocus" itemSpacing="[60, 60]" rowLabelOffset="[[9, 24]]" numRows="1" showRowLabel="true" showRowCounter="true" visible="true" drawFocusFeedback="true" focusBitmapUri="pkg:/images/hd_focus.9.png" itemComponentName="ExtrasItem" />
+        <Animation id="backdropFadeIn" duration="0.5" repeat="false" easeFunction="inOutQuad">
+            <FloatFieldInterpolator id="backdropFadeInInterp" key="[0.0, 1.0]" keyValue="[0.0, 0.4]" fieldToInterp="backdrop.opacity" />
+        </Animation>
+        <Animation id="backdropPrevFadeOut" duration="0.5" repeat="false" easeFunction="inOutQuad">
+            <FloatFieldInterpolator id="backdropPrevFadeOutInterp" key="[0.0, 1.0]" keyValue="[0.4, 0.0]" fieldToInterp="backdropPrev.opacity" />
+        </Animation>
+    </children>
+</component>
+<!--//# sourceMappingURL=./PersonDetails.xml.map -->


### PR DESCRIPTION
Adjust the size of the posters on Person Details and sort the posters by date. Adjust positions on person details and set focus to the first poster instead of the favorites.

# Pull Request

## Summary
Provide a brief description of what this PR changes and why.

## Related Issues
Link related issues or tickets separated by commas.


- Related to #185

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [X] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
- Adjusted the sizes of filmography poster on Person Detail Page
- Sort filmography on Person Detail Page by Premiere Date
- Adjust the layout of Person Detail Page to correctly show poster labels
- Removed the Favorite text from Person Detail Page
- Set initial focus to the first filmography poster on Person Detail Page
- Removed Official Rating from posters label on Person Detail Screen to avoid overlapping.

## Testing
Describe how this change was tested.

- [X] Tested on physical Roku device
- [X] Tested via sideload
- [ ] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. Select a movie or series, choose an artist and enter on the Person Detail Page


## Screenshots (if applicable)

Version 1.5.0 Person Detail page:

<img width="1873" height="1075" alt="image" src="https://github.com/user-attachments/assets/33b7bc7a-e98e-4482-8822-f3b390788a21" />




After proposed modifications:

<img width="1896" height="1078" alt="image" src="https://github.com/user-attachments/assets/5cdc0057-0f5b-446e-a913-066281365174" />




## Checklist
- [ ] Code builds successfully
- [X] Code follows project style and conventions
- [ ] No unnecessary commented-out code
- [ ] No new warnings introduced
