### PR TITLE
Adjust posters on Person Detail page

### DIFF
--- a/components/PersonDetails.bs
+++ b/components/PersonDetails.bs
@@ -18,7 +18,6 @@ sub init()
     m.favoriteButtonGroup = m.top.findNode("favoriteButtonGroup")
     m.favoriteIcon = m.top.findNode("favoriteIcon")
     m.favoriteButtonBg = m.top.findNode("favoriteButtonBg")
-    m.favoriteText = m.top.findNode("favoriteText")
 
     if isValid(m.favoriteButtonGroup)
         m.favoriteButtonGroup.observeField("focusedChild", "onFavoriteButtonFocusChanged")
@@ -42,7 +41,6 @@ sub init()
     if isValid(m.extrasGrid)
         m.extrasGrid.observeField("focusedItem", "onFilmographyItemFocused")
     end if
-    m.extrasGrid.setFocus(true)
 
     m.top.optionsAvailable = false
 
@@ -68,18 +66,12 @@ sub updateFavoriteFocusVisual()
         if isValid(m.favoriteIcon)
             m.favoriteIcon.blendColor = fave ? "#CC3333" : "#000000"
         end if
-        if isValid(m.favoriteText) then m.favoriteText.color = ColorPalette.WHITE
     else
         m.favoriteButtonBg.blendColor = "#444444"
         m.favoriteButtonBg.opacity = 0.6
         if isValid(m.favoriteIcon)
             m.favoriteIcon.blendColor = fave ? "#CC3333" : "#FFFFFF"
         end if
-        if isValid(m.favoriteText) then m.favoriteText.color = "#CCCCCC"
-    end if
-
-    if isValid(m.favoriteText)
-        m.favoriteText.text = fave ? tr("Favorited") : tr("Favorite")
     end if
 end sub
 

--- a/components/PersonDetails.bs
+++ b/components/PersonDetails.bs
@@ -42,6 +42,7 @@ sub init()
     if isValid(m.extrasGrid)
         m.extrasGrid.observeField("focusedItem", "onFilmographyItemFocused")
     end if
+    m.extrasGrid.setFocus(true)
 
     m.top.optionsAvailable = false
 

--- a/components/PersonDetails.xml
+++ b/components/PersonDetails.xml
@@ -49,33 +49,27 @@
       <Poster id="favoriteButtonBg"
         uri="pkg:/images/hd_focus_filled.9.png"
         loadDisplayMode="scaleToFit"
-        width="120"
-        height="96"
+        width="80"
+        height="75" 
         blendColor="#444444"
         opacity="0.6" />
       <Poster id="favoriteIcon"
         uri="pkg:/images/icons/heart.png"
         width="48"
         height="48"
-        translation="[36, 24]" />
-      <Text id="favoriteText"
-        translation="[0, 100]"
-        font="font:SmallestSystemFont"
-        horizAlign="center"
-        width="120"
-        color="#CCCCCC"
-        text="Favorite" />
+        translation="[16, 10]" />
+
     </Group>
 
     <!-- Filmography section header -->
     <Text id="filmographyLabel"
-      translation="[96, 630]"
+      translation="[96, 600]"
       font="font:MediumBoldSystemFont"
       color="#FFFFFF" />
 
     <!-- Filmography row list -->
     <ExtrasRowList id="extrasGrid"
-      translation="[96, 670]"
+      translation="[96, 650]"
       rowFocusAnimationStyle="floatingFocus"
       itemSpacing="[60, 60]"
       rowLabelOffset="[[9, 24]]"

--- a/components/PersonDetails.xml
+++ b/components/PersonDetails.xml
@@ -50,14 +50,14 @@
         uri="pkg:/images/hd_focus_filled.9.png"
         loadDisplayMode="scaleToFit"
         width="80"
-        height="75" 
+        height="75"
         blendColor="#444444"
         opacity="0.6" />
       <Poster id="favoriteIcon"
         uri="pkg:/images/icons/heart.png"
         width="48"
         height="48"
-        translation="[16, 10]" />
+        translation="[16, 13]" />
 
     </Group>
 

--- a/components/extras/ExtrasItem.bs
+++ b/components/extras/ExtrasItem.bs
@@ -249,11 +249,6 @@ sub showContent()
             end if
         end if
 
-        if isChainValid(cont, "json.officialrating")
-            if cont.json.officialrating <> "" and isValidAndNotEmpty(cont.subTitle)
-                cont.subTitle += ` - ${cont.json.officialrating}`
-            end if
-        end if
 
         m.role.Text = cont.subTitle.trim()
     else

--- a/components/extras/ExtrasItem.bs
+++ b/components/extras/ExtrasItem.bs
@@ -249,6 +249,11 @@ sub showContent()
             end if
         end if
 
+        if isChainValid(cont, "json.officialrating")
+            if cont.json.officialrating <> "" and isValidAndNotEmpty(cont.subTitle)
+                cont.subTitle += ` - ${cont.json.officialrating}`
+            end if
+        end if
 
         m.role.Text = cont.subTitle.trim()
     else

--- a/components/extras/ExtrasRowList.bs
+++ b/components/extras/ExtrasRowList.bs
@@ -425,15 +425,15 @@ sub updateContent(loadedContent as object)
 
     ' Add Movies row if there are any
     if movies.count() > 0
-        row = buildRow("Movies", movies, 234)
-        addRowSize([234, 351])
+        row = buildRow("Movies", movies, 180)
+        addRowSize([180, 270])
         m.top.content.appendChild(row)
     end if
 
     ' Add TV Shows row if there are any
     if shows.count() > 0
-        row = buildRow("TV Shows", shows, 234)
-        addRowSize([234, 351])
+        row = buildRow("TV Shows", shows, 180)
+        addRowSize([180, 270])
         m.top.content.appendChild(row)
     end if
 end sub

--- a/components/extras/ExtrasRowList.bs
+++ b/components/extras/ExtrasRowList.bs
@@ -426,14 +426,14 @@ sub updateContent(loadedContent as object)
     ' Add Movies row if there are any
     if movies.count() > 0
         row = buildRow("Movies", movies, 180)
-        addRowSize([180, 270])
+        addRowSize([180, 305])
         m.top.content.appendChild(row)
     end if
 
     ' Add TV Shows row if there are any
     if shows.count() > 0
         row = buildRow("TV Shows", shows, 180)
-        addRowSize([180, 270])
+        addRowSize([180, 305])
         m.top.content.appendChild(row)
     end if
 end sub

--- a/components/extras/LoadExtrasTask.bs
+++ b/components/extras/LoadExtrasTask.bs
@@ -289,7 +289,7 @@ function loadPersonVideos() as object
         "userid": getUserId(),
         "PersonIds": m.top.itemId,
         "Recursive": true,
-        "SortBy": "SortName",
+        "SortBy": "PremiereDate",
         "SortOrder": "Ascending",
         "IncludeItemTypes": "Movie,Series",
         "ImageTypeLimit": 1,

--- a/components/extras/LoadExtrasTask.bs
+++ b/components/extras/LoadExtrasTask.bs
@@ -290,7 +290,7 @@ function loadPersonVideos() as object
         "PersonIds": m.top.itemId,
         "Recursive": true,
         "SortBy": "PremiereDate",
-        "SortOrder": "Ascending",
+        "SortOrder": "Descending",
         "IncludeItemTypes": "Movie,Series",
         "ImageTypeLimit": 1,
         "EnableImageTypes": "Primary,Backdrop,Thumb",
@@ -323,16 +323,16 @@ function loadPersonVideos() as object
             tmp.addField("imageWidth", "integer", false)
             tmp.addField("labelText", "string", false)
 
-            tmp.imageWidth = 234
+            tmp.imageWidth = 180
 
             ' Set poster URL - use correct server for multi-server items
-            imgParams = { "maxHeight": 351, "maxWidth": 234 }
+            imgParams = { "maxHeight": 270, "maxWidth": 180 }
             if hasImageTagPrimary(item)
                 imgParams.Tag = item.ImageTags.Primary
             end if
 
             if isMultiServer()
-                tmp.posterURL = normalizedServerUrl + "/Items/" + item.Id + "/Images/Primary?maxWidth=234&maxHeight=351&quality=90"
+                tmp.posterURL = normalizedServerUrl + "/Items/" + item.Id + "/Images/Primary?maxWidth=180&maxHeight=270&quality=90"
                 if hasImageTagPrimary(item)
                     tmp.posterURL = tmp.posterURL + "&tag=" + item.ImageTags.Primary
                 end if


### PR DESCRIPTION
# Pull Request

## Summary
Adjust the size of the posters on Person Details and sort the posters by date. Adjust positions on person details and set focus to the first poster instead of the favorites.

## Related Issues

- Fixes #185

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [X] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
- Adjusted the sizes of filmography poster on Person Detail Page
- Sort filmography on Person Detail Page by Premiere Date
- Adjust the layout of Person Detail Page to correctly show poster labels
- Removed the Favorite text from Person Detail Page
- Set initial focus to the first filmography poster on Person Detail Page
- Removed Official Rating from posters label on Person Detail Screen to avoid overlapping.

## Testing
Describe how this change was tested.

- [X] Tested on physical Roku device
- [X] Tested via sideload
- [ ] Manual testing completed
- [ ] Not tested (explain why):



## Screenshots (if applicable)
Version 1.5.0 Person Detail page:

<img width="1873" height="1075" alt="image" src="https://github.com/user-attachments/assets/2a4493db-fd55-4f12-b862-75c0ddcc05fe" />

After proposed modifications:

<img width="1896" height="1078" alt="image" src="https://github.com/user-attachments/assets/bf2f5b27-aedf-4bb0-b945-85c1b3532613" />



## Checklist
- [ ] Code builds successfully
- [X] Code follows project style and conventions
- [ ] No unnecessary commented-out code
- [ ] No new warnings introduced
