### PR TITLE
Fix search crash

### DIFF
--- a/source/api/Items.bs
+++ b/source/api/Items.bs
@@ -172,11 +172,7 @@ function searchMedia(query as string)
         for each item in data.Items
             tmp = CreateObject("roSGNode", "SearchData")
 
-            imgNode = CreateObject("roSGNode", "ImageData")
-            imgNode.imagetype = ImageType.PRIMARY
-            imgNode.url = ImageURL(item.id, ImageType.PRIMARY, { "maxWidth": 400, "maxHeight": 250, "quality": "90" })
-            tmp.image = imgNode
-
+            tmp.image = PosterImage(item.id)
             tmp.id = item.LookupCI("id")
             tmp.title = item.LookupCI("name")
             tmp.AlbumArtist = item.LookupCI("AlbumArtist")
@@ -851,10 +847,13 @@ function TVSeasonExtras(seasonId as string) as dynamic
     results = []
     for each item in data
         tmp = CreateObject("roSGNode", "TVEpisodeData")
-        tmp.image = ImageURL(item.id, ImageType.PRIMARY, { "maxWidth": 400, "maxHeight": 250 })
+        tmp.image = PosterImage(item.id, { "maxWidth": 400, "maxHeight": 250 })
         tmp.json = item
         tmp.type = "Video"
-        tmp.overview = item.LookupCI("overview")
+        tmpMetaData = ItemMetaData(item.id)
+        if isValid(tmpMetaData) and isValid(tmpMetaData.overview)
+            tmp.overview = tmpMetaData.overview
+        end if
         results.push(tmp)
     end for
 


### PR DESCRIPTION
# Pull Request

## Summary
Revert breaking changes from https://github.com/Moonfin-Client/Roku/pull/114/changes/7b15ab47c72321804a827453f243c7408863e38d that caused the app to crash during search on weaker roku devices. 

Log before this pr:
```
08-12 01:42:07.023 sdkl [sg.scene.bitmap.big] Warning! Loaded texture (500 x 750) larger than the UI resolution (1280 x 720) - GridItemMedium/Poster:itemPoster https://image.tmdb.org/t/p/w500/wObGipjKUyrU4V7s6p6i1XiFb6T.jpg
08-12 01:46:30.657 sdkl [sg.scene.bitmap.big] Warning! Loaded texture (500 x 750) larger than the UI resolution (1280 x 720) - GridItemMedium/Poster:itemPoster https://image.tmdb.org/t/p/w500/wObGipjKUyrU4V7s6p6i1XiFb6T.jpg
BRIGHTSCRIPT: ERROR: roSGNode.<lookup>: Rendezvous aborted for Node: pkg:/source/utils/SeerrUtils.brs(508)
```

When these warnings/errors popped up, my roku froze for a few seconds. On weaker devices, this probably causes the crash. 

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #
- Related to #

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

- change imageurl back to posterimage to fix image size warnings
- change overview lookupci back to isvalid chain to fix seerr lookup error
- 

## Testing
Describe how this change was tested.

- [X] Tested on physical Roku device
- [ ] Tested via sideload
- [ ] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. Search something
2. No longer get app freeze or errors/warnings in the debug log
3.

## Screenshots (if applicable)
Include screenshots or recordings for UI changes.

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
