### PR TITLE
remove roku settings not present in core to avoid unexpected behavior

### DIFF
--- a/components/ItemGrid/AudioBookGridItem.bs
+++ b/components/ItemGrid/AudioBookGridItem.bs
@@ -28,8 +28,6 @@ sub init()
         m.itemPoster.loadDisplayMode = m.topParent.imageDisplayMode
     end if
 
-    m.gridTitles = "showalways"
-
     themeApply.ApplyToItem(m.top)
 end sub
 

--- a/components/ItemGrid/AudioBookGridItem.bs
+++ b/components/ItemGrid/AudioBookGridItem.bs
@@ -28,7 +28,7 @@ sub init()
         m.itemPoster.loadDisplayMode = m.topParent.imageDisplayMode
     end if
 
-    m.gridTitles = m.global.session.user.settings["itemgrid.gridTitles"]
+    m.gridTitles = "showalways"
 
     themeApply.ApplyToItem(m.top)
 end sub

--- a/components/ItemGrid/MusicArtistGridItem.bs
+++ b/components/ItemGrid/MusicArtistGridItem.bs
@@ -19,7 +19,7 @@ sub init()
         m.itemPoster.loadDisplayMode = m.topParent.imageDisplayMode
     end if
 
-    m.gridTitles = m.global.session.user.settings["itemgrid.gridTitles"]
+    m.gridTitles = "showalways"
     m.posterText.visible = false
     m.postTextBackground.visible = false
 

--- a/components/ItemGrid/MusicArtistGridItem.bs
+++ b/components/ItemGrid/MusicArtistGridItem.bs
@@ -19,7 +19,6 @@ sub init()
         m.itemPoster.loadDisplayMode = m.topParent.imageDisplayMode
     end if
 
-    m.gridTitles = "showalways"
     m.posterText.visible = false
     m.postTextBackground.visible = false
 

--- a/components/Libraries/AudioBookLibraryView.bs
+++ b/components/Libraries/AudioBookLibraryView.bs
@@ -6,7 +6,7 @@ import "pkg:/source/utils/misc.bs"
 
 sub init()
     m.top.imageDisplayMode = "scaleToZoom"
-    m.top.showItemTitles = m.global.session.user.settings["itemgrid.gridTitles"]
+    m.top.showItemTitles = "showalways"
 
 
     m.options = m.top.findNode("options")
@@ -51,7 +51,7 @@ sub init()
     'set inital counts for overhang before content is loaded.
     m.loadItemsTask.totalRecordCount = 0
 
-    m.top.gridTitles = m.global.session.user.settings["itemgrid.gridTitles"]
+    m.top.gridTitles = "showalways"
 end sub
 
 'Load initial set of Data

--- a/components/Libraries/LiveTVLibraryView.bs
+++ b/components/Libraries/LiveTVLibraryView.bs
@@ -53,7 +53,7 @@ sub init()
     'set inital counts for overhang before content is loaded.
     m.loadItemsTask.totalRecordCount = 0
 
-    m.top.gridTitles = m.global.session.user.settings["itemgrid.gridTitles"]
+    m.top.gridTitles = "showalways"
 end sub
 
 sub setColumnSizes(layout = ImageLayout.PORTRAIT as string)

--- a/components/Libraries/MusicLibraryView.bs
+++ b/components/Libraries/MusicLibraryView.bs
@@ -271,7 +271,7 @@ sub loadInitialItems()
 
     m.filterOptions = ParseJson(m.filterOptions)
 
-    m.top.showItemTitles = m.global.session.user.settings["itemgrid.gridTitles"]
+    m.top.showItemTitles = "showalways"
 
     m.loadItemsTask.searchTerm = m.top.searchTerm
     m.emptyText.visible = false

--- a/components/Libraries/OtherLibrary.bs
+++ b/components/Libraries/OtherLibrary.bs
@@ -13,14 +13,12 @@ import "pkg:/source/utils/config.bs"
 import "pkg:/source/utils/deviceCapabilities.bs"
 import "pkg:/source/utils/misc.bs"
 
-const ASPECT_RATIO_PORTRAIT_NO_TITLE = 1.52173
-const ASPECT_RATIO_LANDSCAPE_NO_TITLE = .56307
 const ASPECT_RATIO_PORTRAIT_WITH_TITLE = 1.69565
 const ASPECT_RATIO_LANDSCAPE_WITH_TITLE = .66307
 
 sub init()
     m.top.imageDisplayMode = "scaleToZoom"
-    m.top.showItemTitles = "showalways" ?? "showonhover"
+    m.top.showItemTitles = "showalways"
 
     m.loadItemsTask1 = createObject("roSGNode", "LoadItemsTask")
 
@@ -113,11 +111,7 @@ sub setColumnSizes(layout = ImageLayout.PORTRAIT as string)
         imageWidthData = val(chainLookupReturn(m.global.session, "user.settings.numberOfColumnsLandscapeData", "418"))
     end if
 
-    if isStringEqual(m.top.showItemTitles, "hidealways")
-        aspectRatio = isStringEqual(layout, ImageLayout.PORTRAIT) ? ASPECT_RATIO_PORTRAIT_NO_TITLE : ASPECT_RATIO_LANDSCAPE_NO_TITLE
-    else
-        aspectRatio = isStringEqual(layout, ImageLayout.PORTRAIT) ? ASPECT_RATIO_PORTRAIT_WITH_TITLE : ASPECT_RATIO_LANDSCAPE_WITH_TITLE
-    end if
+    aspectRatio = isStringEqual(layout, ImageLayout.PORTRAIT) ? ASPECT_RATIO_PORTRAIT_WITH_TITLE : ASPECT_RATIO_LANDSCAPE_WITH_TITLE
 
     defaultSize = [imageWidthData, CInt(imageWidthData * aspectRatio)]
 

--- a/components/Libraries/OtherLibrary.bs
+++ b/components/Libraries/OtherLibrary.bs
@@ -20,7 +20,7 @@ const ASPECT_RATIO_LANDSCAPE_WITH_TITLE = .66307
 
 sub init()
     m.top.imageDisplayMode = "scaleToZoom"
-    m.top.showItemTitles = m.global.session.user.settings["itemgrid.gridTitles"] ?? "showonhover"
+    m.top.showItemTitles = "showalways" ?? "showonhover"
 
     m.loadItemsTask1 = createObject("roSGNode", "LoadItemsTask")
 
@@ -76,7 +76,7 @@ sub init()
     'set inital counts for overhang before content is loaded.
     m.loadItemsTask.totalRecordCount = 0
 
-    m.top.gridTitles = m.global.session.user.settings["itemgrid.gridTitles"]
+    m.top.gridTitles = "showalways"
 
     m.loadStatus = ViewLoadStatus.INIT
 end sub

--- a/components/home/LoadItemsTask.bs
+++ b/components/home/LoadItemsTask.bs
@@ -1022,7 +1022,6 @@ function loadMergedContinueWatching() as object
         SortOrder: "Descending",
         ImageTypeLimit: 1,
         UserId: m.global.session.user.id,
-        EnableRewatching: m.global.session.user.settings["ui.details.enablerewatchingnextup"],
         DisableFirstEpisode: false,
         limit: 25,
         EnableTotalRecordCount: false
@@ -1546,7 +1545,6 @@ function loadNextUp() as object
         SortOrder: "Descending",
         ImageTypeLimit: 1,
         UserId: m.global.session.user.id,
-        EnableRewatching: m.global.session.user.settings["ui.details.enablerewatchingnextup"],
         DisableFirstEpisode: false,
         limit: 26,
         EnableTotalRecordCount: false

--- a/components/tvshows/SeasonDetails.bs
+++ b/components/tvshows/SeasonDetails.bs
@@ -97,19 +97,6 @@ sub onEpisodeObjectsChanged()
     totalCount = objects.Items.count()
     m.episodeCount.text = stri(totalCount).trim()
 
-    ' Jump to first unwatched if setting enabled
-    if m.global.session.user.settings["ui.tvshows.startListFromUnwatched"] ?? false
-        firstUnwatched = 0
-        for i = 0 to objects.Items.count() - 1
-            item = objects.Items[i]
-            if isChainValid(item, "json.UserData.Played") and not item.json.UserData.Played
-                firstUnwatched = i
-                exit for
-            end if
-        end for
-        m.episodeList.jumpToItem = firstUnwatched
-    end if
-
     updateSeason()
 end sub
 

--- a/components/tvshows/TVEpisodeList.bs
+++ b/components/tvshows/TVEpisodeList.bs
@@ -14,7 +14,6 @@ sub init()
     m.scrollBar.color = ColorPalette.BLACK77
     m.thumb.color = ColorPalette.LIGHTGREY
 
-    m.firstUnwatched = 0
     m.top.content = setData()
     updateSize()
 
@@ -77,14 +76,7 @@ end sub
 
 sub updateSize()
     m.top.itemSpacing = [20, 20]
-
-    if m.top.numColumns = 1
-        m.top.itemSize = [1620, 300]
-        return
-    end if
-
-    ' Size of the individual episodes
-    m.top.itemSize = [805, 200]
+    m.top.itemSize = [1620, 300]
 end sub
 
 sub setupRows()
@@ -99,18 +91,6 @@ end sub
 function setData()
     data = CreateObject("roSGNode", "ContentNode")
     if not isValid(m.top.objects) then return data
-
-    i = 0
-    m.firstUnwatched = -1
-    for each item in m.top.objects.items
-        if m.firstUnwatched = -1
-            if not chainLookupReturn(item, "watched", false)
-                m.firstUnwatched = i
-                exit for
-            end if
-        end if
-        i++
-    end for
 
     data.appendChildren(m.top.objects.items)
 

--- a/components/tvshows/TVEpisodeList.bs
+++ b/components/tvshows/TVEpisodeList.bs
@@ -22,10 +22,6 @@ sub init()
     m.top.observeFieldscoped("currFocusRow", "onCurrFocusRowChange")
     m.top.observeFieldscoped("clippingRect", "onclippingRectChange")
 
-    if m.global.session.user.settings["ui.tvshows.startListFromUnwatched"] ?? false
-        m.top.jumpToItem = m.firstUnwatched
-    end if
-
     calculateButtonThumbProperties()
 end sub
 
@@ -95,13 +91,9 @@ sub setupRows()
     updateSize()
     objects = m.top.objects
     m.top.numRows = objects.items.count()
-    m.top.numColumns = (m.global.session.user.settings["ui.tvshows.twoColumnEpisodeList"] ?? true) ? 2 : 1
+    m.top.numColumns = 1
     m.top.content = setData()
     calculateButtonThumbProperties()
-
-    if m.global.session.user.settings["ui.tvshows.startListFromUnwatched"] ?? false
-        m.top.jumpToItem = m.firstUnwatched
-    end if
 end sub
 
 function setData()

--- a/settings/settings.json
+++ b/settings/settings.json
@@ -194,6 +194,14 @@
             "default": "false"
           },
           {
+            "title": "Max Days Next Up",
+            "description": "Set the maximum amount of days a show should stay in the 'Next Up' list without watching it. Maximum value is 1000 days.",
+            "settingName": "ui.details.maxdaysnextup",
+            "type": "integer",
+            "max": "1000",
+            "default": "365"
+          },
+          {
             "title": "Prefer Thumbnails",
             "description": "If thumbnails are selected in Home Row Image, show series instead of episode thumbnails.",
             "settingName": "ui.home.preferThumbnails",
@@ -2977,6 +2985,13 @@
             ]
           },
           {
+            "title": "Disable Unwatched Episode Count",
+            "description": "If enabled, the number of unwatched episodes in a series/season will be removed.",
+            "settingName": "ui.tvshows.disableUnwatchedEpisodeCount",
+            "type": "bool",
+            "default": "false"
+          },
+          {
             "title": "Use Fallback Font Across App",
             "description": "Changes the font used in the app to the server's configured fallback font.",
             "settingName": "useFallbackFont",
@@ -3135,25 +3150,11 @@
             "default": "true"
           },
           {
-            "title": "Grid View Item Titles",
-            "description": "Select when to show titles in grid view.",
-            "settingName": "itemgrid.gridTitles",
-            "type": "radio",
-            "default": "showonhover",
-            "options": [
-              {
-                "title": "Show On Hover",
-                "id": "showonhover"
-              },
-              {
-                "title": "Always Show",
-                "id": "showalways"
-              },
-              {
-                "title": "Always Hide",
-                "id": "hidealways"
-              }
-            ]
+            "title": "Blur Unwatched Episode Thumbnails",
+            "description": "Apply a blur effect to thumbnails of unwatched episodes to avoid spoilers.",
+            "settingName": "ui.tvshows.blurunwatched",
+            "type": "bool",
+            "default": "false"
           },
           {
             "title": "Library Image Orientation",
@@ -3272,62 +3273,6 @@
               {
                 "value": "10",
                 "data": "154"
-              }
-            ]
-          },
-          {
-            "title": "TV Shows",
-            "description": "Settings relating to the appearance of pages in TV Libraries.",
-            "children": [
-              {
-                "title": "Blur Unwatched Episode Thumbnails",
-                "description": "Apply a blur effect to thumbnails of unwatched episodes to avoid spoilers.",
-                "settingName": "ui.tvshows.blurunwatched",
-                "type": "bool",
-                "default": "false"
-              },
-              {
-                "title": "Disable Unwatched Episode Count",
-                "description": "If enabled, the number of unwatched episodes in a series/season will be removed.",
-                "settingName": "ui.tvshows.disableUnwatchedEpisodeCount",
-                "type": "bool",
-                "default": "false"
-              },
-              {
-                "title": "Max Days Next Up",
-                "description": "Set the maximum amount of days a show should stay in the 'Next Up' list without watching it. Maximum value is 1000 days.",
-                "settingName": "ui.details.maxdaysnextup",
-                "type": "integer",
-                "max": "1000",
-                "default": "365"
-              },
-              {
-                "title": "Rewatching Next Up",
-                "description": "Show already watched episodes in 'Next Up' sections.",
-                "settingName": "ui.details.enablerewatchingnextup",
-                "type": "bool",
-                "default": "false"
-              },
-              {
-                "title": "Skip Details for Single Seasons",
-                "description": "If enabled, selecting a TV series with only one season will go straight to the episode list rather than the show details and season list.",
-                "settingName": "ui.tvshows.goStraightToEpisodeListing",
-                "type": "bool",
-                "default": "false"
-              },
-              {
-                "title": "Start Episode List From First Unwatched Episode",
-                "description": "When opening a season's list of episodes, automatically scroll down and start the cursor on the first unwatched episode.",
-                "settingName": "ui.tvshows.startListFromUnwatched",
-                "type": "bool",
-                "default": "false"
-              },
-              {
-                "title": "Two Column Episode List",
-                "description": "Display the episode list in two columns instead of one.",
-                "settingName": "ui.tvshows.twoColumnEpisodeList",
-                "type": "bool",
-                "default": "true"
               }
             ]
           }

--- a/settings/settings.json
+++ b/settings/settings.json
@@ -2985,13 +2985,6 @@
             ]
           },
           {
-            "title": "Disable Unwatched Episode Count",
-            "description": "If enabled, the number of unwatched episodes in a series/season will be removed.",
-            "settingName": "ui.tvshows.disableUnwatchedEpisodeCount",
-            "type": "bool",
-            "default": "false"
-          },
-          {
             "title": "Use Fallback Font Across App",
             "description": "Changes the font used in the app to the server's configured fallback font.",
             "settingName": "useFallbackFont",
@@ -3028,6 +3021,13 @@
                 "id": "20"
               }
             ]
+          },
+          {
+            "title": "Disable Unwatched Episode Count",
+            "description": "If enabled, the number of unwatched episodes in a series/season will be removed.",
+            "settingName": "ui.tvshows.disableUnwatchedEpisodeCount",
+            "type": "bool",
+            "default": "false"
           },
           {
             "title": "Show What's New Popup",

--- a/source/ShowScenes.bs
+++ b/source/ShowScenes.bs
@@ -835,16 +835,6 @@ function CreateSeriesDetailsGroup(seriesID as string, seriesServerData = invalid
         enableTotalRecordCount: false
     })
 
-    ' Divert to season details if user setting goStraightToEpisodeListing is enabled and only one season exists.
-    if m.global.session.user.settings["ui.tvshows.goStraightToEpisodeListing"]
-        if isChainValid(apiSeasonData, "items")
-            if chainLookup(apiSeasonData, "items").count() = 1
-                stopLoadingSpinner()
-                return CreateSeasonDetailsGroupByID(seriesID, chainLookup(apiSeasonData, "items")[0].id)
-            end if
-        end if
-    end if
-
     seasonData = CreateObject("roSGNode", "ContentNode")
     for each item in apiSeasonData.Items
         tmp = seasonData.createChild("TVSeasonData")

--- a/source/ShowScenes.bs
+++ b/source/ShowScenes.bs
@@ -809,7 +809,6 @@ function hasNextUpEpisode(parentID as string) as boolean
         SortOrder: "Descending",
         ImageTypeLimit: 1,
         UserId: m.global.session.user.id,
-        EnableRewatching: m.global.session.user.settings["ui.details.enablerewatchingnextup"],
         enableResumable: true,
         DisableFirstEpisode: false,
         limit: 1,

--- a/source/utils/quickplay.bs
+++ b/source/utils/quickplay.bs
@@ -230,7 +230,6 @@ namespace quickplay
                 "SortOrder": "Descending",
                 "ImageTypeLimit": 1,
                 "UserId": m.global.session.user.id,
-                "EnableRewatching": m.global.session.user.settings["ui.details.enablerewatchingnextup"],
                 "DisableFirstEpisode": false,
                 "EnableTotalRecordCount": false
             })
@@ -250,7 +249,6 @@ namespace quickplay
                 "SortOrder": "Descending",
                 "ImageTypeLimit": 1,
                 "UserId": m.global.session.user.id,
-                "EnableRewatching": m.global.session.user.settings["ui.details.enablerewatchingnextup"],
                 "DisableFirstEpisode": false,
                 "EnableTotalRecordCount": false
             })
@@ -320,7 +318,6 @@ namespace quickplay
             "SortBy": "DatePlayed",
             "SortOrder": "Descending",
             "ImageTypeLimit": "1",
-            "EnableRewatching": m.global.session.user.settings["ui.details.enablerewatchingnextup"],
             "DisableFirstEpisode": "false",
             "EnableTotalRecordCount": "false"
         }


### PR DESCRIPTION
# Pull Request

## Summary
Removed some settings from library menu that did not exist in core. Most of these settings did absolutely nothing in the moonfin ui, they are legacy from upstream jf roku app. 

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #
- Related to #

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [X] Refactor
- [ ] Performance improvement
- [ ] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

- removed settings that don't do anything in moonfin ui
- remove references to these settings across repo. even though they don't do anything, there is still code for legacy components and this removes any issues/warnings while building now that the settings are removed
- move 2 settings (max days next up, watched indicators) from library to general to match core

## Testing
Describe how this change was tested.

- [X] Tested on physical Roku device
- [ ] Tested via sideload
- [ ] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. Settings are gone, nothing breaks in library/details pages
2.
3.

## Screenshots (if applicable)
Include screenshots or recordings for UI changes.

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
