### PR TITLE
dismiss settings when opening whats new popup

### DIFF
--- a/components/settings/settings.bs
+++ b/components/settings/settings.bs
@@ -2329,6 +2329,7 @@ function onKeyEvent(key as string, press as boolean) as boolean
             end if
 
             if isStringEqual(key, KeyCode.OK)
+                dismissPanel()
                 m.global.sceneManager.callFunc("whatsNewDialog")
                 return true
             end if


### PR DESCRIPTION
# Pull Request

## Summary
When opening the "whats new" dialog from settings, first close the settings panel. 

When the whats new dialog closes, focus is returned to the previous screen (https://github.com/Moonfin-Client/Roku/commit/a79048e84f1b04fac555f96a0c9bab30e611ae45). However, if the settings panel is open, the dialog replaces the panel in focus, and the panel becomes stale, unable to be returned to. Trying to return/set focus pack to settings results in a new panel being drawn underneath the stale one. 

To avoid this, just dismiss the panel before opening the dialog, so when the dialog closes the focus returns correctly to the previous actual screen. 

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #223 
- Related to #

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

- dismiss settings panel before opening whatsnew popup
- 
- 

## Testing
Describe how this change was tested.

- [X] Tested on physical Roku device
- [ ] Tested via sideload
- [ ] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. settings, scroll down, what's new
2. press back or ok
3. the home screen is properly focused, without a stale settings panel stuck on top

## Screenshots (if applicable)
Include screenshots or recordings for UI changes.

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
