### PR TITLE
Recently released series type

### DIFF
--- a/components/data/HomeData.bs
+++ b/components/data/HomeData.bs
@@ -57,7 +57,7 @@ sub setData()
             m.top.iconUrl = "pkg:/media_type_icons/books.png"
         end if
 
-    else if datum.type = "Episode" or LCase(datum.type) = "recording" or datum.type = "MusicVideo"
+    else if datum.type = "Episode" or LCase(datum.type) = "recording" or datum.type = "MusicVideo" or datum.type = "Season"
         m.top.isWatched = datum.UserData.Played
 
         imgParams = {}

--- a/components/home/LoadItemsTask.bs
+++ b/components/home/LoadItemsTask.bs
@@ -14,6 +14,8 @@ import "pkg:/source/utils/SeerrUtils.bs"
 ' Items a "Recently Added" row holds, both per library and after libraries are merged
 const LATEST_MEDIA_LIMIT = 25
 
+const FIELDS = "DateCreated,Type,UserData,Overview,Genres,CommunityRating,CriticRating,OfficialRating,RunTimeTicks,ProductionYear,SeriesName,ParentIndexNumber,IndexNumber,Status,ImageTags,BackdropImageTags,ParentBackdropItemId,ParentBackdropImageTags,ParentThumbItemId,ParentThumbImageTag,SeriesId,SeriesPrimaryImageTag,ParentLogoItemId,ParentLogoImageTag,PrimaryImageTag,PrimaryImageAspectRatio"
+
 sub init()
     m.top.itemsToLoad = "libraries"
     m.top.functionName = "loadItems"
@@ -174,7 +176,7 @@ function loadRecentlyReleased() as object
         limit: 50,
         parentId: m.top.itemId,
         recursive: true,
-        fields: "PrimaryImageAspectRatio,Genres,Overview,ChildCount,RecursiveItemCount",
+        fields: FIELDS,
         enableImageTypes: `${ImageType.PRIMARY}, ${ImageType.BACKDROP}, ${ImageType.THUMB}`,
         imageTypeLimit: 1,
         includeItemTypes: includeItemTypes,

--- a/components/home/LoadItemsTask.bs
+++ b/components/home/LoadItemsTask.bs
@@ -156,6 +156,19 @@ end function
 function loadRecentlyReleased() as object
     results = []
 
+    includeItemTypes = `${ItemType.MOVIE}, ${ItemType.SERIES}, ${ItemType.BOOK}, ${ItemType.AUDIOBOOK}, ${ItemType.MUSICALBUM}`
+
+    if isStringEqual(m.top.metadata.contentType, "tvshows")
+        recentlyReleasedSeriesType = m.global.session.user.settings["ui.home.recentlyReleasedSeriesType"] ?? "series"
+        if isStringEqual(recentlyReleasedSeriesType, "season")
+            includeItemTypes = `${ItemType.SEASON}`
+        else if isStringEqual(recentlyReleasedSeriesType, "episode")
+            includeItemTypes = `${ItemType.EPISODE}`
+        else
+            includeItemTypes = `${ItemType.SERIES}`
+        end if
+    end if
+
     params = {
         userId: m.global.session.user.id,
         limit: 50,
@@ -164,7 +177,7 @@ function loadRecentlyReleased() as object
         fields: "PrimaryImageAspectRatio,Genres,Overview,ChildCount,RecursiveItemCount",
         enableImageTypes: `${ImageType.PRIMARY}, ${ImageType.BACKDROP}, ${ImageType.THUMB}`,
         imageTypeLimit: 1,
-        includeItemTypes: `${ItemType.MOVIE}, ${ItemType.SERIES}, ${ItemType.BOOK}, ${ItemType.AUDIOBOOK}, ${ItemType.MUSICALBUM}`,
+        includeItemTypes: includeItemTypes,
         sortBy: "PremiereDate,ProductionYear,SortName",
         sortOrder: "Descending",
         enableTotalRecordCount: false

--- a/settings/settings.json
+++ b/settings/settings.json
@@ -3114,6 +3114,27 @@
             "default": "false"
           },
           {
+            "title": "Recently Released Series Sort By",
+            "description": "Sort Recently Released Series home rows by series, latest season, or latest episode air date",
+            "settingName": "ui.home.recentlyReleasedSeriesType",
+            "type": "radio",
+            "default": "series",
+            "options": [
+              {
+                "title": "Series",
+                "id": "series"
+              },
+              {
+                "title": "Season",
+                "id": "season"
+              },
+              {
+                "title": "Episode",
+                "id": "episode"
+              }
+            ]
+          },
+          {
             "title": "Show Media Details",
             "description": "Show details of the selected item at the top of Library pages.",
             "settingName": "ui.library.showMediaDetails",

--- a/source/utils/settingsSync.bs
+++ b/source/utils/settingsSync.bs
@@ -27,6 +27,7 @@ namespace settingsSync
             { pluginKey: "mergeContinueWatchingNextUp", rokuKey: "ui.home.mergeContinueWatchingNextUp", type: "bool" },
             { pluginKey: "enableMultiServerLibraries", rokuKey: "ui.home.enableMultiServer", type: "bool" },
             { pluginKey: "mergeRecentRowsByType", rokuKey: "ui.home.mergeRecentRowsByType", type: "bool" },
+            { pluginKey: "recentlyReleasedSeriesType", rokuKey: "ui.home.recentlyReleasedSeriesType", type: "direct" },
             { pluginKey: "showMediaDetailsOnLibraryPage", rokuKey: "ui.library.showMediaDetails", type: "bool" },
             { pluginKey: "hideBackdropsInLibraries", rokuKey: "ui.library.hideBackdrops", type: "bool" },
             { pluginKey: "mediaBarMode", rokuKey: "ui.home.mediaBarMode", type: "direct" },


### PR DESCRIPTION
# Pull Request

## Summary
By default, the recently released row for a tv show library shows recently released tv shows (bear with me). It determines the "recently released" date by S01E01, ie when the series premiered. So unless it's a brand new show, it's not showing up. It would be nice if this row could show me that a new season is out, or new episode.

So I added an option to filter the recently released row for tv shows by series/season/episode, with series being the default to match current behavior.

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #
- Related to https://github.com/Moonfin-Client/Plugin/pull/237

## Type of Change
- [ ] Bug fix
- [X] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

- add recentlyReleasedSeriesType setting
- pass setting to api query when fetching recently released items for tv shows
- treat seasons the same as episodes when fetching image urls

## Testing
Describe how this change was tested.

- [X] Tested on physical Roku device
- [ ] Tested via sideload
- [ ] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1.
2.
3.

## Screenshots (if applicable)
Setting:
<img width="1280" height="720" alt="image" src="https://github.com/user-attachments/assets/55869349-1401-42f5-bbf7-bd67b6fd7a88" />

Series:
<img width="1280" height="720" alt="image" src="https://github.com/user-attachments/assets/2563544f-0a11-440b-87af-966bef0ab3eb" />

Season:
<img width="1280" height="720" alt="image" src="https://github.com/user-attachments/assets/476ec32a-a14a-4cac-afd6-122cf4f1d157" />

Episode:
<img width="1280" height="720" alt="image" src="https://github.com/user-attachments/assets/242548cb-e5e7-44de-94ab-63561e16f1ce" />

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
