### PR TITLE
add trickplay back to scrubbing ui

### DIFF
--- a/components/video/VideoPlayerView.bs
+++ b/components/video/VideoPlayerView.bs
@@ -371,6 +371,9 @@ sub stopScrubbing()
         m.scrubInfo.visible = false
     end if
 
+    trickplayImage = m.top.findNode("trickplayImage")
+    if isValid(trickplayImage) then trickplayImage.visible = false
+
     m.top.control = VideoControl.RESUME
     m.pauseOverlay.visible = false
     hideSegmentSkipButton()
@@ -407,6 +410,9 @@ sub onScrubTimer()
 
     m.positionText.text = secondsToHuman(m.scrubPosition, true)
     setVideoEndingTime(m.scrubPosition)
+
+    ' Show the trickplay frame at the scrub position
+    displayTrickplayImage(m.scrubPosition)
 end sub
 
 ' handleHideAction: Handles action to hide OSD menu
@@ -1031,8 +1037,16 @@ sub displayTrickplayImage(trickPosition as integer)
     offsetHoriz = 100
     offsetVert = 900 - m.trickplayDataFinal.Height
 
-    ' If we can get translation data for the trickplaybar's thumb icon, use it so the trickplay images can move left/right with seeking
-    if isValid(m.positionTranslation)
+    if m.scrubActive
+        if m.top.duration > 0
+            scrubPct = m.scrubPosition / m.top.duration
+            offsetHoriz = 103 + 1714 * scrubPct - m.trickplayDataFinal.Width / 2
+        else
+            offsetHoriz = 103
+        end if
+        offsetVert = 900 - m.trickplayDataFinal.Height
+    else if isValid(m.positionTranslation)
+        ' If we can get translation data for the trickplaybar's thumb icon, use it so the trickplay images can move left/right with seeking
         if m.positionTranslation.translation[0] = 0 then return
         offsetHoriz = m.positionTranslation.translation[0] - 50
     end if
@@ -1069,6 +1083,7 @@ sub displayTrickplayImage(trickPosition as integer)
     ' Move clippingRect to next trickplay image within tileset - offsetting translation by an equal amount so it doesn't move
     trickplayImage.translation = `[${offsetHoriz - (iconColumn * m.trickplayDataFinal.Width)},  ${offsetVert - (iconRow * m.trickplayDataFinal.Height)}]`
     trickplayImage.clippingRect = `[${iconColumn * m.trickplayDataFinal.Width}, ${iconRow * m.trickplayDataFinal.Height}, ${m.trickplayDataFinal.Width}, ${m.trickplayDataFinal.Height}]`
+    trickplayImage.visible = true
 end sub
 
 ' populateChapterMenu: ' Parse chapter data from API and appeand to chapter list menu

--- a/components/video/VideoPlayerView.bs
+++ b/components/video/VideoPlayerView.bs
@@ -1044,12 +1044,14 @@ sub displayTrickplayImage(trickPosition as integer)
         else
             offsetHoriz = 103
         end if
-        offsetVert = 900 - m.trickplayDataFinal.Height
     else if isValid(m.positionTranslation)
         ' If we can get translation data for the trickplaybar's thumb icon, use it so the trickplay images can move left/right with seeking
         if m.positionTranslation.translation[0] = 0 then return
         offsetHoriz = m.positionTranslation.translation[0] - 50
     end if
+
+    maxOffsetHoriz = 1920 - m.trickplayDataFinal.Width
+    if offsetHoriz > maxOffsetHoriz then offsetHoriz = maxOffsetHoriz
 
     if offsetHoriz < 0 then offsetHoriz = 0
 


### PR DESCRIPTION
# Pull Request

## Summary
This PR brings back trickplay images to the new scrubbing UI. The scrub position is fed to `displayTrickplayImage()` on every timer tick, and the image is repositioned to follow the progress bar.

## Related Issues
- Closes #228

## Type of Change
- [ ] Bug fix
- [X] New feature
- [ ] Refactor
- [ ] Performance improvement
- [X] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
- Call `displayTrickplayImage(m.scrubPosition)` on every scrub tick so the image tracks the scrub position.
- Anchored the image horizontally to the scrub progress bar instead of Roku's trickplay bar.

## Testing
- [X] Tested on physical Roku device
- [X] Tested via sideload
- [X] Manual testing completed
- [ ] Not tested (explain why):

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
