### PR TITLE
fix-ui - Spoilermode Extension, the Roku Port

### DIFF
--- a/components/tvshows/SeasonEpisodeRow.bs
+++ b/components/tvshows/SeasonEpisodeRow.bs
@@ -25,7 +25,8 @@ sub itemContentChanged()
         unplayedCount: chainLookupReturn(itemData, "json.UserData.UnplayedItemCount", 0)
     }
 
-    m.episodeOverview.text = isValid(itemData.overview) ? itemData.overview : ""
+    hideMediaDesc = moonfinPlugin.ParseBoolSetting(chainLookupReturn(m.global.session, "user.settings.`ui.itemdetail.hideMediaDescription`", false), false)
+    m.episodeOverview.text = (not hideMediaDesc and isValid(itemData.overview)) ? itemData.overview : ""
 
     if not isChainValid(itemData, "json") then return
 

--- a/components/tvshows/TVEpisodeListItem.bs
+++ b/components/tvshows/TVEpisodeListItem.bs
@@ -103,7 +103,8 @@ sub itemContentChanged()
         unplayedCount: chainLookupReturn(itemData, "json.UserData.UnplayedItemCount", 0)
     }
 
-    m.overview.text = itemData.overview
+    hideMediaDesc = moonfinPlugin.ParseBoolSetting(chainLookupReturn(m.global.session, "user.settings.`ui.itemdetail.hideMediaDescription`", false), false)
+    m.overview.text = (not hideMediaDesc and isValid(itemData.overview)) ? itemData.overview : ""
 
     if not isChainValid(itemData, "json") then return
 


### PR DESCRIPTION
# Pull Request

## Summary
Extend "Hide Media Description on Details Page" (`ui.itemdetail.hideMediaDescription`) preference to episode list items and season episode rows on Roku.

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #
- Related to # https://github.com/Moonfin-Client/Moonfin-Core/pull/1241 (port of)

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [X] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

- Updated **TVEpisodeListItem.bs** to check `ui.itemdetail.hideMediaDescription` before setting episode overview text.
- Updated **SeasonEpisodeRow.bs** to check `ui.itemdetail.hideMediaDescription` before setting episode overview text.

## Testing
Describe how this change was tested.

- [ ] Tested on physical Roku device
- [ ] Tested via sideload
- [ ] Manual testing completed
- [X] Not tested (explain why): Pinging @jmawet 

### Test Steps
1. Toggle "Hide Media Description on Details Page" (`ui.itemdetail.hideMediaDescription`) under Settings -> Personalization.
2. Verify that episode overviews in TVEpisodeListItem and SeasonEpisodeRow are hidden cleanly when enabled.

## Screenshots (if applicable)
Include screenshots or recordings for UI changes.

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
