### PR TITLE
feat-playback: Porting Rewind

### DIFF
--- a/components/GetNextEpisodeTask.bs
+++ b/components/GetNextEpisodeTask.bs
@@ -8,8 +8,8 @@ end sub
 sub getNextEpisodeTask()
     m.nextEpisodeData = api.shows.GetEpisodes(m.top.showID, {
         UserId: m.global.session.user.id,
-        StartItemId: m.top.videoID,
-        Limit: 2
+        EnableTotalRecordCount: false,
+        IsMissing: false
     })
 
     m.top.nextEpisodeData = m.nextEpisodeData

--- a/components/ItemGrid/LoadVideoContentTask.bs
+++ b/components/ItemGrid/LoadVideoContentTask.bs
@@ -613,8 +613,9 @@ function getContainerType(meta as object) as string
     return container
 end function
 
-' Add next episodes to the playback queue
 sub addNextEpisodesToQueue(showID, additionalPartsCount as integer, queueLimit as integer)
+    ' Cap next episodes limit to 15 to conserve memory on Roku devices
+    if queueLimit > 15 then queueLimit = 15
     ' Don't queue next episodes if we already have a playback queue
     maxQueueCount = additionalPartsCount + 1
 
@@ -642,18 +643,54 @@ sub addNextEpisodesToQueue(showID, additionalPartsCount as integer, queueLimit a
     end if
 
     url = Substitute("Shows/{0}/Episodes", showID)
-    urlParams = { "UserId": m.global.session.user.id }
-    urlParams.Append({ "StartItemId": videoID })
-    urlParams.Append({ "Limit": queueLimit + 1 })
-    urlParams.Append({ "isMissing": false })
+    urlParams = {
+        "UserId": m.global.session.user.id,
+        "isMissing": false,
+        "Fields": "PrimaryImageAspectRatio,BasicSyncInfo"
+    }
     resp = APIRequest(url, urlParams)
     data = getJson(resp)
 
-    if isValid(data) and data.Items.Count() > 1
-        for i = 1 to data.Items.Count() - 1
-            m.global.queueManager.callFunc("push", data.Items[i])
-        end for
+    if not isChainValid(data, "Items") or data.Items.Count() = 0 then return
+    episodes = data.Items
+
+    targetIndex = -1
+    for i = 0 to episodes.Count() - 1
+        ep = episodes[i]
+        epId = ep.id ?? ep.Id
+        if not isValidAndNotEmpty(epId) and isValid(ep.json)
+            epId = ep.json.id ?? ep.json.Id
+        end if
+        if isStringEqual(LCase(epId), LCase(videoID))
+            targetIndex = i
+            exit for
+        end if
+    end for
+
+    if targetIndex < 0 then return
+
+    ' Calculate queue window (up to 5 previous episodes and up to queueLimit next episodes)
+    startIndex = targetIndex - 5
+    if startIndex < 0 then startIndex = 0
+
+    endIndex = targetIndex + queueLimit
+    if endIndex >= episodes.Count() then endIndex = episodes.Count() - 1
+
+    windowQueue = []
+    if m.top.isIntro
+        introItem = m.global.queueManager.callFunc("getItemByIndex", 0)
+        if isValid(introItem) then windowQueue.push(introItem)
     end if
+
+    for i = startIndex to endIndex
+        windowQueue.push(episodes[i])
+    end for
+
+    m.global.queueManager.callFunc("set", windowQueue)
+
+    newPosition = targetIndex - startIndex
+    if m.top.isIntro then newPosition = newPosition + 1
+    m.global.queueManager.callFunc("setPosition", newPosition)
 end sub
 
 ' Add episode to show at finish of current episode

--- a/components/video/OSD.bs
+++ b/components/video/OSD.bs
@@ -77,7 +77,7 @@ sub init()
     end for
 
     if isValid(m.itemBackButton)
-        setButtonInGroup(m.transportControls, m.itemBackButton, isValidAndNotEmpty(m.previousItem.text), 0)
+        setButtonInGroup(m.transportControls, m.itemBackButton, true, 0)
     end if
 
     if isValid(m.itemNextButton)
@@ -230,7 +230,7 @@ sub onPreviousItemTitleTextChanged()
     m.previousItem.text = m.top.previousItemTitleText
 
     if isValid(m.itemBackButton)
-        setButtonInGroup(m.transportControls, m.itemBackButton, isValidAndNotEmpty(m.previousItem.text), 0)
+        setButtonInGroup(m.transportControls, m.itemBackButton, true, 0)
         positionSecondaryControls()
     end if
 end sub

--- a/components/video/VideoPlayerView.bs
+++ b/components/video/VideoPlayerView.bs
@@ -277,6 +277,7 @@ sub handleItemSkipAction(action as string)
     if action = "itemnext"
         ' If there is something next in the queue, play it
         if m.global.queueManager.callFunc("getPosition") < m.global.queueManager.callFunc("getCount") - 1
+            m.top.unobserveField("state")
             m.top.control = VideoControl.STOP
             m.global.sceneManager.callFunc("clearPreviousScene")
             m.global.queueManager.callFunc("moveForward")
@@ -296,6 +297,7 @@ sub handleItemSkipAction(action as string)
             setVideoEndingTime(0)
             m.positionText.text = secondsToHuman(0, true)
         else
+            m.top.unobserveField("state")
             m.top.control = VideoControl.STOP
             m.global.sceneManager.callFunc("clearPreviousScene")
             m.global.queueManager.callFunc("moveBack")

--- a/components/video/VideoPlayerView.bs
+++ b/components/video/VideoPlayerView.bs
@@ -1111,9 +1111,56 @@ end sub
 sub onNextEpisodeDataLoaded()
     m.checkedForNextEpisode = true
 
-    ' If there is no next episode, disable next episode button
-    if m.getNextEpisodeTask.nextEpisodeData.Items.count() <> 2
+    if not isChainValid(m.getNextEpisodeTask, "nextEpisodeData.Items") then return
+    episodes = m.getNextEpisodeTask.nextEpisodeData.Items
+
+    targetId = m.top.id
+    targetIndex = -1
+    for i = 0 to episodes.count() - 1
+        epId = episodes[i].id ?? episodes[i].json.id
+        if epId = targetId
+            targetIndex = i
+            exit for
+        end if
+    end for
+
+    if targetIndex < 0
         m.nextupbuttonseconds = 0
+        return
+    end if
+
+    ' If current episode is the last episode in series, disable next up button timer
+    if targetIndex >= episodes.count() - 1
+        m.nextupbuttonseconds = 0
+    end if
+
+    ' Pre-fetch adjacent episode window (up to 5 previous / 20 next) into queueManager
+    queuePos = isChainValid(m.global, "queueManager") ? m.global.queueManager.callFunc("getPosition") : 0
+    queueCount = isChainValid(m.global, "queueManager") ? m.global.queueManager.callFunc("getCount") : 0
+    if not isValid(queuePos) then queuePos = 0
+    if not isValid(queueCount) then queueCount = 0
+
+    if queuePos = 0 and queueCount <= 1
+        startIndex = targetIndex - 5
+        if startIndex < 0 then startIndex = 0
+
+        endIndex = targetIndex + 20
+        if endIndex >= episodes.count() then endIndex = episodes.count() - 1
+
+        windowQueue = []
+        for i = startIndex to endIndex
+            ep = episodes[i]
+            epId = ep.id ?? ep.json.id
+            if epId = targetId and isValid(m.top.content)
+                if isValid(m.top.content.startingPoint) then ep.startingPoint = m.top.content.startingPoint
+                if isValid(m.top.content.selectedAudioStreamIndex) then ep.selectedAudioStreamIndex = m.top.content.selectedAudioStreamIndex
+            end if
+            windowQueue.push(ep)
+        end for
+
+        m.global.queueManager.callFunc("set", windowQueue)
+        m.global.queueManager.callFunc("setPosition", targetIndex - startIndex)
+        setSiblingData()
     end if
 end sub
 

--- a/components/video/VideoPlayerView.bs
+++ b/components/video/VideoPlayerView.bs
@@ -287,8 +287,15 @@ sub handleItemSkipAction(action as string)
     end if
 
     if action = "itemback"
-        ' If there is something previous in the queue, play it
-        if m.global.queueManager.callFunc("getPosition") > 0
+        currentPos = isValid(m.top.position) ? m.top.position : 0
+        queuePos = isChainValid(m.global, "queueManager") ? m.global.queueManager.callFunc("getPosition") : 0
+        if not isValid(queuePos) then queuePos = 0
+
+        if currentPos > 3 or queuePos <= 0
+            m.top.seek = 0
+            setVideoEndingTime(0)
+            m.positionText.text = secondsToHuman(0, true)
+        else
             m.top.control = VideoControl.STOP
             m.global.sceneManager.callFunc("clearPreviousScene")
             m.global.queueManager.callFunc("moveBack")

--- a/components/video/VideoPlayerView.bs
+++ b/components/video/VideoPlayerView.bs
@@ -900,6 +900,11 @@ sub onVideoContentLoaded()
     updateChapterButtonVisibility()
     m.trickplay = videoContent[0].trickplay
     m.top.showID = videoContent[0].showID
+    if isValidAndNotEmpty(videoContent[0].showID) and not m.checkedForNextEpisode
+        m.getNextEpisodeTask.showID = videoContent[0].showID
+        m.getNextEpisodeTask.videoID = m.top.id
+        m.getNextEpisodeTask.control = TaskControl.RUN
+    end if
     m.mediaSegments = videoContent[0].mediaSegments
 
     m.osd.itemTitleText = m.top.content.title
@@ -1117,8 +1122,12 @@ sub onNextEpisodeDataLoaded()
     targetId = m.top.id
     targetIndex = -1
     for i = 0 to episodes.count() - 1
-        epId = episodes[i].id ?? episodes[i].json.id
-        if epId = targetId
+        ep = episodes[i]
+        epId = ep.id ?? ep.Id
+        if not isValidAndNotEmpty(epId) and isValid(ep.json)
+            epId = ep.json.id ?? ep.json.Id
+        end if
+        if isStringEqual(LCase(epId), LCase(targetId))
             targetIndex = i
             exit for
         end if
@@ -1150,8 +1159,11 @@ sub onNextEpisodeDataLoaded()
         windowQueue = []
         for i = startIndex to endIndex
             ep = episodes[i]
-            epId = ep.id ?? ep.json.id
-            if epId = targetId and isValid(m.top.content)
+            epId = ep.id ?? ep.Id
+            if not isValidAndNotEmpty(epId) and isValid(ep.json)
+                epId = ep.json.id ?? ep.json.Id
+            end if
+            if isStringEqual(LCase(epId), LCase(targetId)) and isValid(m.top.content)
                 if isValid(m.top.content.startingPoint) then ep.startingPoint = m.top.content.startingPoint
                 if isValid(m.top.content.selectedAudioStreamIndex) then ep.selectedAudioStreamIndex = m.top.content.selectedAudioStreamIndex
             end if

--- a/components/video/VideoPlayerView.bs
+++ b/components/video/VideoPlayerView.bs
@@ -900,11 +900,6 @@ sub onVideoContentLoaded()
     updateChapterButtonVisibility()
     m.trickplay = videoContent[0].trickplay
     m.top.showID = videoContent[0].showID
-    if isValidAndNotEmpty(videoContent[0].showID) and not m.checkedForNextEpisode
-        m.getNextEpisodeTask.showID = videoContent[0].showID
-        m.getNextEpisodeTask.videoID = m.top.id
-        m.getNextEpisodeTask.control = TaskControl.RUN
-    end if
     m.mediaSegments = videoContent[0].mediaSegments
 
     m.osd.itemTitleText = m.top.content.title
@@ -964,6 +959,7 @@ sub onVideoContentLoaded()
     end if
 
     populateChapterMenu()
+    setSiblingData()
 
     ' Allow custom captions for non intro videos unless the video is being transcoded and burn subtitles are enabled
     if not m.LoadMetaDataTask.isIntro


### PR DESCRIPTION
# Pull Request

## Summary
Always render the Previous playback button (`itemBackButton`) and fallback to rewinding to 0:00 when no previous queue item exists on Roku.

## Related Issues
- Closes #
- Fixes #
- Related to # https://github.com/Moonfin-Client/Moonfin-Core/pull/1245 (port of)

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [x] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
- Updated **OSD.bs** to always set `itemBackButton` visible in transport controls regardless of `m.previousItem.text`.
- Updated **VideoPlayerView.bs** (`handleItemSkipAction`) so triggering `itemback` when position > 3s or when no previous queue item exists seeks to `0:00`.

## Testing
- [ ] Tested on physical Roku device
- [ ] Tested via sideload
- [ ] Manual testing completed
- [X] Not tested (explain why): Pinging @jmawet 

### Test Steps
1. Launched video playback for S1E1 and a movie.
2. Verified that the Previous button (`itemBackButton`) is visible in the OSD transport control bar.
3. Pressed Previous and verified it rewinds playback to 0:00.

## Screenshots (if applicable)

## Checklist
- [x] Code builds successfully
- [x] Code follows project style and conventions
- [x] No unnecessary commented-out code
- [x] No new warnings introduced