### PR TITLE
navigation fix for upNextCard and overview

### DIFF
--- a/components/details/ModernItemDetails.bs
+++ b/components/details/ModernItemDetails.bs
@@ -219,6 +219,7 @@ end sub
 sub showUpNextCard()
     if not isValid(m.upNextItem)
         m.upNextCard.visible = false
+        updateOverviewWidth()
         return
     end if
     ep = m.upNextItem
@@ -226,6 +227,15 @@ sub showUpNextCard()
     m.upNextCard.title = ep.labelText
     m.upNextCard.progress = chainLookupReturn(ep, "json.UserData.PlayedPercentage", 0)
     m.upNextCard.visible = true
+    updateOverviewWidth()
+end sub
+
+sub updateOverviewWidth()
+    if isSeries() and isValid(m.upNextCard) and m.upNextCard.visible
+        m.overview.width = 1260
+    else
+        m.overview.width = 1350
+    end if
 end sub
 
 function upNextThumbUrl(ep as object) as string
@@ -866,6 +876,8 @@ sub itemContentChanged()
     if isValid(overviewNode)
         overviewNode.visible = not hideMediaDesc and isValidAndNotEmpty(overviewText)
     end if
+
+    updateOverviewWidth()
 
     ' Estimate if overview text overflows visible area (1350x180px, ~6 lines)
     overviewLen = 0

--- a/components/details/ModernItemDetails.bs
+++ b/components/details/ModernItemDetails.bs
@@ -275,10 +275,16 @@ end sub
 
 sub onUpNextEscape()
     dir = m.upNextCard.escape
-    if dir = "up"
+    if dir = "left"
+        if overviewCanScroll()
+            m.overview.setFocus(true)
+            m.top.lastFocus = m.overview
+            setLastFocus(m.overview)
+        end if
+    else if dir = "up"
         m.top.lastFocus = m.upNextCard
         FocusOverhang(m.top)
-    else
+    else if dir = "down"
         focusButtonsFromTabs()
     end if
 end sub
@@ -2721,6 +2727,15 @@ function onKeyEvent(key as string, press as boolean) as boolean
             setLastFocus(m.buttonGroups[m.currentButtonIndex])
         end if
         return true
+    end if
+
+    if key = KeyCode.RIGHT and isValid(m.overview) and m.overview.isInFocusChain()
+        if isValid(m.upNextCard) and m.upNextCard.visible
+            m.upNextCard.setFocus(true)
+            m.top.lastFocus = m.upNextCard
+            setLastFocus(m.upNextCard)
+            return true
+        end if
     end if
 
     if key = KeyCode.UP and m.buttonGroups.count() > 0


### PR DESCRIPTION
# Pull Request

## Summary
This PR fixes a couple issues between the overview and the upNextCard on modern item details. It changes the width of the overview when upNextCard is visible so it doesn't clip behind the card, and then adds left/right navigation between the overview (if it's scrollable) and the upNextCard.

## Related Issues
- Closes #224

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [X] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
- Added new function `updateOverviewWidth()` which checks if the item is series and upNextCard is visible, then sets the overview width.
- Added focus to overview in `onUpNextEscape()` and below when the overview is focused.

## Testing
- [X] Tested on physical Roku device
- [X] Tested via sideload
- [X] Manual testing completed
- [ ] Not tested (explain why):

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
