### PR TITLE
taming the details screen description font size

### DIFF
--- a/components/details/ExpandableOverview.bs
+++ b/components/details/ExpandableOverview.bs
@@ -42,7 +42,11 @@ sub onContentChanged()
         m.top.expanded = false
     end if
 
-    m.overviewText.font.size = m.top.fontSize
+    overviewSize = m.top.fontSize
+    if fontRegistry.HasFamily(get_user_setting("ui.theme.fontFamily"))
+        overviewSize = overviewSize * 0.85
+    end if
+    m.overviewText.font.size = overviewSize
     m.overviewText.lineSpacing = Int(m.top.fontSize * (LINE_HEIGHT - 1) + 0.5)
     m.overviewText.text = m.top.text
 
@@ -53,7 +57,11 @@ sub onContentChanged()
 end sub
 
 function lineHeight() as integer
-    return Int(m.top.fontSize * LINE_HEIGHT + 0.5)
+    overviewSize = m.top.fontSize
+    if fontRegistry.HasFamily(get_user_setting("ui.theme.fontFamily"))
+        overviewSize = overviewSize * 0.85
+    end if
+    return Int(overviewSize * LINE_HEIGHT + 0.5)
 end function
 
 ' Measured on the label that draws it, so the height counted is the height shown

--- a/components/details/ExpandableOverview.bs
+++ b/components/details/ExpandableOverview.bs
@@ -1,5 +1,6 @@
 import "pkg:/source/enums/ColorPalette.bs"
 import "pkg:/source/enums/KeyCode.bs"
+import "pkg:/source/utils/fontApply.bs"
 import "pkg:/source/utils/misc.bs"
 import "pkg:/source/utils/themeChrome.bs"
 
@@ -42,27 +43,22 @@ sub onContentChanged()
         m.top.expanded = false
     end if
 
-    overviewSize = m.top.fontSize
-    if fontRegistry.HasFamily(get_user_setting("ui.theme.fontFamily"))
-        overviewSize = overviewSize * 0.85
-    end if
+    overviewSize = fontApply.ThemeBodyTextSize(m.top.fontSize)
     m.overviewText.font.size = overviewSize
-    m.overviewText.lineSpacing = Int(m.top.fontSize * (LINE_HEIGHT - 1) + 0.5)
+    m.overviewText.lineSpacing = Int(overviewSize * (LINE_HEIGHT - 1) + 0.5)
+
+    ' A theme font draws smaller than the size asked for, and by a different amount
+    ' for each family, so the line pitch is measured rather than worked out
+    m.overviewText.text = "Ag"
+    m.linePitch = Int(measureText(m.top.maxWidth) + m.overviewText.lineSpacing + 0.5)
+
     m.overviewText.text = m.top.text
 
     ' Whether the box is needed is judged on the width the text has without one
-    m.top.canToggle = measureText(m.top.maxWidth) > COLLAPSED_LINES * lineHeight()
+    m.top.canToggle = measureText(m.top.maxWidth) > COLLAPSED_LINES * m.linePitch
 
     layout()
 end sub
-
-function lineHeight() as integer
-    overviewSize = m.top.fontSize
-    if fontRegistry.HasFamily(get_user_setting("ui.theme.fontFamily"))
-        overviewSize = overviewSize * 0.85
-    end if
-    return Int(overviewSize * LINE_HEIGHT + 0.5)
-end function
 
 ' Measured on the label that draws it, so the height counted is the height shown
 function measureText(width as float) as float
@@ -87,13 +83,13 @@ sub layout()
     if m.top.expanded
         ' Capped on a whole line, so the last one shown is not sliced in half
         if textHeight > EXPANDED_MAX_HEIGHT
-            textHeight = Int(EXPANDED_MAX_HEIGHT / lineHeight()) * lineHeight()
+            textHeight = Int(EXPANDED_MAX_HEIGHT / m.linePitch) * m.linePitch
         end if
     else
-        textHeight = COLLAPSED_LINES * lineHeight()
+        textHeight = COLLAPSED_LINES * m.linePitch
     end if
 
-    m.scrollStep = SCROLL_LINES * lineHeight()
+    m.scrollStep = SCROLL_LINES * m.linePitch
     showText(textWidth, textHeight, fullHeight, BOX_PAD)
 
     m.readMore.text = m.top.expanded ? tr("Read Less") : tr("Read More")

--- a/components/details/ItemDetails.bs
+++ b/components/details/ItemDetails.bs
@@ -41,6 +41,9 @@ const CLASSIC_LOGO_HEIGHT = 116
 const CLASSIC_CODEC_GAP = 8
 const CLASSIC_CONTENT_LEFT = 96
 const CLASSIC_CONTENT_WIDTH = 1728
+' Kept clear of the artwork on the right, which is a wide thumbnail on an episode
+' rather than a poster
+const CLASSIC_OVERVIEW_WIDTH = 1290
 const CLASSIC_SEPARATOR_MARGIN = 7
 const CLASSIC_PILL_PAD_X = 14
 const CLASSIC_PILL_PAD_Y = 4
@@ -105,7 +108,7 @@ sub init()
     m.logoShadow = m.top.findNode("logoShadow")
     m.titleNode = m.top.findNode("title")
     m.overview = m.top.findNode("overview")
-    m.overview.maxWidth = 1350
+    m.overview.maxWidth = CLASSIC_OVERVIEW_WIDTH
     ' Opening the overview changes how much room it takes, so what sits under it
     ' moves down to make way
     m.overview.observeField("boxHeight", "onOverviewHeightChanged")

--- a/components/details/ModernItemDetails.bs
+++ b/components/details/ModernItemDetails.bs
@@ -202,7 +202,7 @@ end sub
 sub sizeHeroFonts()
     heroSize = fontApply.ThemeTextSize(HERO_TEXT_SIZE)
     badgeSize = fontApply.ThemeTextSize(HERO_BADGE_TEXT_SIZE)
-    overviewSize = fontApply.ThemeTextSize(OVERVIEW_TEXT_SIZE)
+    overviewSize = OVERVIEW_TEXT_SIZE
 
     for each id in ["releaseYear", "officialRating", "seasonCount", "episodeNumber", "runtime", "endsAt", "metaGenres", "techSize", "techSeparator", "tagline"]
         node = m.top.findNode(id)
@@ -217,6 +217,10 @@ sub sizeHeroFonts()
     if isValid(ratingsRow)
         ratingsRow.valueSize = badgeSize
         ratingsRow.nameSize = badgeSize
+    end if
+
+    if fontRegistry.HasFamily(get_user_setting("ui.theme.fontFamily"))
+        overviewSize = overviewSize * 0.8
     end if
     m.overview.fontSize = overviewSize
     m.top.findNode("techSeparator").text = fontApply.ThemeSeparator()

--- a/components/details/ModernItemDetails.bs
+++ b/components/details/ModernItemDetails.bs
@@ -53,7 +53,8 @@ const TAB_CONTENT_GAP = 12
 const CONTENT_WIDTH = 1728
 const HERO_WIDTH = 1595
 const HERO_WIDTH_WITH_UP_NEXT = 960
-const OVERVIEW_WIDTH = 1160
+' Kept clear of the artwork on the right
+const OVERVIEW_WIDTH = 1100
 const UP_NEXT_WIDTH = 594
 const UP_NEXT_TOP_GAP = 14
 ' The hero's small copy. Bigger than the other clients ask for, because the Roku
@@ -202,7 +203,6 @@ end sub
 sub sizeHeroFonts()
     heroSize = fontApply.ThemeTextSize(HERO_TEXT_SIZE)
     badgeSize = fontApply.ThemeTextSize(HERO_BADGE_TEXT_SIZE)
-    overviewSize = OVERVIEW_TEXT_SIZE
 
     for each id in ["releaseYear", "officialRating", "seasonCount", "episodeNumber", "runtime", "endsAt", "metaGenres", "techSize", "techSeparator", "tagline"]
         node = m.top.findNode(id)
@@ -219,7 +219,9 @@ sub sizeHeroFonts()
         ratingsRow.nameSize = badgeSize
     end if
 
-    m.overview.fontSize = overviewSize
+    ' The overview does its own theme sizing, so it takes the plain size rather
+    ' than the bumped one
+    m.overview.fontSize = OVERVIEW_TEXT_SIZE
     m.top.findNode("techSeparator").text = fontApply.ThemeSeparator()
 
     ' The title is already large enough to read whatever font it is drawn in

--- a/components/details/ModernItemDetails.bs
+++ b/components/details/ModernItemDetails.bs
@@ -219,9 +219,6 @@ sub sizeHeroFonts()
         ratingsRow.nameSize = badgeSize
     end if
 
-    if fontRegistry.HasFamily(get_user_setting("ui.theme.fontFamily"))
-        overviewSize = overviewSize * 0.8
-    end if
     m.overview.fontSize = overviewSize
     m.top.findNode("techSeparator").text = fontApply.ThemeSeparator()
 

--- a/source/utils/fontApply.bs
+++ b/source/utils/fontApply.bs
@@ -5,6 +5,10 @@ import "pkg:/source/utils/fontRegistry.bs"
 ' which leaves small copy hard to read across a room. Blocks of small text ask
 ' for more so they land back at a comfortable size.
 const THEME_TEXT_BUMP = 1.35
+' A paragraph is the one place that bump works against itself. A long run of a
+' display face reads better a little smaller than the copy around it, so the
+' overview asks for less instead.
+const THEME_BODY_TRIM = 0.85
 
 namespace fontApply
 
@@ -12,6 +16,12 @@ namespace fontApply
         if not fontRegistry.HasFamily(get_user_setting("ui.theme.fontFamily")) then return base
 
         return Int(base * THEME_TEXT_BUMP + 0.5)
+    end function
+
+    function ThemeBodyTextSize(base as integer) as integer
+        if not fontRegistry.HasFamily(get_user_setting("ui.theme.fontFamily")) then return base
+
+        return Int(base * THEME_BODY_TRIM + 0.5)
     end function
 
     ' The dot between facts, in whatever form the font in play can draw


### PR DESCRIPTION
# Pull Request

## Summary
The description text on details screens became giant when using a theme with an alternate font.

Modern details screen scaled it super big. 

Both details screens could use an adjustment. 

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #
- Related to #

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

- don't use default theme scaling for overview text size on modern detail screen because that makes it huge
- reduce text size by 20% for non standard theme fonts in overview card (independent of details screen style)
- 

## Testing
Describe how this change was tested.

- [X] Tested on physical Roku device
- [ ] Tested via sideload
- [ ] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1.
2.
3.

## Screenshots (if applicable)
<img width="1280" height="720" alt="image" src="https://github.com/user-attachments/assets/01b4444c-3eaa-484b-9b57-822f3fdcfc24" />
<img width="1280" height="720" alt="image" src="https://github.com/user-attachments/assets/b30628ef-3a6f-4b7c-8fd4-68dd24459978" />
<img width="1280" height="720" alt="image" src="https://github.com/user-attachments/assets/fbe69e33-cd9d-41c1-8c10-d07e94e1372f" />
<img width="1280" height="720" alt="image" src="https://github.com/user-attachments/assets/6f13e234-41c1-4f8f-81b1-4cb390155dca" />


## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
