### PR TITLE
remove incompatible imagedimension field set in search results

### DIFF
--- a/components/search/SearchRow.bs
+++ b/components/search/SearchRow.bs
@@ -150,7 +150,6 @@ sub appendGrid(data as object, bucket as object, aspect as string)
             if index + offset >= bucket.count() then exit for
 
             item = bucket[index + offset]
-            item.imageDimensions = [card.width, card.image]
             row.appendChild(item)
         end for
 
@@ -166,7 +165,6 @@ sub appendRow(data as object, title as string, bucket as object, aspect as strin
     row.title = title + " (" + Str(bucket.count()).trim() + ")"
 
     for each item in bucket
-        item.imageDimensions = [card.width, card.image]
         row.appendChild(item)
     end for
 


### PR DESCRIPTION
# Pull Request

## Summary
When creating the ContentNode objects for the search page rows, you were passing item.imageDimensions

imageDimensions exists for SearchData objects, not ContentNode objects. So it was getting dropped and throwing debug warnings

I just removed the field to get rid of the warnings since it did nothing

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #
- Related to #

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

- remove item.imageDimension sets in SearchRows.bs
- 
- 

## Testing
Describe how this change was tested.

- [X] Tested on physical Roku device
- [ ] Tested via sideload
- [ ] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. Search something
2. No longer get bombarded with warnings on telnet logs
3.

## Screenshots (if applicable)
Include screenshots or recordings for UI changes.

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
