### PR TITLE
move seerr results to bottom of all search tab

### DIFF
--- a/components/search/SearchRow.bs
+++ b/components/search/SearchRow.bs
@@ -90,15 +90,15 @@ function getData()
             end if
         end for
     else
-        if seerrItems.count() > 0
-            appendRow(data, "Seerr", seerrItems, searchGroups.ASPECT_POSTER)
-        end if
-
         for each entry in searchGroups.Catalogue()
             if not isValidAndNotEmpty(buckets[entry.key]) then continue for
 
             appendRow(data, entry.title, buckets[entry.key], searchGroups.AspectFor(entry.types[0]))
         end for
+
+        if seerrItems.count() > 0
+            appendRow(data, "Seerr", seerrItems, searchGroups.ASPECT_POSTER)
+        end if
     end if
 
     m.top.rowHeights = m.rowHeights


### PR DESCRIPTION
# Pull Request

## Summary
The "all" tab was showing seerr results at the top, they should be at the bottom

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #
- Related to #

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

- SearchRows.bs was appending the seerr rows before the category rows, I just moved the function call after and that fixed it
- 
- 

## Testing
Describe how this change was tested.

- [X] Tested on physical Roku device
- [ ] Tested via sideload
- [ ] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1.
2.
3.

## Screenshots (if applicable)
Include screenshots or recordings for UI changes.
<img width="1280" height="720" alt="image" src="https://github.com/user-attachments/assets/fff9d7e0-41dd-4879-8b37-c76ae78cb829" />


## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
