### PR TITLE
fix studio images scaling on modern home rows focus

### DIFF
--- a/components/home/Home.bs
+++ b/components/home/Home.bs
@@ -9,7 +9,6 @@ import "pkg:/source/utils/config.bs"
 import "pkg:/source/utils/deviceCapabilities.bs"
 import "pkg:/source/utils/SeerrUtils.bs"
 import "pkg:/source/utils/misc.bs"
-import "pkg:/source/constants/HomeRowItemSizes.bs"
 
 sub init()
     ' Check if this is truly the first run (ever, not just this session)
@@ -1320,9 +1319,19 @@ sub showModernFocusCard(focusedItem as object)
 
     m.mfPendingUri = homeLandscapeUri(focusedItem)
     itemDataType = isValid(focusedItem.type) ? LCase(focusedItem.type) : ""
-    if itemDataType = "seerrbrowse" or itemDataType = "seerrshortcut"
+    ' Studios and networks carry a wide logo, which has to sit whole inside the frame on a
+    ' dark ground rather than being cropped to fill it. Genre and shortcut tiles use full
+    ' backdrop art, so they keep the zoom treatment everything else gets.
+    browseType = LCase(chainLookupReturn(focusedItem, "json.SeerrBrowseType", ""))
+    isLogoTile = itemDataType = "seerrbrowse" and (browseType = "studio" or browseType = "network")
+    if isLogoTile
         m.mfImage.loadDisplayMode = "scaleToFit"
+        m.mfImagePrev.loadDisplayMode = "scaleToFit"
         m.mfBackdrop.opacity = 1.0
+    else
+        m.mfImage.loadDisplayMode = "scaleToZoom"
+        m.mfImagePrev.loadDisplayMode = "scaleToZoom"
+        m.mfBackdrop.opacity = 0
     end if
 
     if isValid(m.mfImageSettle)

--- a/components/home/Home.bs
+++ b/components/home/Home.bs
@@ -9,6 +9,7 @@ import "pkg:/source/utils/config.bs"
 import "pkg:/source/utils/deviceCapabilities.bs"
 import "pkg:/source/utils/SeerrUtils.bs"
 import "pkg:/source/utils/misc.bs"
+import "pkg:/source/constants/HomeRowItemSizes.bs"
 
 sub init()
     ' Check if this is truly the first run (ever, not just this session)
@@ -73,6 +74,7 @@ sub init()
     ' Modern rows focused card overlay
     m.modernFocusCard = m.top.findNode("modernFocusCard")
     m.mfImage = m.top.findNode("mfImage")
+    m.mfBackdrop = m.top.findNode("mfBackdrop")
     m.mfInfo = m.top.findNode("mfInfo")
     m.mfTitle = m.top.findNode("mfTitle")
     m.mfMeta = m.top.findNode("mfMeta")
@@ -1317,6 +1319,11 @@ sub showModernFocusCard(focusedItem as object)
     end if
 
     m.mfPendingUri = homeLandscapeUri(focusedItem)
+    itemDataType = isValid(focusedItem.type) ? LCase(focusedItem.type) : ""
+    if itemDataType = "seerrbrowse" or itemDataType = "seerrshortcut"
+        m.mfImage.loadDisplayMode = "scaleToFit"
+        m.mfBackdrop.opacity = 1.0
+    end if
 
     if isValid(m.mfImageSettle)
         m.mfImageSettle.control = "stop"
@@ -1401,6 +1408,7 @@ sub hideModernFocusCard()
     m.mfCrossfading = false
     m.mfSettling = false
     m.mfPendingUri = ""
+    m.mfBackdrop.opacity = 0
 
     if isValid(m.modernFocusCard) then m.modernFocusCard.visible = false
     m.modernCardShown = false

--- a/components/home/Home.xml
+++ b/components/home/Home.xml
@@ -85,6 +85,7 @@
       <MaskGroup id="mfImageMask" maskUri="pkg:/images/posterWideMask.png">
         <!-- The outgoing image stays up until the incoming one is ready, so the card
              never shows a gap while the wide art is fetched -->
+        <Rectangle id="mfBackdrop" width="464" height="270" color="#000000FF" opacity="0" />
         <Poster id="mfImagePrev" width="464" height="270" loadDisplayMode="scaleToZoom" opacity="0" />
         <Poster id="mfImage" width="464" height="270" loadDisplayMode="scaleToZoom" opacity="0" />
       </MaskGroup>


### PR DESCRIPTION
# Pull Request

## Summary
Studio logos were scaling to fill the modern focus card, leaving the logo bigger than the available space. 

Conversely, the backdrop behind the studio logo did not scale, leaving a "half" backdrop

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #
- Related to #

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

- use correct scaling for studio rows modern focus card
- add correctly sized backdrop for studio rows modern focus card
- ensure backdrop hides when modern focus card hides to avoid persisting the backdrop when not needed

## Testing
Describe how this change was tested.

- [ ] Tested on physical Roku device
- [ ] Tested via sideload
- [ ] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1.
2.
3.

## Screenshots (if applicable)
Include screenshots or recordings for UI changes.
<img width="1280" height="720" alt="image" src="https://github.com/user-attachments/assets/f9b6b654-388a-4bd8-9f24-f3432c904c1f" />


## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
