### PR TITLE
Fix modern row reflow on first load

### DIFF
--- a/components/home/Home.bs
+++ b/components/home/Home.bs
@@ -330,7 +330,7 @@ end sub
 
 ' Check if Featured Media should be shown when content loads
 sub onHomeRowsContentLoaded()
-    if not isValid(m.mediaBar) or not isValid(m.homeRows) then return
+    if not isValid(m.mediaBar) and not isValid(m.homeRows) then return
 
     if m.modernHomeRows and isValid(m.homeRows.content)
         focused = m.homeRows.rowItemFocused

--- a/components/home/Home.bs
+++ b/components/home/Home.bs
@@ -330,14 +330,15 @@ end sub
 
 ' Check if Featured Media should be shown when content loads
 sub onHomeRowsContentLoaded()
-    if not isValid(m.mediaBar) and not isValid(m.homeRows) then return
-
-    if m.modernHomeRows and isValid(m.homeRows.content)
+    if m.modernHomeRows and isValid(m.homeRows) and isValid(m.homeRows.content)
         focused = m.homeRows.rowItemFocused
-        if isValid(focused) and focused.count() = 2
-            if focused[0] >= 0 and focused[1] >= 0
-                applyModernReflow(focused[0], focused[1])
-            end if
+        if not isValid(focused) or focused.count() <> 2 or focused[0] < 0 or focused[1] < 0
+            ' Nothing has focus yet when the rows land, so the first row stays flat
+            ' until the viewer moves. Reflow its first card directly, which is safe
+            ' to do again when a real focus arrives with the same coordinates.
+            applyModernReflow(0, 0)
+        else
+            applyModernReflow(focused[0], focused[1])
         end if
     end if
 
@@ -351,7 +352,7 @@ sub onHomeRowsContentLoaded()
 
     ' Only show/focus Media Bar if it's enabled and home rows doesn't have focus
     if m.isMediaBarEnabled
-        if not m.homeRows.hasFocus()
+        if isValid(m.homeRows) and not m.homeRows.hasFocus()
             applyMediaBarLayout(true)
         end if
     else


### PR DESCRIPTION
# Pull Request

## Summary
there's an issue in onHomeRowsContentLoaded that caused it to exit prematurely before it got a chance to do anything

for some reason when triggered, isValid(m.homeRows) returns false? Even though only m.homeRows notifier can trigger onHomeRowsContentLoaded? So how can it trigger if it's not valid? Whack

I changed the "or" to an "and" so it only returns if neither m.homeRows or m.mediaBar is valid. If at least 1 is valid, it proceeds. Individual actions within the function are still gated by individual isValid() chekcs on the item the action is being performed on, so I think that should still be ok in terms of protections? At this point we might just be able to remove that first line instead of changing it, or at least removing the isValid(m.homeRows) since that's the part that appears to be broken for some reason. 

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #
- Related to #

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

- 
- 
- 

## Testing
Describe how this change was tested.

- [ ] Tested on physical Roku device
- [ ] Tested via sideload
- [ ] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. Start the app with media bar = off, modern reflow will apply to the first item so the first row renders correctly
2. Start the app with media bar = on, media bar loads, no modern reflow is applied since mediabar has focus
3.

## Screenshots (if applicable)
Include screenshots or recordings for UI changes.

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
