### PR TITLE
Fix ratings row overlaying on to overview in modern home

### DIFF
--- a/components/home/Home.bs
+++ b/components/home/Home.bs
@@ -1320,6 +1320,7 @@ sub showModernFocusCard(focusedItem as object)
         m.mfRatings.ratingsData = invalid
         m.mfRatings.visible = false
     end if
+    updateModernOverviewPosition()
 
     m.modernFocusCard.visible = true
 
@@ -1777,6 +1778,13 @@ function formatRating(rating as float) as string
     return Left(rating.toStr(), 3)
 end function
 
+sub updateModernOverviewPosition()
+    if not isValid(m.mfOverview) then return
+    y = 75
+    if isValid(m.mfRatings) and m.mfRatings.visible then y = 126
+    m.mfOverview.translation = [0, y]
+end sub
+
 sub setFieldVisibility(fieldName as string, isVisible as boolean)
     fieldNode = m.top.findNode(fieldName)
     if isValid(fieldNode)
@@ -1894,6 +1902,7 @@ sub onHomeRatingsLoaded(event as object)
     if m.modernHomeRows and isValid(m.mfRatings)
         m.mfRatings.ratingsData = result
         m.mfRatings.visible = true
+        updateModernOverviewPosition()
     end if
 
     if not isValid(ratingsContainer) then return

--- a/components/home/Home.xml
+++ b/components/home/Home.xml
@@ -93,7 +93,7 @@
         <ScrollingText id="mfTitle" font="font:MediumBoldSystemFont" color="#FFFFFF" maxWidth="464" translation="[0, 0]" />
         <Label id="mfMeta" font="font:SmallestBoldSystemFont" color="#CCCCCC" width="760" maxLines="1" translation="[0, 40]" />
         <RatingsRow id="mfRatings" visible="false" labelFont="font:SmallestBoldSystemFont" ratingSpacing="14" translation="[0, 74]" />
-        <Label id="mfOverview" font="font:SmallestSystemFont" color="#DDDDDD" width="760" wrap="true" maxLines="3" lineSpacing="4" translation="[0, 108]" />
+        <Label id="mfOverview" font="font:SmallestSystemFont" color="#DDDDDD" width="760" wrap="true" maxLines="3" lineSpacing="4" translation="[0, 75]" />
       </Group>
       <!-- The info comes up as the neighbouring cells slide, so this matches
            modernShiftAnim in HomeItem.xml -->


### PR DESCRIPTION
# Pull Request

## Summary
With the recent changes to the style of ratings, they ended up being overlayed under the overview text. This PR changes the y of `mfOverview` when the item has ratings, or doesn't.

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [X] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
- Moved default `mfOverview` y translation up to 75.
- Added `updateModernOverviewPosition()` to check if ratings is visible, and if so shifts the overview down to a y translation of 126.

## Testing
- [X] Tested on physical Roku device
- [X] Tested via sideload
- [X] Manual testing completed
- [ ] Not tested (explain why):

## Screenshots
Before
<img width="1920" height="923" alt="screenshot-2026-09-01-20 21 39 276" src="https://github.com/user-attachments/assets/5c5a6b8e-16a6-4cbe-b10f-0a051a74cc47" />


After
<img width="1920" height="929" alt="screenshot-2026-09-01-20 15 13 439" src="https://github.com/user-attachments/assets/c3d4cd22-5ea5-4260-81b9-c6bf79681105" />


## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
