### PR TITLE
fix modern reflow on first boot for real this time i swear

### DIFF
--- a/components/home/Home.bs
+++ b/components/home/Home.bs
@@ -331,33 +331,22 @@ end sub
 
 ' Check if Featured Media should be shown when content loads
 sub onHomeRowsContentLoaded()
-    if m.modernHomeRows and isValid(m.homeRows) and isValid(m.homeRows.content)
-        focused = m.homeRows.rowItemFocused
-        if not isValid(focused) or focused.count() <> 2 or focused[0] < 0 or focused[1] < 0
-            ' Nothing has focus yet when the rows land, so the first row stays flat
-            ' until the viewer moves. Reflow its first card directly, which is safe
-            ' to do again when a real focus arrives with the same coordinates.
-            applyModernReflow(0, 0)
-        else
-            applyModernReflow(focused[0], focused[1])
-        end if
-    end if
+    if not isValid(m.mediaBar) or not isValid(m.homeRows) then return
 
     ' Check if Media Bar is enabled via toggle (no longer checking homesection0)
-    if isValid(m.homeRows)
-        mediaBarCheck = m.homeRows.callFunc("isFeaturedMediaEnabled")
-        if isValid(mediaBarCheck) and type(mediaBarCheck) = "roBoolean"
-            m.isMediaBarEnabled = mediaBarCheck
-        end if
+    mediaBarCheck = m.homeRows.callFunc("isFeaturedMediaEnabled")
+    if isValid(mediaBarCheck) and type(mediaBarCheck) = "roBoolean"
+        m.isMediaBarEnabled = mediaBarCheck
     end if
 
     ' Only show/focus Media Bar if it's enabled and home rows doesn't have focus
-    if m.isMediaBarEnabled
-        if isValid(m.homeRows) and not m.homeRows.hasFocus()
-            applyMediaBarLayout(true)
-        end if
+    if m.isMediaBarEnabled and not m.homeRows.hasFocus()
+        applyMediaBarLayout(true)
     else
-        applyMediaBarLayout(false)
+        ' Media bar disabled or home rows having focus means focused item details should be loaded
+        ' onItemFocusChanged has guardrails already to return if focus is not on a valid
+        ' home row item, so we can just call it directly
+        onItemFocusChanged()
     end if
 end sub
 


### PR DESCRIPTION
# Pull Request

## Summary
turns out the change you made to my pr undid my fix, but also revealed that my fix was not correct either it just broke other stuff so the thing causing the issue never triggered. I have found the REAL cause of it

applyMediaBar(false)

I added a bunch of print statements in the code to figure out what was happening, turns out, applyMediaBar(false) undoes the modern reflow? Whack. Anyways, I removed it, tweaked some stuff around, it is working reliably now in my testing. 

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #
- Related to #

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

- reinstate initial validity check for homerows and mediabar
- remove the broken applyMediaBar(false) call
- remove the applyModernReflow explicit calls since they did nothing anyways it turns out
- call onItemChanged() one more time to make extra sure reflow applies to correct row/item and the poster behind it disappears (both of those situations sometimes occured on my weak roku depending on what order things loaded in)

simply calling onItemChanged() after determining no media bar is needed is the safest and most reliable way to ensure the reflow applies correctly from my testing. it already has all the conditions/safeguards in place that we were trying to replicate directly before

## Testing
Describe how this change was tested.

- [X] Tested on physical Roku device
- [ ] Tested via sideload
- [ ] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1.
2.
3.

## Screenshots (if applicable)
Include screenshots or recordings for UI changes.
<img width="1280" height="720" alt="image" src="https://github.com/user-attachments/assets/620eb5a0-de83-4b02-a0e2-e44290e5a998" />


## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
