### PR TITLE
fix warning from invalid field on text object on person screen

### DIFF
--- a/components/extras/ExtrasItem.bs
+++ b/components/extras/ExtrasItem.bs
@@ -208,7 +208,6 @@ sub showContent()
                     ' Non-episode: standard layout
                     m.name.translation = [0, labelY]
                     m.role.translation = [0, labelY + 40]
-                    m.role.maxWidth = posterWidth
                     m.role.visible = true
 
                     if isValid(m.epNumber) then m.epNumber.visible = false

--- a/components/extras/ExtrasItem.bs
+++ b/components/extras/ExtrasItem.bs
@@ -208,6 +208,7 @@ sub showContent()
                     ' Non-episode: standard layout
                     m.name.translation = [0, labelY]
                     m.role.translation = [0, labelY + 40]
+                    m.role.width = posterWidth
                     m.role.visible = true
 
                     if isValid(m.epNumber) then m.epNumber.visible = false
@@ -239,7 +240,7 @@ sub showContent()
             ' Handle music videos differently
             if isStringEqual(cont.LookupCI("type"), ItemType.MUSICVIDEO)
                 m.name.maxWidth = 400
-                m.role.maxWidth = 400
+                m.role.width = 400
             end if
         end if
 


### PR DESCRIPTION
# Pull Request

## Summary
There was a warning in telnet logs when going to person details screen

You were trying to set maxWidth on text

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #
- Related to #

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

- deleted line causing warning
- 
- 

## Testing
Describe how this change was tested.

- [X] Tested on physical Roku device
- [ ] Tested via sideload
- [ ] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. Go to person details screen
2. No more warning
3. Huzzah!

## Screenshots (if applicable)
Include screenshots or recordings for UI changes.

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
