### PR TITLE
fix focused episode going offscreen on season pages that lack descrip…

### DIFF
--- a/components/details/ModernItemDetails.bs
+++ b/components/details/ModernItemDetails.bs
@@ -964,6 +964,7 @@ end sub
 
 sub onTabBarEscape()
     dir = m.tabBar.escape
+    scrollAmount = m.overview.visible ? -500 : 0
     if dir = "up"
         focusButtonsFromTabs()
     else if dir = "down"
@@ -971,7 +972,7 @@ sub onTabBarEscape()
             if m.seerrBlock.callFunc("focusFirst")
                 m.top.lastFocus = m.seerrBlock
                 setLastFocus(m.seerrBlock)
-                scrollContentTo(-500)
+                scrollContentTo(scrollAmount)
             end if
             return
         end if
@@ -980,7 +981,7 @@ sub onTabBarEscape()
             m.activeGrid.setFocus(true)
             m.top.lastFocus = m.activeGrid
             setLastFocus(m.activeGrid)
-            scrollContentTo(-500)
+            scrollContentTo(scrollAmount)
         end if
     end if
 end sub

--- a/components/details/ModernItemDetails.bs
+++ b/components/details/ModernItemDetails.bs
@@ -371,7 +371,7 @@ end sub
 ' the page down with it
 sub onSeerrFocusMoved()
     if not m.seerrBlock.isInFocusChain() then return
-    scrollContentTo(-(500 + m.seerrBlock.focusedOffset))
+    scrollContentTo(contentScrollOffset() - m.seerrBlock.focusedOffset)
 end sub
 
 ' A Seerr title arrives as a tmdb id, and the screen asks Seerr for the rest itself
@@ -964,10 +964,10 @@ end sub
 
 sub onTabBarEscape()
     dir = m.tabBar.escape
-    scrollAmount = m.overview.visible ? -500 : 0
     if dir = "up"
         focusButtonsFromTabs()
     else if dir = "down"
+        scrollAmount = contentScrollOffset()
         if isValid(m.seerrBlock) and isValid(m.activeGrid) and m.activeGrid.isSameNode(m.seerrBlock)
             if m.seerrBlock.callFunc("focusFirst")
                 m.top.lastFocus = m.seerrBlock
@@ -1024,7 +1024,7 @@ sub OnScreenShown(_isReturning = false as boolean)
         setLastFocus(m.top.lastFocus)
 
         if isValid(m.extrasGrid) and m.top.lastFocus.isSameNode(m.extrasGrid)
-            scrollContentTo(-500)
+            scrollContentTo(contentScrollOffset())
         else
             scrollContentTo(0)
         end if
@@ -2814,6 +2814,13 @@ end function
 ' Smooth page scrolling
 ' ============================================
 
+' How far the page moves so the tab content clears the header. The description is
+' most of that height, so a title without one already sits high enough to leave alone.
+function contentScrollOffset() as integer
+    if not isValid(m.overview) or not m.overview.visible then return 0
+    return -500
+end function
+
 sub scrollContentTo(targetY as integer)
     if m.scrollAnim = invalid or m.scrollInterp = invalid or m.scrollableContent = invalid then return
     m.scrollAnim.control = "stop"
@@ -2826,8 +2833,10 @@ sub onExtrasRowChanged()
     ' Only scroll the page when first entering the extras area.
     ' The RowList's built-in floatingFocus handles row-level scrolling.
     if m.extrasGrid = invalid or not m.extrasGrid.isInFocusChain() then return
-    if m.currentScrollY <> -500
-        scrollContentTo(-500)
+
+    target = contentScrollOffset()
+    if m.currentScrollY <> target
+        scrollContentTo(target)
     end if
 end sub
 


### PR DESCRIPTION
…tions

# Pull Request

## Summary
On modern details page when you navigate down below the tab bar, it scrolls the screen up to focus on the tab's content
Some shows, when on the season page, if the season lacked a description, the amount the page scrolls made the focused episode appear offscreen. The description/overview is what takes up most of the space being scrolled, so if there is no overview, the content is already close enough to the top of the screen. 

This pr blocks the screen scroll on any page lacking a description, to avoid this. 

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #
- Related to #

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

- instead of hardcoding a -500 shift, choose shift amount based on overview visibility
- 
- 

## Testing
Describe how this change was tested.

- [X] Tested on physical Roku device
- [ ] Tested via sideload
- [ ] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. Go to a season detail page with no description. Go down to the episode list, screen does not scroll
2. Go to literally any other detail page (series/movie/season/any) that has a description. Go down below the tab bar, screen scrolls same as before
3.

## Screenshots (if applicable)
Include screenshots or recordings for UI changes.

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
