### PR TITLE
dont preserve sidebar on screens that should hide it

### DIFF
--- a/components/data/SceneManager.bs
+++ b/components/data/SceneManager.bs
@@ -52,12 +52,10 @@ sub setOverhangVisibility(visible as boolean)
     m.overhang.isVisible = visible
 end sub
 
-' The rail down the left is a fixture of every screen, so a screen asking for a
-' clear top only hides the bar that would sit over its content
 sub setContentNavVisibility(visible as boolean)
     if not isValid(m.overhang) then return
 
-    setOverhangVisibility(visible or m.overhang.isSubType("Sidebar"))
+    setOverhangVisibility(visible)
 end sub
 
 '


### PR DESCRIPTION
# Pull Request

## Summary
Sidebar was showing on the library screens. Reverted that so it hides just like on other clients. 

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #
- Related to #

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [X] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

- remove the "or sidebar" part of the visibility determination so sidebar isn't forced to stay on all screens
- 
- 

## Testing
Describe how this change was tested.

- [X] Tested on physical Roku device
- [ ] Tested via sideload
- [ ] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1.
2.
3.

## Screenshots (if applicable)
Before:
<img width="1280" height="720" alt="image" src="https://github.com/user-attachments/assets/93aa21f0-dc7e-4b15-bc0d-e5220944183c" />

After: 
<img width="1280" height="720" alt="image" src="https://github.com/user-attachments/assets/95492470-b9cb-49e7-af7c-861e51ac1697" />


## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
