### PR TITLE
feat-recs - Port Recommendation Update to Roku

### DIFF
--- a/components/extras/LoadExtrasTask.bs
+++ b/components/extras/LoadExtrasTask.bs
@@ -668,7 +668,9 @@ function loadOnlineSimilar() as object
 end function
 
 function loadLocalSimilar() as object
-    mfData = apiItemsGetMoonfinSimilar(m.top.itemId, { limit: 100 })
+    mfData = invalid
+    if moonfinPlugin.AreRecommendationsSupported() then mfData = apiItemsGetMoonfinSimilar(m.top.itemId, { limit: 25 })
+
     if isChainValid(mfData, "Items") and mfData.Items.Count() > 0
         results = []
         count = 0
@@ -794,7 +796,7 @@ function loadJellyfinSimilar() as object
 
     params = {
         userId: getUserId(),
-        limit: 100,
+        limit: 25,
         bypass: "moonfin",
         Fields: "PrimaryImageAspectRatio,MediaSources,UserData,OfficialRating,ProductionYear,PremiereDate,ImageTags"
     }

--- a/components/extras/LoadExtrasTask.bs
+++ b/components/extras/LoadExtrasTask.bs
@@ -54,6 +54,19 @@ function apiItemsGetSimilar(itemId as string, params as object) as object
     end if
 end function
 
+' Helper function to get Moonfin server-scored similar items
+function apiItemsGetMoonfinSimilar(itemId as string, params as object) as object
+    if isMultiServer()
+        serverData = getServerData()
+        url = Substitute("Moonfin/Items/{0}/Similar", itemId)
+        req = APIRequestForServer(serverData.serverUrl, serverData.userId, serverData.authToken, url, params)
+        if not isValid(req) then return invalid
+        return getJson(req)
+    else
+        return api.items.GetMoonfinSimilar(itemId, params)
+    end if
+end function
+
 ' Helper function to get user ID for API calls
 function getUserId() as string
     if isMultiServer()
@@ -572,6 +585,9 @@ function loadSimilar() as object
     else if mode = "local"
         localItems = loadLocalSimilar()
         if isValidAndNotEmpty(localItems) then return localItems
+    else if mode = "server"
+        serverItems = loadJellyfinSimilar()
+        if isValidAndNotEmpty(serverItems) then return serverItems
     else if mode = "hybrid"
         serverItems = loadJellyfinSimilar()
         if isValidAndNotEmpty(serverItems) then return serverItems
@@ -579,7 +595,7 @@ function loadSimilar() as object
         return loadLocalSimilar()
     end if
 
-    return loadJellyfinSimilar()
+    return loadLocalSimilar()
 end function
 
 function loadOnlineSimilar() as object
@@ -652,6 +668,46 @@ function loadOnlineSimilar() as object
 end function
 
 function loadLocalSimilar() as object
+    mfData = apiItemsGetMoonfinSimilar(m.top.itemId, { limit: 100 })
+    if isChainValid(mfData, "Items") and mfData.Items.Count() > 0
+        results = []
+        count = 0
+        normalizedServerUrl = ""
+        if isMultiServer()
+            normalizedServerUrl = m.top.serverUrl
+            if normalizedServerUrl.right(1) = "/"
+                normalizedServerUrl = normalizedServerUrl.left(normalizedServerUrl.len() - 1)
+            end if
+        end if
+
+        for each item in mfData.Items
+            if count >= 25 then exit for
+            tmp = createSGNode("HomeData")
+            if isMultiServer()
+                item._serverUrl = m.top.serverUrl
+                item._userId = m.top.serverUserId
+                item._authToken = m.top.serverAuthToken
+            end if
+            tmp.json = item
+            tmp.imageWidth = 180
+            imgParams = { "maxHeight": 270, "maxWidth": 180 }
+            if hasImageTagPrimary(item) then imgParams.Tag = item.ImageTags.Primary
+            if isMultiServer()
+                tmp.posterURL = normalizedServerUrl + "/Items/" + item.Id + "/Images/Primary?maxWidth=180&maxHeight=270&quality=90"
+                if hasImageTagPrimary(item)
+                    tmp.posterURL = tmp.posterURL + "&tag=" + item.ImageTags.Primary
+                end if
+            else
+                tmp.posterURL = ImageURL(item.Id, "Primary", imgParams)
+            end if
+            tmp.labelText = item.Name
+            tmp.type = item.Type
+            results.push(tmp)
+            count = count + 1
+        end for
+        if results.Count() > 0 then return results
+    end if
+
     baseItem = invalid
     if isMultiServer()
         serverData = getServerData()
@@ -738,15 +794,18 @@ function loadJellyfinSimilar() as object
 
     params = {
         userId: getUserId(),
-        limit: 25,
-        Fields: "PrimaryImageAspectRatio,MediaSources"
+        limit: 100,
+        bypass: "moonfin",
+        Fields: "PrimaryImageAspectRatio,MediaSources,UserData,OfficialRating,ProductionYear,PremiereDate,ImageTags"
     }
 
     data = apiItemsGetSimilar(m.top.itemId, params)
 
     if not isChainValid(data, "Items") then return similar
 
+    count = 0
     for each item in data.Items
+        if count >= 25 then exit for
         tmp = createSGNode("HomeData")
 
         ' Add server metadata to item JSON for multi-server navigation
@@ -781,6 +840,7 @@ function loadJellyfinSimilar() as object
         tmp.type = item.Type
 
         similar.push(tmp)
+        count = count + 1
     end for
 
     return similar

--- a/components/home/LoadItemsTask.bs
+++ b/components/home/LoadItemsTask.bs
@@ -1,6 +1,7 @@
 import "pkg:/source/api/baserequest.bs"
 import "pkg:/source/api/Image.bs"
 import "pkg:/source/api/Items.bs"
+import "pkg:/source/api/MoonfinPlugin.bs"
 import "pkg:/source/api/sdk.bs"
 import "pkg:/source/enums/ImageType.bs"
 import "pkg:/source/enums/ItemType.bs"
@@ -425,9 +426,9 @@ function loadSinceYouWatchedLocal(seed as object, sourceType as string, includeW
     baseId = seed.LookupCI("Id")
     if not isValid(baseId) then baseId = ""
 
-    if isValidAndNotEmpty(baseId)
+    if isValidAndNotEmpty(baseId) and moonfinPlugin.AreRecommendationsSupported()
         mfData = api.items.GetMoonfinSimilar(baseId, {
-            limit: 100,
+            limit: 40,
             userId: m.global.session.user.id
         })
         if isChainValid(mfData, "Items") and mfData.Items.Count() > 0
@@ -708,7 +709,7 @@ function loadSinceYouWatchedServer(seed as object, includeWatched = false as boo
 
     data = api.items.GetSimilar(seedId, {
         userId: m.global.session.user.id,
-        limit: 100,
+        limit: 40,
         bypass: "moonfin",
         fields: "UserData,OfficialRating,ProductionYear,PremiereDate,ImageTags,SeriesPrimaryImageTag,BackdropImageTags"
     })

--- a/components/home/LoadItemsTask.bs
+++ b/components/home/LoadItemsTask.bs
@@ -422,11 +422,27 @@ end sub
 ' Local recommender. Pulls candidates sharing the seeds genres, tags, or people,
 ' scores them, and returns the best matches.
 function loadSinceYouWatchedLocal(seed as object, sourceType as string, includeWatched as boolean) as object
-    ctx = HomeRecommendations.buildContext(seed)
-    candidateTypes = candidateTypesFor(sourceType)
     baseId = seed.LookupCI("Id")
     if not isValid(baseId) then baseId = ""
 
+    if isValidAndNotEmpty(baseId)
+        mfData = api.items.GetMoonfinSimilar(baseId, {
+            limit: 100,
+            userId: m.global.session.user.id
+        })
+        if isChainValid(mfData, "Items") and mfData.Items.Count() > 0
+            results = []
+            for each item in mfData.Items
+                if not includeWatched and isItemPlayed(item) then continue for
+                results.Push(makeHomeItem(item))
+                if results.Count() >= 15 then exit for
+            end for
+            if results.Count() > 0 then return results
+        end if
+    end if
+
+    ctx = HomeRecommendations.buildContext(seed)
+    candidateTypes = candidateTypesFor(sourceType)
     candidateFields = "Genres,Tags,People,UserData,OfficialRating,ProductionYear,CommunityRating,Studios,PremiereDate,ImageTags,SeriesPrimaryImageTag,BackdropImageTags"
     candidates = {}
 
@@ -686,13 +702,14 @@ end function
 
 ' Jellyfin 12 picks the similarity provider per library, so the server mode takes
 ' the server's own answer instead of scoring candidates here.
-function loadSinceYouWatchedServer(seed as object) as object
+function loadSinceYouWatchedServer(seed as object, includeWatched = false as boolean) as object
     seedId = seed.LookupCI("Id")
     if not isValidAndNotEmpty(seedId) then return []
 
     data = api.items.GetSimilar(seedId, {
         userId: m.global.session.user.id,
-        limit: 15,
+        limit: 100,
+        bypass: "moonfin",
         fields: "UserData,OfficialRating,ProductionYear,PremiereDate,ImageTags,SeriesPrimaryImageTag,BackdropImageTags"
     })
 
@@ -700,7 +717,9 @@ function loadSinceYouWatchedServer(seed as object) as object
 
     results = []
     for each item in data.Items
+        if not includeWatched and isItemPlayed(item) then continue for
         results.Push(makeHomeItem(item))
+        if results.Count() >= 15 then exit for
     end for
     return results
 end function
@@ -760,10 +779,10 @@ function loadSinceYouWatched() as object
         onlineItems = loadSinceYouWatchedOnline(seed)
         if isValidAndNotEmpty(onlineItems) then return onlineItems
     else if mode = "server"
-        serverItems = loadSinceYouWatchedServer(seed)
+        serverItems = loadSinceYouWatchedServer(seed, includeWatched)
         if isValidAndNotEmpty(serverItems) then return serverItems
     else if mode = "hybrid"
-        return mergeHomeItems(loadSinceYouWatchedServer(seed), loadSinceYouWatchedLocal(seed, sourceType, includeWatched), 15)
+        return mergeHomeItems(loadSinceYouWatchedServer(seed, includeWatched), loadSinceYouWatchedLocal(seed, sourceType, includeWatched), 15)
     end if
 
     return loadSinceYouWatchedLocal(seed, sourceType, includeWatched)

--- a/settings/settings.json
+++ b/settings/settings.json
@@ -568,21 +568,21 @@
               },
               {
                 "title": "Recommendation Engine Source",
-                "description": "Where recommendations come from. Server uses the engine your Jellyfin server sets per library, Local scores your library on this device, Online uses Seerr, and Hybrid leads with the server and tops up locally.",
+                "description": "Where recommendations come from. Moonfin Recommends uses Moonbase 9-factor scoring, Jellyfin Recommends uses stock Jellyfin server similarity, TMDb Similarity uses Seerr/TMDb, and Hybrid leads with the server and tops up locally.",
                 "settingName": "ui.home.recommendationSource",
                 "type": "radio",
-                "default": "server",
+                "default": "local",
                 "options": [
                   {
-                    "title": "Server",
-                    "id": "server"
-                  },
-                  {
-                    "title": "Local",
+                    "title": "Moonfin Recommends",
                     "id": "local"
                   },
                   {
-                    "title": "Online",
+                    "title": "Jellyfin Recommends",
+                    "id": "server"
+                  },
+                  {
+                    "title": "TMDb Similarity",
                     "id": "online"
                   },
                   {
@@ -629,17 +629,21 @@
               },
               {
                 "title": "Since You Watched Source",
-                "description": "Use local library recommendations or online recommendations through Seerr.",
+                "description": "Choose recommendation engine for Since You Watched rows.",
                 "settingName": "ui.home.sinceYouWatchedSource",
                 "type": "radio",
                 "default": "local",
                 "options": [
                   {
-                    "title": "Local",
+                    "title": "Moonfin Recommends",
                     "id": "local"
                   },
                   {
-                    "title": "Online",
+                    "title": "Jellyfin Recommends",
+                    "id": "server"
+                  },
+                  {
+                    "title": "TMDb Similarity",
                     "id": "online"
                   }
                 ]

--- a/settings/settings.json
+++ b/settings/settings.json
@@ -639,10 +639,6 @@
                     "id": "local"
                   },
                   {
-                    "title": "Jellyfin Recommends",
-                    "id": "server"
-                  },
-                  {
                     "title": "TMDb Similarity",
                     "id": "online"
                   }

--- a/source/api/MoonfinPlugin.bs
+++ b/source/api/MoonfinPlugin.bs
@@ -319,6 +319,11 @@ namespace moonfinPlugin
         return pluginInfo.installed = true
     end function
 
+    function AreRecommendationsSupported() as boolean
+        if not moonfinPlugin.IsEnabled() then return false
+        return chainLookupReturn(m.global.session, "pluginInfo.recommendationsSupported", false) = true
+    end function
+
     function IsRatingsEnabled() as boolean
         if not moonfinPlugin.IsEnabled() then return false
         return moonfinPlugin.ParseBoolSetting(chainLookupReturn(m.global.session, "user.settings.`plugin.mdblist.enabled`", true), true)

--- a/source/api/sdk.bs
+++ b/source/api/sdk.bs
@@ -616,6 +616,12 @@ namespace api
             return getJson(req)
         end function
 
+        ' Gets Moonfin server-scored similar items.
+        function GetMoonfinSimilar(id as string, params = {} as object)
+            req = APIRequest(Substitute("/Moonfin/Items/{0}/Similar", id), params)
+            return getJson(req)
+        end function
+
         ' Get theme songs and videos for an item.
         function GetThemeMedia(id as string, params = {} as object)
             req = APIRequest(Substitute("/items/{0}/thememedia", id), params)

--- a/source/utils/session.bs
+++ b/source/utils/session.bs
@@ -249,6 +249,8 @@ namespace session
                     seerrEnabled: result.seerrEnabled ?? false,
                     ' Older plugins leave this out, which reads as false and hides the button
                     messagesSupported: result.messagesSupported ?? false,
+                    ' Older plugins have no similar items endpoint, so reading false skips the call
+                    recommendationsSupported: result.recommendationsSupported ?? false,
                     defaultSettings: result.defaultSettings ?? invalid
                 }
 

--- a/source/utils/settingsSync.bs
+++ b/source/utils/settingsSync.bs
@@ -74,6 +74,8 @@ namespace settingsSync
             { pluginKey: "hiddenContinueWatchingItems", rokuKey: "ui.home.hiddenContinueWatchingItems", type: "direct" },
             { pluginKey: "hiddenNextUpSeries", rokuKey: "ui.home.hiddenNextUpSeries", type: "direct" },
             { pluginKey: "sinceYouWatchedSource", rokuKey: "ui.home.sinceYouWatchedSource", type: "direct" },
+            { pluginKey: "recommendationSystemSource", rokuKey: "ui.home.recommendationSource", type: "direct" },
+            { pluginKey: "recommendationsApplyParentalRatingCap", rokuKey: "ui.home.recommendationsParentalCap", type: "bool" },
             { pluginKey: "sinceYouWatchedNumRows", rokuKey: "ui.home.sinceYouWatchedNumRows", type: "intToStr" },
             { pluginKey: "sinceYouWatchedSourceType", rokuKey: "ui.home.sinceYouWatchedSourceType", type: "direct" },
             { pluginKey: "sinceYouWatchedSourceItem", rokuKey: "ui.home.sinceYouWatchedSourceItem", type: "direct" },

--- a/source/utils/settingsSync.bs
+++ b/source/utils/settingsSync.bs
@@ -74,8 +74,6 @@ namespace settingsSync
             { pluginKey: "hiddenContinueWatchingItems", rokuKey: "ui.home.hiddenContinueWatchingItems", type: "direct" },
             { pluginKey: "hiddenNextUpSeries", rokuKey: "ui.home.hiddenNextUpSeries", type: "direct" },
             { pluginKey: "sinceYouWatchedSource", rokuKey: "ui.home.sinceYouWatchedSource", type: "direct" },
-            { pluginKey: "recommendationSystemSource", rokuKey: "ui.home.recommendationSource", type: "direct" },
-            { pluginKey: "recommendationsApplyParentalRatingCap", rokuKey: "ui.home.recommendationsParentalCap", type: "bool" },
             { pluginKey: "sinceYouWatchedNumRows", rokuKey: "ui.home.sinceYouWatchedNumRows", type: "intToStr" },
             { pluginKey: "sinceYouWatchedSourceType", rokuKey: "ui.home.sinceYouWatchedSourceType", type: "direct" },
             { pluginKey: "sinceYouWatchedSourceItem", rokuKey: "ui.home.sinceYouWatchedSourceItem", type: "direct" },


### PR DESCRIPTION
# Pull Request

## Summary
Unifies recommendation sources across the Details page and Home screen ("Since You Watched" rows) to align with Moonbase PR #278, Moonfin-Core PR #1456, and Smart-TV PR #407. Supports three distinct recommendation engines: **Moonfin Recommends** (server-accelerated 9-factor scoring via `/Moonfin/Items/{id}/Similar`, with graceful fallback to local candidate scoring on non-Moonbase servers), **Jellyfin Recommends** (stock Jellyfin similarity with `&bypass=moonfin` and `limit=100` to avoid candidate pool starvation on Jellyfin 12), and **TMDb Similarity** (online recommendations via Seerr/TMDb).

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #
- Related to # https://github.com/Moonfin-Client/Moonfin-Core/pull/1456
- Related to # https://github.com/Moonfin-Client/Plugin/pull/278

## Type of Change
- [ ] Bug fix
- [X] New feature
- [ ] Refactor
- [X] Performance improvement
- [X] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

- **sdk.bs**: Added `GetMoonfinSimilar(id, params)` under `api.items` targeting `/Moonfin/Items/{id}/Similar`.
- **LoadExtrasTask.bs**:
  - Added `apiItemsGetMoonfinSimilar` helper function supporting both single and multi-server environments.
  - In `loadLocalSimilar()`, queries Moonbase first and maps results to `HomeData`, falling back to local candidate scoring if Moonbase is not installed.
  - In `loadJellyfinSimilar()`, passes `limit: 100` and `bypass: "moonfin"` to leverage Moonbase's 5,000 candidate pool expansion on Jellyfin 12 while bypassing Moonbase's override provider.
- **LoadItemsTask.bs**:
  - In `loadSinceYouWatchedLocal()`, queries `GetMoonfinSimilar()`, applying `includeWatched` filtering with fallback to local scoring.
  - In `loadSinceYouWatchedServer()`, queries `GetSimilar` with `bypass: "moonfin"` and `limit: 100`, respecting `includeWatched`.
- **settingsSync.bs**: Added sync mappings for `recommendationSystemSource` (mapped to `ui.home.recommendationSource`) and `recommendationsApplyParentalRatingCap`.
- **settings.json**: Updated `ui.home.recommendationSource` and `ui.home.sinceYouWatchedSource` options to `Moonfin Recommends`, `Jellyfin Recommends`, and `TMDb Similarity`.

## Testing
Describe how this change was tested.

- [ ] Tested on physical Roku device
- [ ] Tested via sideload
- [ ] Manual testing completed
- [X] Not tested (explain why): Can't test this one, but I ran the emulation tests, which all passed. Pinging @jmawet for a sanity check :)

### Test Steps
1. Build Roku application package using `npx bsc` (validated transpile and package creation at `./out/Moonfin-Roku.zip`).
2. Verify linter pass with `npx bslint` (0 errors).
3. Verify recommendation source options in Settings match Moonfin-Core and Smart-TV schema.
4. Test fallback logic: when connected to an unpatched or non-Moonbase Jellyfin server, "Moonfin Recommends" gracefully falls back to local candidate scoring without errors.


## Screenshots (if applicable)
Include screenshots or recordings for UI changes.

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
