### PR TITLE
feat-homescreen - Add toggle and mirrored sizing for Modern cards on My Media row

### DIFF
--- a/components/home/Home.bs
+++ b/components/home/Home.bs
@@ -1163,9 +1163,16 @@ sub onItemFocusChanged()
     focusedItem = focusedRow.getChild(focused[1])
     if not isValid(focusedItem) then return
 
-    if m.modernHomeRows
+    isRowModern = m.modernHomeRows and (focusedRow.id <> "smalllibrarytiles" or isModernMyMediaCards())
+    if isRowModern
+        if isValid(m.homeRows) and m.homeRows.focusBitmapUri <> "" then m.homeRows.focusBitmapUri = ""
         applyModernReflow(focused[0], focused[1])
         showModernFocusCard(focusedItem)
+    else
+        if m.modernHomeRows and isValid(m.homeRows) and m.homeRows.focusBitmapUri <> "pkg:/images/posterFocus.9.png"
+            m.homeRows.focusBitmapUri = "pkg:/images/posterFocus.9.png"
+        end if
+        hideModernFocusCard()
     end if
 
     if isValid(m.itemTitle)

--- a/components/home/Home.bs
+++ b/components/home/Home.bs
@@ -44,7 +44,9 @@ sub init()
 
     ' The overlay card is the focus indicator in modern rows, so the row list
     ' does not draw its own portrait focus border underneath it.
+    ' A row still on landscape tiles wants it back, so the markup's image is kept.
     if m.modernHomeRows and isValid(m.homeRows)
+        m.classicFocusBitmapUri = m.homeRows.focusBitmapUri
         m.homeRows.focusBitmapUri = ""
     end if
 
@@ -1163,16 +1165,16 @@ sub onItemFocusChanged()
     focusedItem = focusedRow.getChild(focused[1])
     if not isValid(focusedItem) then return
 
-    isRowModern = m.modernHomeRows and (focusedRow.id <> "smalllibrarytiles" or isModernMyMediaCards())
-    if isRowModern
-        if isValid(m.homeRows) and m.homeRows.focusBitmapUri <> "" then m.homeRows.focusBitmapUri = ""
-        applyModernReflow(focused[0], focused[1])
-        showModernFocusCard(focusedItem)
-    else
-        if m.modernHomeRows and isValid(m.homeRows) and m.homeRows.focusBitmapUri <> "pkg:/images/posterFocus.9.png"
-            m.homeRows.focusBitmapUri = "pkg:/images/posterFocus.9.png"
+    if m.modernHomeRows
+        ' focusBitmapUri is set on the whole row list, so it has to follow the focus
+        if useModernCardsForRow(focusedRow.id)
+            if m.homeRows.focusBitmapUri <> "" then m.homeRows.focusBitmapUri = ""
+            applyModernReflow(focused[0], focused[1])
+            showModernFocusCard(focusedItem)
+        else
+            if m.homeRows.focusBitmapUri <> m.classicFocusBitmapUri then m.homeRows.focusBitmapUri = m.classicFocusBitmapUri
+            hideModernFocusCard()
         end if
-        hideModernFocusCard()
     end if
 
     if isValid(m.itemTitle)

--- a/components/home/HomeItem.bs
+++ b/components/home/HomeItem.bs
@@ -141,7 +141,16 @@ sub itemContentChanged()
     if not isValid(itemData) then return
     localGlobal = m.global
 
-    if m.modernEnabled then setupModernShiftObserver(itemData)
+    itemDataType = isValid(itemData.type) ? LCase(itemData.type) : ""
+    isCollectionItem = inArray([ItemType.COLLECTIONFOLDER, ItemType.USERVIEW, ItemType.CHANNEL, ItemType.FOLDER], itemDataType)
+
+    if m.modernEnabled and not (isCollectionItem and not isModernMyMediaCards())
+        setupModernShiftObserver(itemData)
+    else if isValid(m.modernObservedNode)
+        m.modernObservedNode.unobserveFieldScoped("modernShift")
+        m.modernObservedNode = invalid
+        if isValid(m.scaleGroup) then m.scaleGroup.translation = [0, 0]
+    end if
 
     if isValid(m.playedIndicator)
         m.playedIndicator.data = {

--- a/components/home/HomeItem.bs
+++ b/components/home/HomeItem.bs
@@ -141,10 +141,12 @@ sub itemContentChanged()
     if not isValid(itemData) then return
     localGlobal = m.global
 
-    itemDataType = isValid(itemData.type) ? LCase(itemData.type) : ""
-    isCollectionItem = inArray([ItemType.COLLECTIONFOLDER, ItemType.USERVIEW, ItemType.CHANNEL, ItemType.FOLDER], itemDataType)
+    ' A card's content hangs off the row it was appended to, so the parent has the row id
+    parentRow = itemData.getParent()
+    rowId = ""
+    if isValid(parentRow) then rowId = parentRow.id
 
-    if m.modernEnabled and not (isCollectionItem and not isModernMyMediaCards())
+    if m.modernEnabled and useModernCardsForRow(rowId)
         setupModernShiftObserver(itemData)
     else if isValid(m.modernObservedNode)
         m.modernObservedNode.unobserveFieldScoped("modernShift")

--- a/components/home/HomeRows.bs
+++ b/components/home/HomeRows.bs
@@ -592,7 +592,7 @@ sub setRowItemSize()
 
     for i = 0 to homeSections.count() - 1
         cursor = isValid(homeSections[i].cursorSize) ? homeSections[i].cursorSize : homeRowItemSizes.MOVIE_POSTER
-        if modern and (homeSections[i].id <> "smalllibrarytiles" or isModernMyMediaCards()) then cursor = forceModernPortraitRow(homeSections[i], cursor)
+        if modern and useModernCardsForRow(homeSections[i].id) then cursor = forceModernPortraitRow(homeSections[i], cursor)
         newSizeArray[i] = cursor
     end for
     m.top.rowItemSize = newSizeArray

--- a/components/home/HomeRows.bs
+++ b/components/home/HomeRows.bs
@@ -592,7 +592,7 @@ sub setRowItemSize()
 
     for i = 0 to homeSections.count() - 1
         cursor = isValid(homeSections[i].cursorSize) ? homeSections[i].cursorSize : homeRowItemSizes.MOVIE_POSTER
-        if modern then cursor = forceModernPortraitRow(homeSections[i], cursor)
+        if modern and (homeSections[i].id <> "smalllibrarytiles" or isModernMyMediaCards()) then cursor = forceModernPortraitRow(homeSections[i], cursor)
         newSizeArray[i] = cursor
     end for
     m.top.rowItemSize = newSizeArray

--- a/settings/settings.json
+++ b/settings/settings.json
@@ -244,7 +244,7 @@
           },
           {
             "title": "Modern cards on My Media row",
-            "description": "Display customizable posters that expand on focus. Disable to always show landscape thumbnail.",
+            "description": "Display customizable posters that expand on focus. Disable to always show landscape thumbnail. Moonfin will need to be closed and reopened for change to take effect.",
             "settingName": "ui.home.modernCardsOnMyMediaRow",
             "icon": "picture.png",
             "type": "bool",

--- a/settings/settings.json
+++ b/settings/settings.json
@@ -243,6 +243,14 @@
             ]
           },
           {
+            "title": "Modern cards on My Media row",
+            "description": "Display customizable posters that expand on focus. Disable to always show landscape thumbnail.",
+            "settingName": "ui.home.modernCardsOnMyMediaRow",
+            "icon": "picture.png",
+            "type": "bool",
+            "default": "true"
+          },
+          {
             "title": "Classic Layout Home Rows Padding",
             "description": "Adjust vertical padding between home screen rows in classic layout",
             "settingName": "ui.home.classicRowsPadding",

--- a/source/utils/misc.bs
+++ b/source/utils/misc.bs
@@ -447,10 +447,10 @@ function isModernHomeRows() as boolean
     return isStringEqual(chainLookupReturn(m.global.session, "user.settings.`ui.home.rowsStyle`", "v2"), "v2")
 end function
 
-' Returns true when modern cards should be used on the My Media row.
-function isModernMyMediaCards() as boolean
-    val = toBoolean(chainLookupReturn(m.global.session, "user.settings.`ui.home.modernCardsOnMyMediaRow`", true))
-    return val = invalid or val = true
+' Only the My Media row answers to the modern cards setting.
+function useModernCardsForRow(rowId as dynamic) as boolean
+    if not isStringEqual(rowId, "smalllibrarytiles") then return true
+    return get_user_setting_bool("ui.home.modernCardsOnMyMediaRow", true)
 end function
 
 ' chainLookup: Returns value from property chain using case insensitive lookups

--- a/source/utils/misc.bs
+++ b/source/utils/misc.bs
@@ -447,6 +447,12 @@ function isModernHomeRows() as boolean
     return isStringEqual(chainLookupReturn(m.global.session, "user.settings.`ui.home.rowsStyle`", "v2"), "v2")
 end function
 
+' Returns true when modern cards should be used on the My Media row.
+function isModernMyMediaCards() as boolean
+    val = toBoolean(chainLookupReturn(m.global.session, "user.settings.`ui.home.modernCardsOnMyMediaRow`", true))
+    return val = invalid or val = true
+end function
+
 ' chainLookup: Returns value from property chain using case insensitive lookups
 '
 ' @param {dynamic} root - high-level object to test property chain against

--- a/source/utils/settingsSync.bs
+++ b/source/utils/settingsSync.bs
@@ -47,6 +47,7 @@ namespace settingsSync
             { pluginKey: "detailUseSeriesThumbnails", rokuKey: "ui.itemdetail.useSeriesThumbnails", type: "bool" },
             { pluginKey: "hideHomeMediaDescription", rokuKey: "ui.home.hideMediaDescription", type: "bool" },
             { pluginKey: "homeRowsStyle", rokuKey: "ui.home.rowsStyle", type: "direct" },
+            { pluginKey: "modernCardsOnMyMediaRow", rokuKey: "ui.home.modernCardsOnMyMediaRow", type: "bool" },
             { pluginKey: "homeRowOrder", rokuKey: "ui.home.rowOrder", type: "jsonArray", skipRegistry: true },
             { pluginKey: "detailsScreenBlur", rokuKey: "ui.backdrop.detailBlurAmount", type: "direct" },
             { pluginKey: "browsingBlur", rokuKey: "ui.backdrop.homeBlurAmount", type: "direct" },


### PR DESCRIPTION
# Pull Request

## Summary
Adds the `ui.home.modernCardsOnMyMediaRow` setting to Moonfin-Roku and preserves wide landscape card dimensions (`WIDE_POSTER` [464, 270]) on My Media row when expansion is disabled in Modern row layout.

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #
- Related to # https://github.com/Moonfin-Client/Plugin/pull/279

## Type of Change
- [ ] Bug fix
- [X] New feature
- [ ] Refactor
- [ ] Performance improvement
- [X] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

- Added `ui.home.modernCardsOnMyMediaRow` setting entry to **settings.json** with title and description.
- Added `modernCardsOnMyMediaRow` key to **settingsSync.bs** for server synchronisation.
- Added `isModernMyMediaCards()` helper in **misc.bs**.
- In **HomeRows.bs**, retained `homeRowItemSizes.WIDE_POSTER` [464, 270] on My Media row when modern cards expansion is disabled, matching the dimensions of the modern focus card overlay.
- In **Home.bs** and **HomeItem.bs**, bypassed modern card shift and focus card overlay on My Media row when expansion is disabled.


## Testing
Describe how this change was tested.

- [ ] Tested on physical Roku device
- [ ] Tested via sideload
- [ ] Manual testing completed
- [X] Not tested (explain why): No Roku, No Cry. Pinging @jmawet.

### Test Steps
1. In Settings, verify "Modern cards on My Media row" setting exists under Home Screen settings.
2. With Modern Home Rows enabled, disable "Modern cards on My Media row".
3. Verify My Media row displays wide landscape posters sized to match the modern focus thumbnail overlay.

## Screenshots (if applicable)
Include screenshots or recordings for UI changes.

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
