### PR TITLE
Adjust height of Cast and Crew on Modern Detail screen

### DIFF
--- a/components/details/DetailCastCard.xml
+++ b/components/details/DetailCastCard.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <component name="DetailCastCard" extends="Group">
     <children>
-        <Group id="photoGroup" translation="[10, 0]" scaleRotateCenter="[70, 70]">
+        <Group id="photoGroup" translation="[10, 20]" scaleRotateCenter="[70, 70]">
             <!-- A filled circle behind the photo, showing as a ring around it -->
             <Poster id="focusRing" uri="pkg:/images/icons/circle.png" width="148" height="148"
                 translation="[-4, -4]" blendColor="#FFFFFF99" visible="false" />


### PR DESCRIPTION
Adjust Cast and Crew figure's translation

# Pull Request

## Summary
Top Cast or Crew was cropped



## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [X] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
Change translation of id photoGroup to a little further down on DetailCastCard.xml

- 
- 
- 

## Testing
Describe how this change was tested.

- [x] Tested on physical Roku device
- [x] Tested via sideload
- [ ] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. go to a modern detail page
2. chose cast or crew
3. go down to the photo

## Screenshots (if applicable)
Before:

<img width="776" height="516" alt="image" src="https://github.com/user-attachments/assets/9bbe0047-4708-4f3a-9ef3-55cdc36f6b98" />

After:

<img width="757" height="567" alt="image" src="https://github.com/user-attachments/assets/1d135ec1-3a7c-42bf-8384-98402b4baffc" />



## Checklist
- [x] Code builds successfully
- [x] Code follows project style and conventions
- [x] No unnecessary commented-out code
- [x] No new warnings introduced
