### PR TITLE
feat-ui - Add Show Seerr Availability Badges setting

### DIFF
--- a/components/data/HomeData.xml
+++ b/components/data/HomeData.xml
@@ -19,5 +19,6 @@
     <field id="isWatched" type="bool" value="false" />
     <field id="selectedAudioStreamIndex" type="integer" value="0" />
     <field id="startingPoint" type="longinteger" value="0" />
+    <field id="seerrStatus" type="integer" value="0" />
   </interface>
 </component>

--- a/components/details/ItemDetails.bs
+++ b/components/details/ItemDetails.bs
@@ -1022,6 +1022,7 @@ end function
 ' Each extras row lands separately, so the block is placed again as the rows stack up
 sub onExtrasRowsLoaded()
     layoutContainer()
+    updateSeerrSeasonMarkers()
 end sub
 
 sub onSeerrBlockChanged()

--- a/components/details/ModernItemDetails.bs
+++ b/components/details/ModernItemDetails.bs
@@ -331,6 +331,7 @@ sub buildTabsFromContent(content as object)
 
     showUpNextCard()
     buildTabBar()
+    updateSeerrSeasonMarkers()
 end sub
 
 ' Everything Seerr adds to a title goes in one tab rather than several

--- a/components/details/detailButtonHost.bs
+++ b/components/details/detailButtonHost.bs
@@ -112,6 +112,7 @@ sub onSeerrButtonsStale()
     clearButtonRow()
     addButtons(m.top.itemContent.json)
     commitButtonRow()
+    updateSeerrSeasonMarkers()
 
     if hadFocus and m.buttonGroups.count() > 0
         if focusIndex >= m.buttonGroups.count() then focusIndex = m.buttonGroups.count() - 1

--- a/components/extras/ExtrasItem.bs
+++ b/components/extras/ExtrasItem.bs
@@ -27,6 +27,8 @@ sub init()
     m.photoCircle = m.top.findNode("photoCircle")
     m.posterImgRect = m.top.findNode("posterImgRect")
     m.playedIndicator = m.top.findNode("playedIndicator")
+    m.seerrDot = m.top.findNode("seerrDot")
+    m.seerrDotBg = m.top.findNode("seerrDotBg")
     m.scaleGroup = m.top.findNode("scaleGroup")
     m.rectFocusBorder = m.top.findNode("rectFocusBorder")
     m.epNumber = m.top.findNode("epNumber")
@@ -85,8 +87,16 @@ sub showContent()
     if not isValid(m.name) then initName()
     if not isValid(m.role) then initRole()
 
+    if isValid(m.observedCont)
+        m.observedCont.unobserveFieldScoped("seerrStatus")
+        m.observedCont = invalid
+    end if
+
     if isValid(m.top.itemContent)
         cont = m.top.itemContent
+        m.observedCont = cont
+        cont.observeFieldScoped("seerrStatus", "onSeerrStatusChanged")
+        updateSeerrDot(cont)
 
         m.name.text = cont.labelText
         m.name.maxWidth = cont.imageWidth
@@ -261,7 +271,52 @@ sub showContent()
     else
         m.role.text = tr("Unknown")
         m.posterImg.uri = "pkg:/images/baseline_person_white_48dp.png"
+        if isValid(m.seerrDot) then m.seerrDot.visible = false
     end if
+end sub
+
+sub onSeerrStatusChanged()
+    if isValid(m.observedCont) then updateSeerrDot(m.observedCont)
+end sub
+
+sub updateSeerrDot(cont as object)
+    if not isValid(m.seerrDot) then return
+
+    if not isSeerrAvailabilityBadgesEnabled() or not isValid(cont)
+        m.seerrDot.visible = false
+        return
+    end if
+
+    isSeason = isStringEqual(chainLookupReturn(cont, "json.Type", ""), "Season") or isStringEqual(chainLookupReturn(cont, "type", ""), "Season")
+    if not isSeason
+        m.seerrDot.visible = false
+        return
+    end if
+
+    status = chainLookupReturn(cont, "seerrStatus", 0)
+    if status <= 1
+        m.seerrDot.visible = false
+        return
+    end if
+
+    ' Status colors matching SeerrStatusChip, Smart-TV and Core
+    ' 5: Available, 4: Partially Available -> Green
+    ' 3: Processing -> Purple/Requested
+    ' 2: Pending -> Yellow/Pending
+    dotColor = "#22C55E"
+    if status = 2
+        dotColor = "#EAB308"
+    else if status = 3
+        dotColor = "#8B8DFA"
+    else if status = 4 or status = 5
+        dotColor = "#22C55E"
+    else
+        m.seerrDot.visible = false
+        return
+    end if
+
+    if isValid(m.seerrDotBg) then m.seerrDotBg.blendColor = dotColor
+    m.seerrDot.visible = true
 end sub
 
 sub focusChanged()

--- a/components/extras/ExtrasItem.bs
+++ b/components/extras/ExtrasItem.bs
@@ -94,8 +94,11 @@ sub showContent()
 
     if isValid(m.top.itemContent)
         cont = m.top.itemContent
-        m.observedCont = cont
-        cont.observeFieldScoped("seerrStatus", "onSeerrStatusChanged")
+        ' Only season nodes carry seerrStatus, and cast cards share this component.
+        if cont.hasField("seerrStatus")
+            m.observedCont = cont
+            cont.observeFieldScoped("seerrStatus", "onSeerrStatusChanged")
+        end if
         updateSeerrDot(cont)
 
         m.name.text = cont.labelText

--- a/components/extras/ExtrasItem.xml
+++ b/components/extras/ExtrasItem.xml
@@ -19,6 +19,20 @@
         loadDisplayMode="scaleToZoom"
         translation="[0, 0]">
         <PlayedCheckmark id="playedIndicator" translation="[130, 10]" />
+        <Group id="seerrDot" translation="[10, 10]" visible="false">
+          <Poster
+            id="seerrDotShadow"
+            width="24"
+            height="24"
+            translation="[-1, -1]"
+            uri="pkg:/images/icons/circle.png"
+            blendColor="#00000080" />
+          <Poster
+            id="seerrDotBg"
+            width="22"
+            height="22"
+            uri="pkg:/images/icons/circle.png" />
+        </Group>
       </Poster>
 
       <!-- Rectangular focus border overlay -->

--- a/settings/settings.json
+++ b/settings/settings.json
@@ -1712,6 +1712,13 @@
             "icon": "nsfw.png"
           },
           {
+            "title": "Show Seerr Availability Badges",
+            "description": "Show season availability badges on media details pages.",
+            "settingName": "seerr.showAvailabilityBadges",
+            "type": "bool",
+            "default": "true"
+          },
+          {
             "title": "Account & Sign In",
             "description": "Sign in to Seerr or manage your logged-in account. Seerr is accessed through the Moonfin server plugin, so there is nothing to configure here beyond signing in.",
             "settingName": "seerr.accountSettings",

--- a/source/utils/misc.bs
+++ b/source/utils/misc.bs
@@ -455,7 +455,7 @@ end function
 
 ' Returns true when Seerr availability badges are enabled (defaults to true).
 function isSeerrAvailabilityBadgesEnabled() as boolean
-    return toBoolean(chainLookupReturn(m.global.session, "user.settings.`seerr.showAvailabilityBadges`", true))
+    return get_user_setting_bool("seerr.showAvailabilityBadges", true)
 end function
 
 ' chainLookup: Returns value from property chain using case insensitive lookups

--- a/source/utils/misc.bs
+++ b/source/utils/misc.bs
@@ -453,6 +453,11 @@ function useModernCardsForRow(rowId as dynamic) as boolean
     return get_user_setting_bool("ui.home.modernCardsOnMyMediaRow", true)
 end function
 
+' Returns true when Seerr availability badges are enabled (defaults to true).
+function isSeerrAvailabilityBadgesEnabled() as boolean
+    return toBoolean(chainLookupReturn(m.global.session, "user.settings.`seerr.showAvailabilityBadges`", true))
+end function
+
 ' chainLookup: Returns value from property chain using case insensitive lookups
 '
 ' @param {dynamic} root - high-level object to test property chain against

--- a/source/utils/seerrDetailHost.bs
+++ b/source/utils/seerrDetailHost.bs
@@ -32,6 +32,7 @@ sub onSeerrDetailsLoaded(event as object)
 
     node = seerrDetailItem.NodeFor(response.data, m.top.seerrTarget.mediaType)
     if isValid(node) then m.top.itemContent = node
+    updateSeerrSeasonMarkers()
 end sub
 
 sub startSeerrRequest(action as string)
@@ -128,4 +129,101 @@ sub onLibrarySeerrDetails(event as object)
 
     m.seerrDetails = response.data
     m.top.seerrButtonsStale = true
+    updateSeerrSeasonMarkers()
+end sub
+
+' Maps season numbers to Seerr availability status (matching Smart-TV and Core)
+function GetSeerrSeasonMarkers(seerrDetails as object) as object
+    markers = {}
+    if not isValid(seerrDetails) or not isChainValid(seerrDetails, "mediaInfo.seasons") then return markers
+
+    for each season in seerrDetails.mediaInfo.seasons
+        if isValid(season.seasonNumber)
+            status = chainLookupReturn(season, "status", 1)
+            status4k = chainLookupReturn(season, "status4k", 1)
+            effectiveStatus = status > 1 ? status : status4k
+            if effectiveStatus > 1
+                markers[season.seasonNumber.toStr()] = effectiveStatus
+            end if
+        end if
+    end for
+
+    if isChainValid(seerrDetails, "mediaInfo.requests")
+        for each req in seerrDetails.mediaInfo.requests
+            reqStatus = chainLookupReturn(req, "status", 1)
+            mappedStatus = reqStatus = 1 ? 2 : 3
+            if isValid(req.seasons)
+                for each reqSeason in req.seasons
+                    if isValid(reqSeason.seasonNumber)
+                        key = reqSeason.seasonNumber.toStr()
+                        if not markers.doesExist(key)
+                            markers[key] = mappedStatus
+                        end if
+                    end if
+                end for
+            end if
+        end for
+    end if
+
+    return markers
+end function
+
+' Updates the seerrStatus field on all season items across extras rows, tabs, and tab grids
+sub updateSeerrSeasonMarkers()
+    if not isValid(m.seerrDetails) then return
+
+    markers = GetSeerrSeasonMarkers(m.seerrDetails)
+    hasMarkers = (markers.count() > 0)
+    isEnabled = isSeerrAvailabilityBadgesEnabled()
+
+    if isValid(m.extrasGrid) and isValid(m.extrasGrid.content)
+        applyMarkersToContent(m.extrasGrid.content, markers, isEnabled, hasMarkers)
+    end if
+
+    if isValid(m.sectionItems) and type(m.sectionItems) = "roArray"
+        for each section in m.sectionItems
+            if isValid(section) and type(section) = "roArray"
+                for each item in section
+                    applyMarkerToSeasonItem(item, markers, isEnabled, hasMarkers)
+                end for
+            end if
+        end for
+    end if
+
+    if isValid(m.tabGrid) and isValid(m.tabGrid.content)
+        for i = 0 to m.tabGrid.content.getChildCount() - 1
+            applyMarkerToSeasonItem(m.tabGrid.content.getChild(i), markers, isEnabled, hasMarkers)
+        end for
+    end if
+end sub
+
+sub applyMarkersToContent(content as object, markers as object, isEnabled as boolean, hasMarkers as boolean)
+    for i = 0 to content.getChildCount() - 1
+        row = content.getChild(i)
+        if isValid(row)
+            for j = 0 to row.getChildCount() - 1
+                applyMarkerToSeasonItem(row.getChild(j), markers, isEnabled, hasMarkers)
+            end for
+        end if
+    end for
+end sub
+
+sub applyMarkerToSeasonItem(item as object, markers as object, isEnabled as boolean, hasMarkers as boolean)
+    if not isValid(item) or not isValid(item.json) then return
+
+    itemType = chainLookupReturn(item, "json.Type", "")
+    if not isStringEqual(itemType, "Season") then return
+
+    seasonNum = chainLookupReturn(item, "json.IndexNumber", -1)
+    status = 0
+    if isEnabled and hasMarkers and seasonNum >= 0 and markers.doesExist(seasonNum.toStr())
+        status = markers[seasonNum.toStr()]
+    end if
+
+    if item.hasField("seerrStatus")
+        item.seerrStatus = status
+    else
+        item.addField("seerrStatus", "integer", false)
+        item.seerrStatus = status
+    end if
 end sub

--- a/source/utils/seerrDetailHost.bs
+++ b/source/utils/seerrDetailHost.bs
@@ -148,15 +148,17 @@ function GetSeerrSeasonMarkers(seerrDetails as object) as object
         end if
     end for
 
+    ' Seasons with no status of their own fall back to the HD request they came
+    ' from, since that is the copy the library holds.
     if isChainValid(seerrDetails, "mediaInfo.requests")
         for each req in seerrDetails.mediaInfo.requests
-            reqStatus = chainLookupReturn(req, "status", 1)
-            mappedStatus = reqStatus = 1 ? 2 : 3
-            if isValid(req.seasons)
+            if req.is4k <> true and isValid(req.seasons)
                 for each reqSeason in req.seasons
                     if isValid(reqSeason.seasonNumber)
+                        reqStatus = chainLookupReturn(reqSeason, "status", chainLookupReturn(req, "status", 1))
+                        mappedStatus = SeerrRequestToMediaStatus(reqStatus)
                         key = reqSeason.seasonNumber.toStr()
-                        if not markers.doesExist(key)
+                        if mappedStatus > 0 and not markers.doesExist(key)
                             markers[key] = mappedStatus
                         end if
                     end if
@@ -166,6 +168,15 @@ function GetSeerrSeasonMarkers(seerrDetails as object) as object
     end if
 
     return markers
+end function
+
+' Request statuses are 1 pending, 2 approved, 3 declined, 4 failed, 5 completed.
+' Declined and failed have nothing to draw, so they come back as 0.
+function SeerrRequestToMediaStatus(reqStatus as dynamic) as integer
+    if reqStatus = 1 then return 2
+    if reqStatus = 2 then return 3
+    if reqStatus = 5 then return 5
+    return 0
 end function
 
 ' Updates the seerrStatus field on all season items across extras rows, tabs, and tab grids

--- a/source/utils/settingsSync.bs
+++ b/source/utils/settingsSync.bs
@@ -68,6 +68,7 @@ namespace settingsSync
             { pluginKey: "preferSdhSubtitles", rokuKey: "playback.preferSdhSubtitles", type: "bool" },
             { pluginKey: "seerrBlockNsfw", rokuKey: "seerr.blockNsfw", type: "bool" },
             { pluginKey: "seerrShowMissingCollectionItems", rokuKey: "seerr.showMissingCollectionItems", type: "bool" },
+            { pluginKey: "showSeerrAvailabilityBadges", rokuKey: "seerr.showAvailabilityBadges", type: "bool" },
             { pluginKey: "nextUpMaxDays", rokuKey: "ui.details.maxdaysnextup", type: "intToStr" },
             ' Core counts this one in milliseconds, and playback.nextupbuttonseconds
             ' is a different setting measured in seconds, so they cannot share a key


### PR DESCRIPTION
# Pull Request

## Summary
Adds the `seerr.showAvailabilityBadges` setting definition and synchronization mapping to Moonfin-Roku, and implements the season availability badges on TV series detail screens across both Modern and Classic views.

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #
- Related to # https://github.com/Moonfin-Client/Plugin/pull/283
- Parity with Moonfin-Core https://github.com/Moonfin-Client/Moonfin-Core/pull/1492

## Type of Change
- [ ] Bug fix
- [X] New feature
- [ ] Refactor
- [ ] Performance improvement
- [X] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

- **Settings & Sync**:
  - Added `seerr.showAvailabilityBadges` boolean setting (`default: true`) in `settings.json` under the Seerr preferences section.
  - Added sync mapping `{ pluginKey: "showSeerrAvailabilityBadges", rokuKey: "seerr.showAvailabilityBadges", type: "bool" }` in `settingsSync.bs`.
  - Added `isSeerrAvailabilityBadgesEnabled()` helper function in `misc.bs` to query the active session with fallback to `true`.
- **Card UI (`ExtrasItem`)**:
  - Added `seerrDot` badge in `ExtrasItem.xml` positioned in the top-left corner (`[10, 10]`) opposite the watched checkmark.
  - Added dynamic observation of `seerrStatus` on `itemContent` in `ExtrasItem.bs`.
  - Colored the badge according to Seerr media status (Green for Available / Partially Available, Purple for Processing, Yellow for Pending) and restricted rendering to Season cards.
- **Data Pipeline**:
  - Added interface field `seerrStatus` to `HomeData.xml`.
  - Implemented `GetSeerrSeasonMarkers()` and `updateSeerrSeasonMarkers()` in `seerrDetailHost.bs` to extract per-season statuses from `mediaInfo.seasons` and active requests.
  - Hooked up season badge population when Seerr details land, when tabs finish building in `ModernItemDetails.bs`, when extras rows load in `ItemDetails.bs`, and when button states refresh in `detailButtonHost.bs`.

## Testing
Describe how this change was tested.

- [ ] Tested on physical Roku device
- [ ] Tested via sideload
- [ ] Manual testing completed
- [X] Not tested (explain why): Verified via `npx bsc` and `bslint` (0 errors/warnings) - @jmawet please!

### Test Steps
1. Navigate to a TV series with Seerr integration active.
2. View season cards under the "Seasons" tab (Modern view) or "Seasons" row (Classic view) and verify the availability dot appears in the top-left corner of available or requested seasons.
3. Toggle `Show Seerr Availability Badges` off in Settings -> Seerr Preferences.
4. Verify the badges disappear from the season cards.

## Screenshots (if applicable)
Include screenshots or recordings for UI changes.

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
