### PR TITLE
Feat-ui - Port Badge Legibility Work

### DIFF
--- a/components/ItemGrid/GridItemMedium.bs
+++ b/components/ItemGrid/GridItemMedium.bs
@@ -77,6 +77,7 @@ sub onWidthChanged()
     ' Only update translations if child nodes are fully initialized
     if isValid(m.playedIndicator) and isValid(m.playedIndicator.width)
         m.playedIndicator.translation = [m.top.width - m.playedIndicator.width, 22]
+        m.playedIndicator.favoriteOffset = [10 - m.playedIndicator.translation[0], 0]
     end if
 
     if isValid(m.itemIconBackground) and isValid(m.itemIconBackground.width) and isValid(m.itemIconBackground.translation)
@@ -101,8 +102,12 @@ sub itemContentChanged()
 
     m.playedIndicator.data = {
         played: chainLookupReturn(itemData, "json.UserData.Played", false),
+        favorite: chainLookupReturn(itemData, "json.UserData.IsFavorite", chainLookupReturn(itemData, "favorite", false)),
         unplayedCount: chainLookupReturn(itemData, "json.UserData.UnplayedItemCount", 0)
     }
+    if isValid(m.playedIndicator.translation)
+        m.playedIndicator.favoriteOffset = [10 - m.playedIndicator.translation[0], 0]
+    end if
 
     ' Set Series and Episode Number for Extra Text
     extraPrefix = string.EMPTY
@@ -172,6 +177,7 @@ sub itemContentChanged()
         m.posterText.font.size = placeholderSize
 
         m.playedIndicator.translation = [imageDimensions[0] - 60, m.playedIndicator.translation[1]]
+        m.playedIndicator.favoriteOffset = [10 - m.playedIndicator.translation[0], 0]
         m.title.translation = [m.title.translation[0], imageDimensions[1] + 30]
         m.itemTextExtra.translation = [m.itemTextExtra.translation[0], imageDimensions[1] + 65]
     end if

--- a/components/ItemGrid/LibraryCard.bs
+++ b/components/ItemGrid/LibraryCard.bs
@@ -6,7 +6,7 @@ const CARD_TITLE_SIZE = 19
 const CARD_SUBTITLE_SIZE = 17
 const CARD_TITLE_LINE = 23
 const CARD_TEXT_GAP = 4
-const CARD_BADGE = 26
+const CARD_BADGE = 28
 const CARD_BADGE_INSET = 8
 const CARD_COUNT_PAD = 8
 ' How far the round focus ring stands out past the artwork it circles
@@ -24,7 +24,13 @@ sub init()
     m.circleOutline = m.top.findNode("circleOutline")
     m.placeholderIcon = m.top.findNode("placeholderIcon")
     m.favoriteBadge = m.top.findNode("favoriteBadge")
+    m.favShadow = m.top.findNode("favShadow")
+    m.favBorder = m.top.findNode("favBorder")
+    m.favBg = m.top.findNode("favBg")
+    m.favIcon = m.top.findNode("favIcon")
     m.watchedBadge = m.top.findNode("watchedBadge")
+    m.watchShadow = m.top.findNode("watchShadow")
+    m.watchBorder = m.top.findNode("watchBorder")
     m.watchBg = m.top.findNode("watchBg")
     m.watchIcon = m.top.findNode("watchIcon")
     m.watchCount = m.top.findNode("watchCount")
@@ -177,8 +183,17 @@ sub drawBadges(json as object)
     end if
 
     ' A screen where everything is a favorite has nothing to say with the heart
+    onBadgeColor = themeChrome.Token("onBadge", "#FFFFFF")
+    recActiveColor = themeChrome.Token("recordingActive", "#F44336")
+
     showFavorite = not isValid(m.metrics) or m.metrics.showFavoriteBadge <> false
-    m.favoriteBadge.visible = showFavorite and chainLookupReturn(json, "UserData.IsFavorite", false) = true
+    isFav = showFavorite and chainLookupReturn(json, "UserData.IsFavorite", false) = true
+    m.favoriteBadge.visible = isFav
+    if isFav
+        if isValid(m.favBg) then m.favBg.blendColor = recActiveColor
+        if isValid(m.favBorder) then m.favBorder.blendColor = onBadgeColor
+        if isValid(m.favIcon) then m.favIcon.blendColor = onBadgeColor
+    end if
 
     played = chainLookupReturn(json, "UserData.Played", false) = true
     unplayed = chainLookupReturn(json, "UserData.UnplayedItemCount", 0)
@@ -197,9 +212,24 @@ sub drawBadges(json as object)
         if badgeWidth < CARD_BADGE then badgeWidth = CARD_BADGE
     end if
 
-    m.watchBg.uri = hasUnplayed ? "pkg:/images/details/badgefill6.9.png" : "pkg:/images/icons/circle.png"
-    m.watchBg.width = badgeWidth
+    badgeUri = hasUnplayed ? "pkg:/images/details/badgefill6.9.png" : "pkg:/images/icons/circle.png"
+    if isValid(m.watchShadow)
+        m.watchShadow.uri = badgeUri
+        m.watchShadow.width = badgeWidth
+    end if
+    if isValid(m.watchBorder)
+        m.watchBorder.uri = badgeUri
+        m.watchBorder.width = badgeWidth
+        m.watchBorder.blendColor = onBadgeColor
+    end if
+
+    m.watchBg.uri = badgeUri
+    m.watchBg.width = badgeWidth - 4
+    m.watchBg.translation = [2, 2]
+    m.watchBg.blendColor = hasUnplayed ? themeChrome.Token("badgeUnplayed", "#00A4DC") : themeChrome.Token("badgeWatched", "#00A4DC")
     m.watchCount.width = badgeWidth
+    if isValid(m.watchCount) then m.watchCount.color = onBadgeColor
+    if isValid(m.watchIcon) then m.watchIcon.blendColor = onBadgeColor
     if isValid(m.badgeRight) then m.watchedBadge.translation = [m.badgeRight - badgeWidth, m.badgeY]
 end sub
 

--- a/components/ItemGrid/LibraryCard.xml
+++ b/components/ItemGrid/LibraryCard.xml
@@ -16,20 +16,28 @@
       <Poster id="placeholderIcon" visible="false" />
 
       <Group id="favoriteBadge" visible="false">
-        <Poster id="favBg" uri="pkg:/images/icons/circle.png" width="26" height="26"
-          blendColor="#000000" opacity="0.65" />
-        <Poster id="favIcon" uri="pkg:/images/icons/heart.png" width="15" height="15"
-          blendColor="#E91E63" translation="[6, 6]" />
+        <Poster id="favShadow" uri="pkg:/images/icons/circle.png" width="28" height="28"
+          translation="[0, 2]" blendColor="#00000099" />
+        <Poster id="favBorder" uri="pkg:/images/icons/circle.png" width="28" height="28"
+          blendColor="#FFFFFF" />
+        <Poster id="favBg" uri="pkg:/images/icons/circle.png" width="24" height="24"
+          translation="[2, 2]" blendColor="#F44336" />
+        <Poster id="favIcon" uri="pkg:/images/icons/heart.png" width="14" height="14"
+          blendColor="#FFFFFF" translation="[7, 7]" />
       </Group>
 
       <Group id="watchedBadge" visible="false">
-        <Poster id="watchBg" uri="pkg:/images/icons/circle.png" width="26" height="26"
-          blendColor="#00A4DC" opacity="0.9" />
-        <Poster id="watchIcon" uri="pkg:/images/icons/check_white.png" width="15" height="15"
-          translation="[6, 6]" />
+        <Poster id="watchShadow" uri="pkg:/images/icons/circle.png" width="28" height="28"
+          translation="[0, 2]" blendColor="#00000099" />
+        <Poster id="watchBorder" uri="pkg:/images/icons/circle.png" width="28" height="28"
+          blendColor="#FFFFFF" />
+        <Poster id="watchBg" uri="pkg:/images/icons/circle.png" width="24" height="24"
+          translation="[2, 2]" blendColor="#00A4DC" />
+        <Poster id="watchIcon" uri="pkg:/images/icons/check_white.png" width="14" height="14"
+          translation="[7, 7]" />
         <!-- A part watched series counts what is left instead of claiming it is done -->
         <Label id="watchCount" font="font:SmallestBoldSystemFont" color="#FFFFFF"
-          width="26" height="26" horizAlign="center" vertAlign="center" visible="false" />
+          width="28" height="28" horizAlign="center" vertAlign="center" visible="false" />
       </Group>
 
       <Label id="cardTitle" font="font:SmallBoldSystemFont" color="#FFFFFF" maxLines="1" />

--- a/components/PlayedCheckmark.bs
+++ b/components/PlayedCheckmark.bs
@@ -3,16 +3,24 @@ import "pkg:/source/utils/misc.bs"
 import "pkg:/source/utils/themeChrome.bs"
 
 sub init()
+    m.shadow = m.top.findNode("shadow")
+    m.border = m.top.findNode("border")
     m.background = m.top.findNode("background")
     m.unplayedNumber = m.top.findNode("unplayedNumber")
     m.checkmark = m.top.findNode("checkmark")
     m.checkmark.font.size = 30
+    m.favoriteBadge = m.top.findNode("favoriteBadge")
+    m.favoriteShadow = m.top.findNode("favoriteShadow")
+    m.favoriteBorder = m.top.findNode("favoriteBorder")
+    m.favoriteBg = m.top.findNode("favoriteBg")
     m.favoriteHeart = m.top.findNode("favoriteHeart")
 
+    if isValid(m.shadow) then m.shadow.visible = false
+    if isValid(m.border) then m.border.visible = false
     m.background.visible = false
     m.checkmark.visible = false
     m.unplayedNumber.visible = false
-    m.favoriteHeart.visible = false
+    if isValid(m.favoriteBadge) then m.favoriteBadge.visible = false
 
     onSizeChange()
 end sub
@@ -23,8 +31,23 @@ sub onSizeChange()
 
     w = m.top.width
     h = m.top.height
-    m.background.width = w
-    m.background.height = h
+
+    if isValid(m.shadow)
+        m.shadow.width = w
+        m.shadow.height = h
+    end if
+
+    if isValid(m.border)
+        m.border.width = w
+        m.border.height = h
+    end if
+
+    ' 2px inset gives a crisp 2px border ring around the circle fill
+    inset = 2
+    m.background.width = w - (inset * 2)
+    m.background.height = h - (inset * 2)
+    m.background.translation = [inset, inset]
+
     m.checkmark.width = w
     m.checkmark.height = h
     m.unplayedNumber.width = w
@@ -42,27 +65,47 @@ end function
 sub onDataChange()
     if not isValid(m.background) then init()
 
+    if isValid(m.shadow) then m.shadow.visible = false
+    if isValid(m.border) then m.border.visible = false
     m.background.visible = false
 
+    onBadgeColor = themeChrome.Token("onBadge", ColorPalette.WHITE)
+
+    if isValid(m.border)
+        m.border.blendColor = onBadgeColor
+    end if
+
     if isValid(m.checkmark)
-        m.checkmark.color = chainLookupReturn(m.global.session, "user.settings.colorPlayedCheckmarkIcon", ColorPalette.WHITE)
+        m.checkmark.color = chainLookupReturn(m.global.session, "user.settings.colorPlayedCheckmarkIcon", onBadgeColor)
         m.checkmark.visible = false
     end if
 
     if isValid(m.unplayedNumber)
-        m.unplayedNumber.color = chainLookupReturn(m.global.session, "user.settings.colorUnplayedCountTextColor", ColorPalette.WHITE)
+        m.unplayedNumber.color = chainLookupReturn(m.global.session, "user.settings.colorUnplayedCountTextColor", onBadgeColor)
         m.unplayedNumber.visible = false
     end if
 
-    m.favoriteHeart.visible = false
+    if isValid(m.favoriteBadge) then m.favoriteBadge.visible = false
 
     if not isValidAndNotEmpty(m.top.data) then return
 
     if chainLookupReturn(m.top.data, "favorite", false)
-        m.favoriteHeart.visible = true
-        offset = m.top.favoriteOffset
-        if isValid(offset) and offset.count() = 2
-            m.favoriteHeart.translation = offset
+        if isValid(m.favoriteBadge)
+            m.favoriteBadge.visible = true
+            offset = m.top.favoriteOffset
+            if isValid(offset) and offset.count() = 2
+                m.favoriteBadge.translation = offset
+            end if
+            if isValid(m.favoriteBg)
+                sharedRecColor = chainLookupReturn(m.global.session, "user.settings.colorRecordingActive", "#F44336")
+                m.favoriteBg.blendColor = themeChrome.Token("recordingActive", sharedRecColor)
+            end if
+            if isValid(m.favoriteBorder)
+                m.favoriteBorder.blendColor = onBadgeColor
+            end if
+            if isValid(m.favoriteHeart)
+                m.favoriteHeart.blendColor = onBadgeColor
+            end if
         end if
     end if
 
@@ -90,6 +133,8 @@ sub onDataChange()
 
         sharedBadgeColor = chainLookupReturn(m.global.session, "user.settings.colorPlayedCheckmarkBackground", "#0066CC")
         m.background.blendColor = themeChrome.Token("badgeUnplayed", sharedBadgeColor)
+        if isValid(m.shadow) then m.shadow.visible = true
+        if isValid(m.border) then m.border.visible = true
         m.background.visible = true
 
         if isValid(m.unplayedNumber)
@@ -103,10 +148,13 @@ sub onDataChange()
     if not chainLookupReturn(m.top.data, "showWatchedCheckmark", true) then return
 
     if chainLookupReturn(m.top.data, "played", false)
-        m.background.blendColor = chainLookupReturn(m.global.session, "user.settings.colorPlayedCheckmarkBackground", "#0066CC")
+        sharedBadgeColor = chainLookupReturn(m.global.session, "user.settings.colorPlayedCheckmarkBackground", "#0066CC")
+        m.background.blendColor = themeChrome.Token("badgeWatched", sharedBadgeColor)
+        if isValid(m.shadow) then m.shadow.visible = true
+        if isValid(m.border) then m.border.visible = true
         m.background.visible = true
         if isValid(m.checkmark)
-            m.checkmark.color = "#FFFFFF"
+            m.checkmark.color = onBadgeColor
             m.checkmark.visible = true
         end if
         return

--- a/components/PlayedCheckmark.xml
+++ b/components/PlayedCheckmark.xml
@@ -6,9 +6,27 @@
 <component name="PlayedCheckmark" extends="Group">
   <children>
     <Poster
-      id="background"
+      id="shadow"
       width="40"
       height="40"
+      translation="[0, 2]"
+      uri="pkg:/images/icons/circle.png"
+      blendColor="#00000099"
+      visible="false" />
+
+    <Poster
+      id="border"
+      width="40"
+      height="40"
+      uri="pkg:/images/icons/circle.png"
+      blendColor="#FFFFFFFF"
+      visible="false" />
+
+    <Poster
+      id="background"
+      width="36"
+      height="36"
+      translation="[2, 2]"
       uri="pkg:/images/icons/circle.png"
       blendColor="#0066CCFF"
       visible="false" />
@@ -22,25 +40,49 @@
       vertAlign="center"
       translation="[0, 2]"
       text="&#x2713;"
+      color="#FFFFFFFF"
       visible="false" />
 
     <Label
       id="unplayedNumber"
       width="40"
       height="40"
-      font="font:SmallSystemFont"
+      font="font:SmallBoldSystemFont"
       horizAlign="center"
       vertAlign="center"
       translation="[0, 2]"
+      color="#FFFFFFFF"
       visible="false" />
 
-    <Poster
-      id="favoriteHeart"
-      width="28"
-      height="28"
-      uri="pkg:/images/icons/heart.png"
-      blendColor="#FF0000FF"
-      visible="false" />
+    <Group id="favoriteBadge" visible="false">
+      <Poster
+        id="favoriteShadow"
+        width="36"
+        height="36"
+        translation="[0, 2]"
+        uri="pkg:/images/icons/circle.png"
+        blendColor="#00000099" />
+      <Poster
+        id="favoriteBorder"
+        width="36"
+        height="36"
+        uri="pkg:/images/icons/circle.png"
+        blendColor="#FFFFFFFF" />
+      <Poster
+        id="favoriteBg"
+        width="32"
+        height="32"
+        translation="[2, 2]"
+        uri="pkg:/images/icons/circle.png"
+        blendColor="#F44336FF" />
+      <Poster
+        id="favoriteHeart"
+        width="18"
+        height="18"
+        translation="[9, 9]"
+        uri="pkg:/images/icons/heart.png"
+        blendColor="#FFFFFFFF" />
+    </Group>
   </children>
   <interface>
     <field id="width" type="float" value="40" onChange="onSizeChange" />

--- a/components/extras/ExtrasItem.bs
+++ b/components/extras/ExtrasItem.bs
@@ -151,6 +151,7 @@ sub showContent()
                 m.playedIndicator.data = {
                     showWatchedCheckmark: showWatchedCheckmark,
                     played: chainLookupReturn(cont, "json.UserData.Played", false),
+                    favorite: chainLookupReturn(cont, "json.UserData.IsFavorite", chainLookupReturn(cont, "favorite", false)),
                     unplayedCount: chainLookupReturn(cont, "json.UserData.UnplayedItemCount", 0)
                 }
             end if
@@ -230,6 +231,7 @@ sub showContent()
 
                 ' Adjust played indicator position
                 m.playedIndicator.translation = [posterWidth - 50, 10]
+                m.playedIndicator.favoriteOffset = [- (posterWidth - 50) + 10, 0]
             else
                 ' Default to portrait poster size
                 m.posterImgRect.width = 234
@@ -245,6 +247,7 @@ sub showContent()
                 m.role.translation = [0, 422]
                 m.role.visible = true
                 m.playedIndicator.translation = [130, 10]
+                m.playedIndicator.favoriteOffset = [-120, 0]
 
                 if isValid(m.epNumber) then m.epNumber.visible = false
                 if isValid(m.epDuration) then m.epDuration.visible = false

--- a/components/extras/ExtrasItem.xml
+++ b/components/extras/ExtrasItem.xml
@@ -22,15 +22,22 @@
         <Group id="seerrDot" translation="[10, 10]" visible="false">
           <Poster
             id="seerrDotShadow"
-            width="24"
-            height="24"
-            translation="[-1, -1]"
-            uri="pkg:/images/icons/circle.png"
-            blendColor="#00000080" />
-          <Poster
-            id="seerrDotBg"
             width="22"
             height="22"
+            translation="[0, 2]"
+            uri="pkg:/images/icons/circle.png"
+            blendColor="#00000099" />
+          <Poster
+            id="seerrDotBorder"
+            width="22"
+            height="22"
+            uri="pkg:/images/icons/circle.png"
+            blendColor="#FFFFFFFF" />
+          <Poster
+            id="seerrDotBg"
+            width="18"
+            height="18"
+            translation="[2, 2]"
             uri="pkg:/images/icons/circle.png" />
         </Group>
       </Poster>

--- a/components/home/HomeItem.bs
+++ b/components/home/HomeItem.bs
@@ -157,9 +157,11 @@ sub itemContentChanged()
     if isValid(m.playedIndicator)
         m.playedIndicator.data = {
             played: chainLookupReturn(itemData, "json.UserData.Played", false),
+            favorite: chainLookupReturn(itemData, "json.UserData.IsFavorite", chainLookupReturn(itemData, "favorite", false)),
             unplayedCount: chainLookupReturn(itemData, "json.UserData.UnplayedItemCount", 0),
             itemType: chainLookupReturn(itemData, "json.Type", "")
         }
+        m.playedIndicator.favoriteOffset = [- (itemData.imageWidth - 50) + 10, 0]
     end if
 
     itemData.AddReplace("Title", itemData.LookupCI("name"))
@@ -178,6 +180,7 @@ sub itemContentChanged()
     ' Reposition played indicator to top-right corner of poster
     if isValid(m.playedIndicator)
         m.playedIndicator.translation = [itemData.imageWidth - 50, 10]
+        m.playedIndicator.favoriteOffset = [- (itemData.imageWidth - 50) + 10, 0]
     end if
 
     m.itemText.maxWidth = itemData.imageWidth


### PR DESCRIPTION
# Pull Request

## Summary
Updates corner badge legibility (watched status checkmarks, unplayed episode counts, and favorite indicators) and Seerr availability markers across Roku poster items and library cards to maximize 10-foot viewing clarity. Adds high-contrast white border rings and elevation drop shadows (`#00000099`, `[0, 2]`), introduces unified circular favorite badges matching Moonfin design standards, and wires favorite status and positioning across home rows, grid cards, and extras.

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #
- Related to #

## Type of Change
- [ ] Bug fix
- [X] New feature
- [ ] Refactor
- [ ] Performance improvement
- [X] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

- **PlayedCheckmark Component** (**PlayedCheckmark.xml**, **PlayedCheckmark.bs**):
  - Upgraded badge hierarchy with background elevation drop shadow (`#00000099`, `[0, 2]`) and high-contrast border ring (`#FFFFFFFF`).
  - Added 2px inset sizing logic in `onSizeChange()` to render a crisp 2px border ring around circular fills.
  - Replaced raw floating heart poster with a dedicated circular favorite badge (`favoriteShadow`, `favoriteBorder`, `favoriteBg`, `favoriteHeart`), dynamically tinted via `themeChrome.Token` (`recordingActive` and `onBadge`).
  - Evaluated favorite indicator independently from watched checkmark so cards can render both indicators simultaneously.
- **Card Wiring & Alignment** (**HomeItem.bs**, **GridItemMedium.bs**, **ExtrasItem.bs**):
  - Passed `favorite` property (`json.UserData.IsFavorite`) to `m.playedIndicator.data`.
  - Implemented dynamic `favoriteOffset` (`[10 - translation[0], 0]`) to ensure the favorite heart is pinned to the top-left poster corner across arbitrary poster dimensions and card aspect ratios.
- **LibraryCard Component** (**LibraryCard.xml**, **LibraryCard.bs**):
  - Standardized `favoriteBadge` and `watchedBadge` to size 28 with high-contrast border rings and drop shadows.
  - Integrated 9-slice pill scaling (`badgefill6.9.png`) with 2px border inset for unplayed episode count pills.
  - Dynamically bound badge fills and icons to `themeChrome.Token` (`badgeWatched`, `badgeUnplayed`, `recordingActive`, `onBadge`).
- **Extras & Seerr Availability** (**ExtrasItem.xml**, **ExtrasItem.bs**):
  - Upgraded `seerrDot` marker with elevation drop shadow (`[0, 2]`, `#00000099`) and high-contrast white border ring.
## Testing
Describe how this change was tested.

- [ ] Tested on physical Roku device
- [ ] Tested via sideload
- [ ] Manual testing completed
- [X] Not tested (explain why): Another Roku special for @jmawet 

### Test Steps
1.  inspect badges across home screen rows, library grids, and detail screens.
2. Switch themes (e.g. Moonfin, Neon Pulse, 8-Bit Hero) and verify badges retain high contrast and correct border rings.

## Screenshots (if applicable)
Include screenshots or recordings for UI changes.

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
