### PR TITLE
Porting Genre Fixes to Roku

### DIFF
--- a/components/ItemGrid/LoadItemsTask2.bs
+++ b/components/ItemGrid/LoadItemsTask2.bs
@@ -247,9 +247,7 @@ sub loadItems()
         params.append({ ExcludeItemTypes: m.top.excludeItemTypes })
     end if
 
-    if not m.top.collapseBoxSetItems
-        params.append({ CollapseBoxSetItems: false })
-    end if
+    params.append({ CollapseBoxSetItems: m.top.collapseBoxSetItems })
 
     if m.top.ItemType = "LiveTV"
         url = "LiveTv/Channels"

--- a/components/Libraries/OtherLibrary.bs
+++ b/components/Libraries/OtherLibrary.bs
@@ -245,19 +245,18 @@ sub loadInitialItems()
 
 
     ' Load Item Types
+    groupCollections = get_user_setting_bool("ui.library.groupItemsIntoCollections", false)
     if isStringEqual(getCollectionType(), "movies")
-        m.loadItemsTask.itemType = "Movie"
+        m.loadItemsTask.itemType = groupCollections ? "Movie,BoxSet" : "Movie"
         m.loadItemsTask.itemId = m.top.parentItem.libraryId
-        ' Exclude collections/boxsets from movie libraries
-        m.loadItemsTask.excludeItemTypes = "BoxSet"
-        m.loadItemsTask.collapseBoxSetItems = false
+        m.loadItemsTask.excludeItemTypes = groupCollections ? "" : "BoxSet"
+        m.loadItemsTask.collapseBoxSetItems = groupCollections
         m.top.showItemTitles = "showalways"
     else if isStringEqual(getCollectionType(), "tvshows")
-        m.loadItemsTask.itemType = "Series"
+        m.loadItemsTask.itemType = groupCollections ? "Series,BoxSet" : "Series"
         m.loadItemsTask.itemId = m.top.parentItem.libraryId
-        ' Exclude collections/boxsets from TV show libraries
-        m.loadItemsTask.excludeItemTypes = "BoxSet"
-        m.loadItemsTask.collapseBoxSetItems = false
+        m.loadItemsTask.excludeItemTypes = groupCollections ? "" : "BoxSet"
+        m.loadItemsTask.collapseBoxSetItems = groupCollections
         m.top.showItemTitles = "showalways"
     else if isStringEqual(getCollectionType(), "music")
         ' Default Settings

--- a/components/Libraries/VisualLibraryScene.bs
+++ b/components/Libraries/VisualLibraryScene.bs
@@ -477,12 +477,23 @@ sub loadInitialItems()
         m.loadItemsTask.itemType = m.top.mediaType
     end if
 
-    ' Exclude collections/boxsets from movie and TV show libraries
-    ' CollapseBoxSetItems=false ensures individual movies inside a BoxSet still appear
+    ' Collections / BoxSet handling for libraries and genre filtering
     collType = getCollectionType()
-    if isStringEqual(collType, CollectionType.MOVIES) or isStringEqual(collType, CollectionType.TVSHOWS)
-        m.loadItemsTask.excludeItemTypes = "BoxSet"
-        m.loadItemsTask.collapseBoxSetItems = false
+    groupCollections = get_user_setting_bool("ui.library.groupItemsIntoCollections", false)
+
+    if isValid(m.top.genreFilter)
+        m.loadItemsTask.collapseBoxSetItems = groupCollections
+        m.loadItemsTask.excludeItemTypes = groupCollections ? "Playlist,Episode,Season,Folder" : "BoxSet,Playlist,Episode,Season,Folder"
+    else if isStringEqual(collType, CollectionType.MOVIES) or isStringEqual(collType, CollectionType.TVSHOWS)
+        m.loadItemsTask.collapseBoxSetItems = groupCollections
+        m.loadItemsTask.excludeItemTypes = groupCollections ? "" : "BoxSet"
+        if groupCollections
+            if isStringEqual(collType, CollectionType.MOVIES)
+                m.loadItemsTask.itemType = "Movie,BoxSet"
+            else
+                m.loadItemsTask.itemType = "Series,BoxSet"
+            end if
+        end if
     end if
 
     ' We're in a genre sub folder

--- a/components/genres/GenresScreen.bs
+++ b/components/genres/GenresScreen.bs
@@ -1,5 +1,6 @@
 import "pkg:/source/enums/ColorPalette.bs"
 import "pkg:/source/enums/TaskControl.bs"
+import "pkg:/source/utils/config.bs"
 import "pkg:/source/utils/misc.bs"
 
 sub init()
@@ -17,6 +18,7 @@ sub init()
 
     m.genreMap = {}
     m.isLoading = false
+    m.lastGroupCollections = invalid
     m.pageTitle.text = tr("Genres")
 
     m.loadGenresTask = createObject("roSGNode", "LoadGenresTask")
@@ -25,7 +27,9 @@ sub init()
 end sub
 
 sub OnScreenShown(_isReturning = false as boolean)
-    if m.genreMap.Count() = 0
+    currentGroupSetting = get_user_setting_bool("ui.library.groupItemsIntoCollections", false)
+    if m.genreMap.Count() = 0 or m.lastGroupCollections <> currentGroupSetting
+        m.lastGroupCollections = currentGroupSetting
         loadGenres()
     else
         m.genreGrid.setFocus(true)
@@ -42,6 +46,7 @@ sub loadGenres()
     showLoading(true)
     hideEmptyState()
 
+    m.loadGenresTask.groupCollections = get_user_setting_bool("ui.library.groupItemsIntoCollections", false)
     m.loadGenresTask.control = TaskControl.RUN
 end sub
 
@@ -74,6 +79,7 @@ sub buildGenreCards()
     ' Sort genres alphabetically
     genreKeys = m.genreMap.Keys()
     sortedKeys = sortArray(genreKeys)
+    usedBackdropUrls = {}
 
     for each genreKey in sortedKeys
         genreData = m.genreMap[genreKey]
@@ -84,14 +90,34 @@ sub buildGenreCards()
         card.addField("json", "assocarray", false)
         card.title = genreData.displayName
 
-        ' Find a backdrop image from this genre's items
+        ' Find a backdrop image from this genre's items, deprioritizing already used backdrops
         backdropUrl = ""
+        candidateBackdrops = []
         for each item in genreData.items
             if isValidAndNotEmpty(item.backdropUrl)
-                backdropUrl = item.backdropUrl
-                exit for
+                candidateBackdrops.push(item.backdropUrl)
             end if
         end for
+
+        if candidateBackdrops.Count() > 0
+            ' First look for an unused backdrop randomly
+            unusedBackdrops = []
+            for each url in candidateBackdrops
+                if not usedBackdropUrls.DoesExist(url)
+                    unusedBackdrops.push(url)
+                end if
+            end for
+
+            if unusedBackdrops.Count() > 0
+                randomIndex = Rnd(unusedBackdrops.Count()) - 1
+                backdropUrl = unusedBackdrops[randomIndex]
+                usedBackdropUrls[backdropUrl] = true
+            else
+                ' Fallback: pick randomly from all available backdrops
+                randomIndex = Rnd(candidateBackdrops.Count()) - 1
+                backdropUrl = candidateBackdrops[randomIndex]
+            end if
+        end if
 
         card.json = {
             itemCount: genreData.items.Count(),
@@ -116,6 +142,7 @@ sub onGenreCardSelected()
 
     genreData = m.genreMap[genreKey]
     genreName = genreData.displayName
+    groupCollections = get_user_setting_bool("ui.library.groupItemsIntoCollections", false)
 
     ' Create a parent item node for the genre browse scene
     genreBrowseItem = createSGNode("ContentNode")
@@ -137,7 +164,7 @@ sub onGenreCardSelected()
         genreName: genreName,
         libraryId: "",
         parentFolder: "",
-        itemType: "Movie,Series"
+        itemType: groupCollections ? "Movie,Series,BoxSet" : "Movie,Series"
     }
     group.parentItem = genreBrowseItem
     group.observeField("selectedItem", "onVisualLibraryItemSelected")

--- a/components/genres/LoadGenresTask.bs
+++ b/components/genres/LoadGenresTask.bs
@@ -103,9 +103,13 @@ end sub
 
 ' Start an async request to load genres from a server
 function startGenreRequest(userSession as object, port as object) as object
+    groupCollections = m.top.groupCollections ?? false
+
     params = {
         userid: userSession.userId,
-        IncludeItemTypes: "Movie,Series",
+        IncludeItemTypes: groupCollections ? "Movie,Series,BoxSet" : "Movie,Series",
+        ExcludeItemTypes: groupCollections ? "Playlist,Episode,Season,Folder" : "BoxSet,Playlist,Episode,Season,Folder",
+        CollapseBoxSetItems: groupCollections,
         Limit: m.top.limit,
         StartIndex: m.top.startIndex,
         Recursive: true,
@@ -142,11 +146,16 @@ function processServerItems(items as object, userSession as object, genreMap as 
     if not isValid(items) then return 0
 
     itemCount = 0
+    groupCollections = m.top.groupCollections ?? false
 
     for each item in items
-        ' Only include movies and series
+        ' Only include movies, series (and boxsets when grouping collections)
         itemType = LCase(item.type)
-        if itemType <> "movie" and itemType <> "series" then continue for
+        if groupCollections
+            if itemType <> "movie" and itemType <> "series" and itemType <> "boxset" then continue for
+        else
+            if itemType <> "movie" and itemType <> "series" then continue for
+        end if
 
         ' Get genres from the item
         if not isValid(item.Genres) or item.Genres.Count() = 0 then continue for

--- a/components/genres/LoadGenresTask.xml
+++ b/components/genres/LoadGenresTask.xml
@@ -7,6 +7,7 @@
         <field id="error" type="string" />
         <field id="totalCount" type="integer" value="0" />
         <field id="enableMultiServer" type="boolean" value="true" />
+        <field id="groupCollections" type="boolean" value="false" />
         <field id="genreResults" type="assocarray" alwaysNotify="true" />
     </interface>
 </component>

--- a/settings/settings.json
+++ b/settings/settings.json
@@ -6425,6 +6425,13 @@
             "default": "false"
           },
           {
+            "title": "Group Items into Collections",
+            "description": "Group movies and series into collections when browsing libraries.",
+            "settingName": "ui.library.groupItemsIntoCollections",
+            "type": "bool",
+            "default": "false"
+          },
+          {
             "title": "Forget Filters",
             "description": "Forget applied library filters when Jellyfin is closed.",
             "settingName": "itemgrid.forgetFilters",

--- a/source/utils/settingsSync.bs
+++ b/source/utils/settingsSync.bs
@@ -31,6 +31,7 @@ namespace settingsSync
             { pluginKey: "recentlyReleasedSeriesType", rokuKey: "ui.home.recentlyReleasedSeriesType", type: "direct" },
             { pluginKey: "showMediaDetailsOnLibraryPage", rokuKey: "ui.library.showMediaDetails", type: "bool" },
             { pluginKey: "hideBackdropsInLibraries", rokuKey: "ui.library.hideBackdrops", type: "bool" },
+            { pluginKey: "groupItemsIntoCollections", rokuKey: "ui.library.groupItemsIntoCollections", type: "bool" },
             { pluginKey: "mediaBarMode", rokuKey: "ui.home.mediaBarMode", type: "direct" },
             { pluginKey: "mediaBarSourceType", rokuKey: "ui.home.mediaBarSourceType", type: "direct" },
             { pluginKey: "mediaBarLibraryIds", rokuKey: "ui.home.mediaBarLibraryIds", type: "jsonArray" },


### PR DESCRIPTION
# Pull Request

## Summary
Brings genre catalog browsing, collection grouping toggle support, Moonbase profile synchronization, and backdrop thumbnail deduplication in Moonfin-Roku into parity with Moonfin-Core (Issue #1521) and Moonfin-Smart-TV. Adds the ui.library.groupItemsIntoCollections setting, enables boxsets collapsing and dynamic item type inclusion when enabled, excludes non-browsable item types (playlists, episodes, seasons, folders), and deduplicates random backdrops across genre tiles.

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #
- Related to # Port of https://github.com/Moonfin-Client/Moonfin-Core/pull/1522

## Type of Change
- [X] Bug fix
- [X] New feature
- [ ] Refactor
- [X] Performance improvement
- [X] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

- **settings.json**: Added the ui.library.groupItemsIntoCollections setting under Library settings ("Group Items into Collections", default: false).
- **settingsSync.bs**: Added { pluginKey: "groupItemsIntoCollections", rokuKey: "ui.library.groupItemsIntoCollections", type: "bool" } to GetMappings() for bidirectional synchronization with Moonbase.
- **LoadGenresTask.xml**: Added <field id="groupCollections" type="boolean" value="false" /> interface property.
- **LoadGenresTask.bs**:
  - In startGenreRequest, dynamically includes BoxSet and collapses boxsets when groupCollections is enabled, and excludes Playlist,Episode,Season,Folder.
  - In processServerItems, allows boxset items when groupCollections is active.
- **GenresScreen.bs**:
  - Reads ui.library.groupItemsIntoCollections and automatically reloads genres in OnScreenShown if the setting changes.
  - Implemented random backdrop deduplication (usedBackdropUrls) across genre cards so tiles avoid repeating identical artwork.
  - Passes itemType: groupCollections ? "Movie,Series,BoxSet" : "Movie,Series" to VisualLibraryScene.
- **VisualLibraryScene.bs**:
  - In genre browse mode, sets collapseBoxSetItems and excludeItemTypes dynamically based on groupItemsIntoCollections.
  - In movie/TV show libraries, collapses boxsets and includes BoxSet when grouping is enabled, and excludes BoxSet when disabled.
- **OtherLibrary.bs**: Applied matching collection grouping and exclusion logic for alternative library views.
- **LoadItemsTask2.bs**: Dispatches explicit { CollapseBoxSetItems: m.top.collapseBoxSetItems } to the server.


## Testing
Describe how this change was tested.

- [ ] Tested on physical Roku device
- [ ] Tested via sideload
- [ ] Manual testing completed
- [X] Not tested (explain why): Pinging @jmawet as per convention.

### Test Steps
1. Navigate to Settings > Library and confirm "Group Items into Collections" appears and toggles.
2. Turn "Group Items into Collections" ON and navigate to the Genres screen:
   - Confirm genre item counts reflect grouped counts.
   - Confirm genre card backdrops are randomized and deduplicated without repeating.
3. Select a genre (e.g. Science Fiction):
   - Confirm items inside are grouped into collections (boxsets collapsed).
   - Confirm non-browsable types (playlists, seasons, folders, episodes) are not present in the list.
4. Turn "Group Items into Collections" OFF and verify genres and library views revert to ungrouped items.

## Screenshots (if applicable)
Include screenshots or recordings for UI changes.

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
